### PR TITLE
Chmod 777 dirs ttfontdata, tmp, graph_cache after install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,12 @@
 	},
 	"autoload": {
 		"classmap": ["mpdf.php", "classes"]
-	}
+	},
+	"scripts": {
+	        "post-install-cmd": [
+	            "php -r \"chmod('./ttfontdata', 0777);\"",
+	            "php -r \"chmod('./tmp', 0777);\"",
+	            "php -r \"chmod('./graph_cache', 0777);\""
+	        ]
+    	}
 }


### PR DESCRIPTION
After installing MPDF with composer, it does not work because of insufficient permissions on temp dirs. People should read Readme to make it work, but when MPDF is a dependency of another package, this may cause confusions for the developer.
Let's make default behavior to make MPDF work just after `composer install`.

If someone want to set another permissions - it will be OK, because after `composer update` custom user's permissions will stay unchanged.