### PR TITLE
PHP 4 constructors are deprecated in PHP 7

### DIFF
--- a/classes/barcode.php
+++ b/classes/barcode.php
@@ -50,6 +50,10 @@ class PDFBarcode {
 	protected $daft;
 
 	public function __construct() {
+		$this->PDFBarcode();
+	}
+
+	public function PDFBarcode(){
 
 	}
 

--- a/classes/bmp.php
+++ b/classes/bmp.php
@@ -4,10 +4,13 @@ class bmp {
 
 var $mpdf = null;
 
+function __construct(&$mpdf) {
+	$this->bmp($mpdf);
+}
+
 function bmp(&$mpdf) {
 	$this->mpdf = $mpdf;
 }
-
 
 function _getBMPimage($data, $file) {
 	$info = array();

--- a/classes/cssmgr.php
+++ b/classes/cssmgr.php
@@ -9,6 +9,9 @@ var $cascadeCSS;
 var $CSS;
 var $tbCSSlvl;
 
+function __construct(&$mpdf) {
+	$this->cssmgr($mpdf);
+}
 
 function cssmgr(&$mpdf) {
 	$this->mpdf = $mpdf;

--- a/classes/directw.php
+++ b/classes/directw.php
@@ -4,6 +4,10 @@ class directw {
 
 var $mpdf = null;
 
+function __construct(&$mpdf) {
+	$this->directw($mpdf);
+}
+
 function directw(&$mpdf) {
 	$this->mpdf = $mpdf;
 }

--- a/classes/gif.php
+++ b/classes/gif.php
@@ -26,6 +26,11 @@ class CGIFLZW
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
+	function __construct()
+	{
+		$this->CGIFLZW();
+	}
+
 	function CGIFLZW()
 	{
 		$this->MAX_LZW_BITS = 12;
@@ -240,6 +245,11 @@ class CGIFCOLORTABLE
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
+	function __construct()
+	{
+		$this->CGIFCOLORTABLE();
+	}
+
 	function CGIFCOLORTABLE()
 	{
 		unSet($this->m_nColors);
@@ -327,6 +337,11 @@ class CGIFFILEHEADER
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
+	function __construct()
+	{
+		$this->CGIFFILEHEADER();
+	}
+
 	function CGIFFILEHEADER()
 	{
 		unSet($this->m_lpVer);
@@ -403,6 +418,11 @@ class CGIFIMAGEHEADER
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
+	function __construct()
+	{
+		$this->CGIFIMAGEHEADER();
+	}
+
 	function CGIFIMAGEHEADER()
 	{
 		unSet($this->m_nLeft);
@@ -472,6 +492,11 @@ class CGIFIMAGE
 	var $m_lzw;
 
 	///////////////////////////////////////////////////////////////////////////
+
+	function __construct()
+	{
+		$this->CGIFIMAGE();
+	}
 
 	function CGIFIMAGE()
 	{
@@ -647,6 +672,11 @@ class CGIF
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
+	function __construct()
+	{
+		$this->CGIF();
+	}
+
 	function CGIF()
 	{
 		$this->m_gfh     = new CGIFFILEHEADER();

--- a/classes/grad.php
+++ b/classes/grad.php
@@ -4,6 +4,10 @@ class grad {
 
 var $mpdf = null;
 
+function __construct(&$mpdf) {
+	$this->grad($mpdf);
+}
+
 function grad(&$mpdf) {
 	$this->mpdf = $mpdf;
 }

--- a/classes/meter.php
+++ b/classes/meter.php
@@ -4,6 +4,10 @@ class meter {
 
 
 function __construct() {
+	$this->meter();
+}
+
+function meter() {
 
 }
 

--- a/classes/mpdfform.php
+++ b/classes/mpdfform.php
@@ -49,6 +49,10 @@ var $form_button_icon;
 // FORMS
 var $textarea_lineheight;
 
+function __construct(&$mpdf) {
+	$this->mpdfform($mpdf);
+}
+
 function mpdfform(&$mpdf) {
 	$this->mpdf = $mpdf;
 

--- a/classes/otl.php
+++ b/classes/otl.php
@@ -43,6 +43,10 @@ var $LuDataCache;
 
 var $debugOTL = false;
 
+function __construct(&$mpdf) {
+	$this->otl($mpdf);
+}
+
 function otl(&$mpdf) {
 	$this->mpdf = $mpdf;
 

--- a/classes/otl_dump.php
+++ b/classes/otl_dump.php
@@ -85,6 +85,10 @@ var $TTCFonts;
 var $maxUniChar;
 var $kerninfo;
 
+	function __construct(&$mpdf) {
+		$this->OTLdump($mpdf);
+	}
+
 	function OTLdump(&$mpdf) {
 		$this->mpdf = $mpdf;
 		$this->maxStrLenRead = 200000;	// Maximum size of glyf table to read in as string (otherwise reads each glyph from file)

--- a/classes/svg.php
+++ b/classes/svg.php
@@ -67,7 +67,11 @@ class SVG {
 	var $textjuststarted;	// mPDF 5.7.4
 	var $intext;		// mPDF 5.7.4
 
-	function SVG(&$mpdf){
+	function __construct(&$mpdf) {
+		$this->SVG($mpdf);
+	}
+
+	function SVG(&$mpdf) {
 		$this->svg_font = array();	// mPDF 6
 		$this->svg_gradient = array();
 		$this->svg_shadinglist = array();

--- a/classes/tocontents.php
+++ b/classes/tocontents.php
@@ -32,6 +32,9 @@ var $TOC_pagenumstyle;	// mPDF 6
 var $TOC_suppress;	// mPDF 6
 var $m_TOC;
 
+function __construct(&$mpdf) {
+	$this->tocontents($mpdf);
+}
 function tocontents(&$mpdf) {
 	$this->mpdf = $mpdf;
 	$this->_toc=array();

--- a/classes/ttfontsuni.php
+++ b/classes/ttfontsuni.php
@@ -119,6 +119,10 @@ var $kerninfo;
 var $haskernGPOS;
 var $hassmallcapsGSUB;
 
+	function __construct() {
+		$this->TTFontFile();
+	}
+
 	function TTFontFile() {
 		$this->maxStrLenRead = 200000;	// Maximum size of glyf table to read in as string (otherwise reads each glyph from file)
 	}

--- a/classes/wmf.php
+++ b/classes/wmf.php
@@ -5,10 +5,13 @@ class wmf {
 var $mpdf = null;
 var $gdiObjectArray;
 
-function wmf(&$mpdf) {
-	$this->mpdf = $mpdf;
+function __construct(&$mpdf) {
+	$this->wmf($mpdf);
 }
 
+function wmf(&$mpdf){
+	$this->mpdf = $mpdf;
+}
 
 function _getWMFimage($data) {
 	$k = _MPDFK;

--- a/mpdf.php
+++ b/mpdf.php
@@ -810,6 +810,10 @@ var $innerblocktags;
 // **********************************
 // **********************************
 
+function __construct($mode='',$format='A4',$default_font_size=0,$default_font='',$mgl=15,$mgr=15,$mgt=16,$mgb=16,$mgh=9,$mgf=9, $orientation='P') {
+  $this->mPDF($mode,$format,$default_font_size,$default_font,$mgl,$mgr,$mgt,$mgb,$mgh,$mgf,$orientation);
+}
+
 function mPDF($mode='',$format='A4',$default_font_size=0,$default_font='',$mgl=15,$mgr=15,$mgt=16,$mgb=16,$mgh=9,$mgf=9, $orientation='P') {
 
 /*-- BACKGROUNDS --*/

--- a/mpdfi/fpdi_pdf_parser.php
+++ b/mpdfi/fpdi_pdf_parser.php
@@ -60,6 +60,10 @@ class fpdi_pdf_parser extends pdf_parser {
      * @param string $filename  Source-Filename
      * @param object $fpdi      Object of type fpdi
      */
+    function __construct($filename,&$fpdi) {
+        $this->fpdi_pdf_parser($filename,$fpdi);
+    }
+
     function fpdi_pdf_parser($filename,&$fpdi) {
         $this->fpdi =& $fpdi;
 	  $this->filename = $filename;

--- a/mpdfi/pdf_context.php
+++ b/mpdfi/pdf_context.php
@@ -28,6 +28,10 @@ class pdf_context {
 
 	// Constructor
 
+	function __construct($f) {
+		$this->pdf_context($f);
+	}
+
 	function pdf_context($f) {
 		$this->file = $f;
 		$this->reset();

--- a/mpdfi/pdf_parser.php
+++ b/mpdfi/pdf_parser.php
@@ -82,6 +82,10 @@ class pdf_parser {
      *
      * @param string $filename  Source-Filename
      */
+	function __construct($filename) {
+		$this->pdf_parser($filename);
+	}
+
 	function pdf_parser($filename) {
         $this->filename = $filename;
 	  // mPDF 4.0

--- a/qrcode/qrcode.class.php
+++ b/qrcode/qrcode.class.php
@@ -51,8 +51,11 @@ if (!defined('__CLASS_QRCODE__'))
 		
 		private $final					= array();
 		private $disable_border			= false;
-		
-		
+
+		public function __construct($value, $level='L') {
+			$this->QRcode($value, $level);
+		}
+
 		/**
 		 * Constructeur
 		 *
@@ -60,7 +63,7 @@ if (!defined('__CLASS_QRCODE__'))
 		 * @param	string		niveau de correction d'erreur (ECC) : L, M, Q, H
 		 * @return	null
 		 */
-		public function __construct($value, $level='L')
+		public function QRcode($value, $level='L')
 		{
 			if (!in_array($level, array('L', 'M', 'Q', 'H')))
 				$this->ERROR('ECC non reconnu : L, M, Q, H');


### PR DESCRIPTION
I'm not sure what your target php version is, but this PR should address the break in compatibility with PHP 7.
If you want to retain PHP 4 compatibility you can probably do this by leaving the original methods, and calling them from new __construct methods.  I have not done this as PHP 4 was [end of life](http://php.net/eol.php) on 7 Aug 2008.