### PR TITLE
mPDF is GPL 2 only, add support details to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,18 @@
 	"description": "A PHP class to generate PDF files from HTML with Unicode/UTF-8 and CJK support",
 	"keywords": ["php", "pdf", "utf-8"],
 	"homepage": "http://www.mpdf1.com/mpdf/index.php",
-	"license": ["GPL-1.0+"],
+	"license": ["GPL-2.0"],
 	"authors": [
 		{
-			"name": "Ian Back"
+			"name": "Ian Back",
+			"role": "Developer"
 		}
 	],
+	"support": {
+	"issues": "https://github.com/mpdf/mpdf/issues",
+	"forum": "http://www.mpdf1.com/forum/",
+	"source": "https://github.com/mpdf/mpdf"
+	},
 	"require": {
 		"php": ">=4.3.10",
 		"ext-mbstring": "*"


### PR DESCRIPTION
Looking at http://mpdf1.com/manual/index.php?tid=265 and http://www.mpdf1.com/mpdf/index.php?page=Licence there is no option to use 'any later version' of the GPL so it looks like the code is GPL 2 only.

Support details are added for convenience.