### PR TITLE
WIP: add support for orphan and widow page breaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 vendor/*
 composer.lock
-custom_config.php
+config.local.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/*
 composer.lock
+custom_config.php

--- a/Tag.php
+++ b/Tag.php
@@ -782,7 +782,7 @@ class Tag
 						$this->CloseTag($this->mpdf->blk[$b]['tag'], $ahtml, $ihtml);
 					}
 					if (!empty($this->mpdf->textbuffer)) { //Output previously buffered content
-                        $this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
+						$this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
 						$this->mpdf->printbuffer($this->mpdf->textbuffer);
 						$this->mpdf->textbuffer = array();
 					}
@@ -1636,7 +1636,7 @@ class Tag
 				else if ($this->mpdf->lastblocklevelchange < 1) {
 					$blockstate = 0;
 				} // NO margins/padding
-                $this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
+				$this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
 				$this->mpdf->printbuffer($this->mpdf->textbuffer, $blockstate);
 				$this->mpdf->textbuffer = array();
 
@@ -2024,7 +2024,7 @@ class Tag
 				}
 
 				$this->SetX($this->mpdf->lMargin + $currblk['outer_left_margin']);
-                $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+				$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 
 				/* -- BACKGROUNDS -- */
 				if (isset($properties['BACKGROUND-IMAGE']) && $properties['BACKGROUND-IMAGE'] && !$this->mpdf->kwt && !$this->mpdf->ColActive && !$this->mpdf->keep_block_together) {
@@ -3659,12 +3659,12 @@ class Tag
 				else if ($this->mpdf->lastblocklevelchange < 1) {
 					$blockstate = 0;
 				} // NO margins/padding
-				// called from block after new div e.g. <div> ... <table> ...    Outputs block top margin/border and padding
+				// called from block after new div e.g. <div> ... <table> ...	Outputs block top margin/border and padding
 				if (count($this->mpdf->textbuffer) == 0 && $this->mpdf->lastblocklevelchange == 1 && !$this->mpdf->tableLevel && !$this->mpdf->kwt) {
 					$this->mpdf->newFlowingBlock($this->mpdf->blk[$this->mpdf->blklvl]['width'], $this->mpdf->lineheight, '', false, 1, true, $this->mpdf->blk[$this->mpdf->blklvl]['direction']);
 					$this->mpdf->finishFlowingBlock(true); // true = END of flowing block
 				} else if (!$this->mpdf->tableLevel && count($this->mpdf->textbuffer)) {
-                    $this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
+					$this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
 					$this->mpdf->printbuffer($this->mpdf->textbuffer, $blockstate);
 				}
 
@@ -5011,7 +5011,7 @@ class Tag
 			$this->mpdf->linebreakjustfinished = false;
 
 			$this->SetX($this->mpdf->lMargin + $this->mpdf->blk[$this->mpdf->blklvl]['outer_left_margin']);
-            $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+			$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 
 			/* -- CSS-FLOAT -- */
 			// If float contained in a float, need to extend bottom to allow for it
@@ -5044,7 +5044,7 @@ class Tag
 			else {
 				$blockstate = 0;
 			}
-			// called from after e.g. </table> </div> </div> ...    Outputs block margin/border and padding
+			// called from after e.g. </table> </div> </div> ...	Outputs block margin/border and padding
 			if (count($this->mpdf->textbuffer) && $this->mpdf->textbuffer[count($this->mpdf->textbuffer) - 1]) {
 				if (substr($this->mpdf->textbuffer[count($this->mpdf->textbuffer) - 1][0], 0, 3) != "\xbb\xa4\xac") { // not special content
 					// Right trim last content and adjust OTLdata
@@ -5066,7 +5066,7 @@ class Tag
 				$this->mpdf->finishFlowingBlock(true); // true = END of flowing block
 				$this->mpdf->PaintDivBB('', $blockstate);
 			} else {
-                $this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
+				$this->mpdf->debugLog("Calling printbuffer from Tag.php", "red");
 				$this->mpdf->printbuffer($this->mpdf->textbuffer, $blockstate);
 			}
 
@@ -5216,10 +5216,10 @@ class Tag
 
 				if (isset($this->mpdf->blk[$this->mpdf->blklvl]['x0'])) {
 					$this->SetX($this->mpdf->blk[$this->mpdf->blklvl]['x0']);
-                    $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+					$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 				} else {
 					$this->SetX($this->mpdf->lMargin);
-                    $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+					$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 				}
 
 				$this->mpdf->lastblocklevelchange = 0;
@@ -5245,7 +5245,7 @@ class Tag
 			}
 
 			$this->SetX($this->mpdf->lMargin + $this->mpdf->blk[$this->mpdf->blklvl]['outer_left_margin']);
-            $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+			$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 
 			if (!$this->mpdf->tableLevel && $page_break_after) {
 				$save_blklvl = $this->mpdf->blklvl;
@@ -6021,7 +6021,7 @@ class Tag
 
 
 			$this->SetX($this->mpdf->lMargin + $this->mpdf->blk[$this->mpdf->blklvl]['outer_left_margin']);
-            $this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
+			$this->mpdf->debugLog("Setting x to: " . $this->mpdf->x . " FROM Tag.php", "red");
 
 			$this->mpdf->maxPosR = max($this->mpdf->maxPosR, ($this->mpdf->x + $this->mpdf->table[1][1]['w']));
 
@@ -6125,13 +6125,13 @@ class Tag
 		/* -- END TABLES -- */
 	}
 
-    function SetX($newX)
-    {
-        if ($this->mpdf->ColActive) {
-            return false;  
-        } else {
-            $this->mpdf->x = $newX;
-        }
-    }
+	function SetX($newX)
+	{
+		if ($this->mpdf->ColActive) {
+			return false;  
+		} else {
+			$this->mpdf->x = $newX;
+		}
+	}
 
 }

--- a/config.php
+++ b/config.php
@@ -120,7 +120,7 @@ $this->ICCProfile = '';	// Colour profile OutputIntent
 
 // DEBUGGING & DEVELOPERS
 $this->showStats = false;
-$this->debug = true; //false;
+$this->debug = false;
 $this->debugfonts = false; // Checks and reports on errors when parsing TTF files - adds significantly to processing time
 $this->showImageErrors = false;
 $this->table_error_report = false; // Die and report error if table is too wide to contain whole words

--- a/config.php
+++ b/config.php
@@ -127,8 +127,8 @@ $this->table_error_report = false; // Die and report error if table is too wide 
 $this->table_error_report_param = ''; // Parameter which can be passed to show in error report i.e. chapter number being processed//
 
 // Widow and Orphan control
-$this->minWidowLines = 3; // min number of widow lines required before a page break will be inserted above a block
-$this->minOrphanLines = 3; // min number of orphan lines allowed before a page break is inserted above a block
+$this->minWidowLines = 0; // min number of widow lines required before a page break will be inserted above a block
+$this->minOrphanLines = 0; // min number of orphan lines allowed before a page break is inserted above a block
 
 $this->title2annots = false; // Automatically convert title="" properties in tags, to annotations
 $this->annotSize = 0.5; // default mm for Adobe annotations - nominal

--- a/config.php
+++ b/config.php
@@ -127,7 +127,7 @@ $this->table_error_report = false; // Die and report error if table is too wide 
 $this->table_error_report_param = ''; // Parameter which can be passed to show in error report i.e. chapter number being processed//
 
 // Widow and Orphan control
-$this->minWidowLines = 3; // min number of widow lines required before a page break will be inserted above a block 
+$this->minWidowLines = 3; // min number of widow lines required before a page break will be inserted above a block
 $this->minOrphanLines = 3; // min number of orphan lines allowed before a page break is inserted above a block
 
 $this->title2annots = false; // Automatically convert title="" properties in tags, to annotations

--- a/config.php
+++ b/config.php
@@ -120,11 +120,15 @@ $this->ICCProfile = '';	// Colour profile OutputIntent
 
 // DEBUGGING & DEVELOPERS
 $this->showStats = false;
-$this->debug = false;
+$this->debug = true; //false;
 $this->debugfonts = false; // Checks and reports on errors when parsing TTF files - adds significantly to processing time
 $this->showImageErrors = false;
 $this->table_error_report = false; // Die and report error if table is too wide to contain whole words
 $this->table_error_report_param = ''; // Parameter which can be passed to show in error report i.e. chapter number being processed//
+
+// Widow and Orphan control
+$this->minWidowLines = 3; // min number of widow lines required before a page break will be inserted above a block 
+$this->minOrphanLines = 3; // min number of orphan lines allowed before a page break is inserted above a block
 
 $this->title2annots = false; // Automatically convert title="" properties in tags, to annotations
 $this->annotSize = 0.5; // default mm for Adobe annotations - nominal

--- a/examples/example02_CSS_styles.php
+++ b/examples/example02_CSS_styles.php
@@ -12,174 +12,6 @@ $html = '
 <p style="font-kerning: on">Nulla felis erat, imperdiet eu, ullamcorper non, nonummy quis, elit. Suspendisse potenti. Ut a eros at ligula vehicula pretium. Maecenas feugiat pede vel risus. Nulla et lectus. Fusce eleifend neque sit amet erat. Integer consectetuer nulla non orci. Morbi feugiat pulvinar dolor. Cras odio. Donec mattis, nisi id euismod auctor, neque metus pellentesque risus, at eleifend lacus sapien et risus. Phasellus metus. Phasellus feugiat, lectus ac aliquam molestie, leo lacus tincidunt turpis, vel aliquam quam odio et sapien. Mauris ante pede, auctor ac, suscipit quis, malesuada sed, nulla. Integer sit amet odio sit amet lectus luctus euismod. Donec et nulla. Sed quis orci. </p>
 <h4>Heading using Small-Caps</h4>
 <p>Proin aliquet lorem id felis. Curabitur vel libero at mauris nonummy tincidunt. Donec imperdiet. Vestibulum sem sem, lacinia vel, molestie et, laoreet eget, urna. Curabitur viverra faucibus pede. Morbi lobortis. Donec dapibus. Donec tempus. Ut arcu enim, rhoncus ac, venenatis eu, porttitor mollis, dui. Sed vitae risus. In elementum sem placerat dui. Nam tristique eros in nisl. Nulla cursus sapien non quam porta porttitor. Quisque dictum ipsum ornare tortor. Fusce ornare tempus enim. </p>
-<hr>
-<h4>The follwing are just page filling content to force a page break</h4>
-<p><strong>The important lines in there are bold and describe the expected behaviour</strong>. The impoLorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-</p>
-
-<p>Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-Duis aute irure dolor in reprehenderit in voluptate
-velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-est laborum.
-</p>
-<p><strong>This should appear on page two, because it has less lines than the default for orphan or widow forces.</strong></p>
-<p>Ut enim ad
-minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-</p>
-
-<p>Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum.
-</p>
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-</p>
-
-<p>Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-</p>
-<p>Duis aute irure dolor in reprehenderit in voluptate
-velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-</p>
-<p>Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. </p>
-<p style="orphans: 4"><strong>This one will have three before the break: but it configured to need to have four!</strong> Lorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
-elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-voluptate velit esse cillum dolore eu fugiat nulla pariatur. </p>
-<p>Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-<p>Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. </p>
-<p>1.Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. </p>
-<p>2. Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. </p>
-<p><Strong>This appears on page 4 because it would otherwise have a widow on the next page less than the default allows </Strong>Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
-sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
-labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
-aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum. Ut enim ad minim veniam, quis nostrud exercitation
-ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 ';
 
 
@@ -187,15 +19,15 @@ ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 //==============================================================
 //==============================================================
 
-include("../mpdf.php");
+require_once __DIR__ . '/../vendor/autoload.php';
 
-$mpdf=new mPDF();
+$mpdf = new mPDF();
 
 $mpdf->SetDisplayMode('fullpage');
 
 // LOAD a stylesheet
 $stylesheet = file_get_contents('mpdfstyleA4.css');
-$mpdf->WriteHTML($stylesheet,1);    // The parameter 1 tells that this is css/style only and no body/html/text
+$mpdf->WriteHTML($stylesheet,1);	// The parameter 1 tells that this is css/style only and no body/html/text
 
 $mpdf->WriteHTML($html);
 
@@ -205,5 +37,3 @@ exit;
 //==============================================================
 //==============================================================
 //==============================================================
-
-?>

--- a/examples/example02_CSS_styles.php
+++ b/examples/example02_CSS_styles.php
@@ -12,6 +12,174 @@ $html = '
 <p style="font-kerning: on">Nulla felis erat, imperdiet eu, ullamcorper non, nonummy quis, elit. Suspendisse potenti. Ut a eros at ligula vehicula pretium. Maecenas feugiat pede vel risus. Nulla et lectus. Fusce eleifend neque sit amet erat. Integer consectetuer nulla non orci. Morbi feugiat pulvinar dolor. Cras odio. Donec mattis, nisi id euismod auctor, neque metus pellentesque risus, at eleifend lacus sapien et risus. Phasellus metus. Phasellus feugiat, lectus ac aliquam molestie, leo lacus tincidunt turpis, vel aliquam quam odio et sapien. Mauris ante pede, auctor ac, suscipit quis, malesuada sed, nulla. Integer sit amet odio sit amet lectus luctus euismod. Donec et nulla. Sed quis orci. </p>
 <h4>Heading using Small-Caps</h4>
 <p>Proin aliquet lorem id felis. Curabitur vel libero at mauris nonummy tincidunt. Donec imperdiet. Vestibulum sem sem, lacinia vel, molestie et, laoreet eget, urna. Curabitur viverra faucibus pede. Morbi lobortis. Donec dapibus. Donec tempus. Ut arcu enim, rhoncus ac, venenatis eu, porttitor mollis, dui. Sed vitae risus. In elementum sem placerat dui. Nam tristique eros in nisl. Nulla cursus sapien non quam porta porttitor. Quisque dictum ipsum ornare tortor. Fusce ornare tempus enim. </p>
+<hr>
+<h4>The follwing are just page filling content to force a page break</h4>
+<p><strong>The important lines in there are bold and describe the expected behaviour</strong>. The impoLorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+</p>
+
+<p>Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum.
+</p>
+<p><strong>This should appear on page two, because it has less lines than the default for orphan or widow forces.</strong></p>
+<p>Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+</p>
+
+<p>Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum.
+</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+</p>
+
+<p>Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+</p>
+<p>Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+</p>
+<p>Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. </p>
+<p style="orphans: 4"><strong>This one will have three before the break: but it configured to need to have four!</strong> Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. </p>
+<p>Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p>Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. </p>
+<p>1.Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. </p>
+<p>2. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. </p>
+<p><Strong>This appears on page 4 because it would otherwise have a widow on the next page less than the default allows </Strong>Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 ';
 
 
@@ -19,15 +187,15 @@ $html = '
 //==============================================================
 //==============================================================
 
-require_once __DIR__ . '/../vendor/autoload.php';
+include("../mpdf.php");
 
-$mpdf = new mPDF();
+$mpdf=new mPDF();
 
 $mpdf->SetDisplayMode('fullpage');
 
 // LOAD a stylesheet
 $stylesheet = file_get_contents('mpdfstyleA4.css');
-$mpdf->WriteHTML($stylesheet,1);	// The parameter 1 tells that this is css/style only and no body/html/text
+$mpdf->WriteHTML($stylesheet,1);    // The parameter 1 tells that this is css/style only and no body/html/text
 
 $mpdf->WriteHTML($html);
 
@@ -37,3 +205,5 @@ exit;
 //==============================================================
 //==============================================================
 //==============================================================
+
+?>

--- a/examples/example64_widows.php
+++ b/examples/example64_widows.php
@@ -1,0 +1,79 @@
+<?php
+
+
+
+$html = '
+<h1>mPDF</h1>
+<h2>Widow Processing</h2>
+<p>In typography, widows and orphans are those words or lines which are separated from other content by a page or column break. They are considered by typographers to be bad form.</p>
+<p>A widow appears at the start of the following page or column, whereas an orphan appears at the end of the current page. A widow has no future; an orphan has no past.</p>
+<p>mPDF attempts to control widows and orphans by moving the page or column break earlier in the manuscript. It does not attempt to adjust leading, tracking, spacing, margins or hyphenation.</p>
+<p>The relevant settings in the <em>config.php</em> file are <strong>minWidowLines</strong> and <strong>minOrphanLines</strong>.</p>
+<p><strong>The important lines in this example are bold, and describe the expected behaviour.</strong></p>
+<h4>The following paragraphs are just page filling content to force page breaks.</h4>
+<hr>
+<p>Nulla felis erat, imperdiet eu, ullamcorper non, nonummy quis, elit. Suspendisse potenti. Ut a eros at ligula vehicula pretium. Maecenas feugiat pede vel risus. Nulla et lectus. Fusce eleifend neque sit amet erat. Integer consectetuer nulla non orci. Morbi feugiat pulvinar dolor. Cras odio. Donec mattis, nisi id euismod auctor, neque metus pellentesque risus, at eleifend lacus sapien et risus. Phasellus metus. Phasellus feugiat, lectus ac aliquam molestie, leo lacus tincidunt turpis, vel aliquam quam odio et sapien. Mauris ante pede, auctor ac, suscipit quis, malesuada sed, nulla. Integer sit amet odio sit amet lectus luctus euismod. Donec et nulla. Sed quis orci. </p>
+<p>Proin aliquet lorem id felis. Curabitur vel libero at mauris nonummy tincidunt. Donec imperdiet. Vestibulum sem sem, lacinia vel, molestie et, laoreet eget, urna. Curabitur viverra faucibus pede. Morbi lobortis. Donec dapibus. Donec tempus. Ut arcu enim, rhoncus ac, venenatis eu, porttitor mollis, dui. Sed vitae risus. In elementum sem placerat dui. Nam tristique eros in nisl. Nulla cursus sapien non quam porta porttitor. Quisque dictum ipsum ornare tortor. Fusce ornare tempus enim. </p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+</p>
+
+<p>Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum.</p>
+<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur.
+<strong>This widow paragraph should appear on page two, because it has less than three lines (the default in config.php) after the page end.</strong></p>
+<p>Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+</p>
+
+';
+
+
+//==============================================================
+//==============================================================
+//==============================================================
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$mpdf = new mPDF();
+
+$mpdf->SetDisplayMode('fullpage');
+
+// LOAD a stylesheet
+$stylesheet = file_get_contents('mpdfstyleA4.css');
+$mpdf->WriteHTML($stylesheet,1);	// The parameter 1 tells that this is css/style only and no body/html/text
+
+$mpdf->WriteHTML($html);
+
+$mpdf->Output();
+
+exit;
+//==============================================================
+//==============================================================
+//==============================================================

--- a/examples/example65_orphans.php
+++ b/examples/example65_orphans.php
@@ -1,0 +1,78 @@
+<?php
+
+
+
+$html = '
+<h1>mPDF</h1>
+<h2>Orphan Processing</h2>
+<p>In typography, widows and orphans are those words or lines which are separated from other content by a page or column break. They are considered by typographers to be bad form.</p>
+<p>A widow appears at the start of the following page or column, whereas an orphan appears at the end of the current page. A widow has no future; an orphan has no past.</p>
+<p>mPDF attempts to control widows and orphans by moving the page or column break earlier in the manuscript. It does not attempt to adjust leading, tracking, spacing, margins or hyphenation.</p>
+<p>The relevant settings in the <em>config.php</em> file are <strong>minWidowLines</strong> and <strong>minOrphanLines</strong>.</p>
+<p><strong>The important lines in this example are bold, and describe the expected behaviour.</strong></p>
+<h4>The following paragraphs are just page filling content to force page breaks.</h4>
+<hr>
+<p>Nulla felis erat, imperdiet eu, ullamcorper non, nonummy quis, elit. Suspendisse potenti. Ut a eros at ligula vehicula pretium. Maecenas feugiat pede vel risus. Nulla et lectus. Fusce eleifend neque sit amet erat. Integer consectetuer nulla non orci. Morbi feugiat pulvinar dolor. Cras odio. Donec mattis, nisi id euismod auctor, neque metus pellentesque risus, at eleifend lacus sapien et risus. Phasellus metus. Phasellus feugiat, lectus ac aliquam molestie, leo lacus tincidunt turpis, vel aliquam quam odio et sapien. Mauris ante pede, auctor ac, suscipit quis, malesuada sed, nulla. Integer sit amet odio sit amet lectus luctus euismod. Donec et nulla. Sed quis orci. </p>
+<p>Proin aliquet lorem id felis. Curabitur vel libero at mauris nonummy tincidunt. Donec imperdiet. Vestibulum sem sem, lacinia vel, molestie et, laoreet eget, urna. Curabitur viverra faucibus pede. Morbi lobortis. Donec dapibus. Donec tempus. Ut arcu enim, rhoncus ac, venenatis eu, porttitor mollis, dui. Sed vitae risus. In elementum sem placerat dui. Nam tristique eros in nisl. Nulla cursus sapien non quam porta porttitor. Quisque dictum ipsum ornare tortor. Fusce ornare tempus enim. </p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+</p>
+
+<p>Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum.</p>
+<p><strong>This orphan part of the paragraph should appear on page two, because it has less than three lines (the default in config.php) before the page end. </strong> Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+</p>
+
+';
+
+
+//==============================================================
+//==============================================================
+//==============================================================
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$mpdf = new mPDF();
+
+$mpdf->SetDisplayMode('fullpage');
+
+// LOAD a stylesheet
+$stylesheet = file_get_contents('mpdfstyleA4.css');
+$mpdf->WriteHTML($stylesheet,1);	// The parameter 1 tells that this is css/style only and no body/html/text
+
+$mpdf->WriteHTML($html);
+
+$mpdf->Output();
+
+exit;
+//==============================================================
+//==============================================================
+//==============================================================

--- a/mpdf.php
+++ b/mpdf.php
@@ -1,7 +1,7 @@
 <?php
 
 // ******************************************************************************
-// Software: mPDFdow, Unicode-HTML Free PDF generator                              *
+// Software: mPDF, Unicode-HTML Free PDF generator                              *
 // Version:  6.0        based on                                                *
 //           FPDF by Olivier PLATHEY                                            *
 //           HTML2FPDF by Renato Coelho                                         *

--- a/mpdf.php
+++ b/mpdf.php
@@ -830,7 +830,7 @@ class mPDF
 
     // Widows and Orphans
     var $minWidowLines;
-    var $mminOrphanLines;
+    var $minOrphanLines;
 
 	var $ispre;
 	var $outerblocktags;

--- a/mpdf.php
+++ b/mpdf.php
@@ -6512,7 +6512,7 @@ class mPDF
                 $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
                 $this->debugLog("Widow detection triggered a page break");
             } else {
-                $this->debugLog("Widow detection, but already handled in Estimate");
+                $this->debugLog("Widow detected, but already handled in Estimate");
             }
         }
 
@@ -6525,7 +6525,7 @@ class mPDF
                 $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
                 $this->debugLog("Orphan detection triggered a page break");
             } else {
-                $this->debugLog("Orphan detection, but already handled in Estimate");
+                $this->debugLog("Orphan detected, but already handled in Estimate");
             }
         }
     
@@ -18827,7 +18827,7 @@ class mPDF
                     $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
                     $this->debugLog("Widow detection triggered a page break");
                 } else {
-                    $this->debugLog("Widow detection, but already handled in Estimate");
+                    $this->debugLog("Widow detected, but already handled in Estimate");
                 }
             }
 
@@ -18839,7 +18839,7 @@ class mPDF
                     $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
                     $this->debugLog("Orphan detection triggered a page break");
                 } else {
-                    $this->debugLog("Orphan detection, but already handled in Estimate");
+                    $this->debugLog("Orphan detected, but already handled in Estimate");
                 }
             }
         }

--- a/mpdf.php
+++ b/mpdf.php
@@ -1,15 +1,15 @@
 <?php
 
 // ******************************************************************************
-// Software: mPDF, Unicode-HTML Free PDF generator                              *
-// Version:  6.0        based on                                                *
-//           FPDF by Olivier PLATHEY                                            *
-//           HTML2FPDF by Renato Coelho                                         *
-// Date:     2014-11-24                                                         *
-// Author:   Ian Back <ianb@bpm1.com>                                           *
-// License:  GPL                                                                *
-//                                                                              *
-// Changes:  See changelog.txt                                                  *
+// Software: mPDF, Unicode-HTML Free PDF generator							  *
+// Version:  6.0		based on												*
+//		   FPDF by Olivier PLATHEY											*
+//		   HTML2FPDF by Renato Coelho										 *
+// Date:	 2014-11-24														 *
+// Author:   Ian Back <ianb@bpm1.com>										   *
+// License:  GPL																*
+//																			  *
+// Changes:  See changelog.txt												  *
 // ******************************************************************************
 
 define('mPDF_VERSION', '6.0');
@@ -178,7 +178,7 @@ class mPDF
 	var $enableImports;
 
 	var $debug;
-    var $stderr;
+	var $stderr;
 
 	var $showStats;
 	var $setAutoTopMargin;
@@ -791,8 +791,8 @@ class mPDF
 	var $DefrMargin; //Default right margin
 	var $x;
 	var $y; //current position in user unit for cell positioning
-    var $bak_x; //x position where we need to back up to insert breaks, or columns
-    var $bak_y; //y position where we need to back up to insert breaks, or columns
+	var $bak_x; //x position where we need to back up to insert breaks, or columns
+	var $bak_y; //y position where we need to back up to insert breaks, or columns
 	var $lasth; //height of last cell printed
 	var $LineWidth; //line width in user unit
 	var $CoreFonts; //array of standard font names
@@ -831,9 +831,9 @@ class mPDF
 	//var $aliasNbPgHex;	// mPDF 6 deleted
 	//var $aliasNbPgGpHex;	// mPDF 6 deleted
 
-    // Widows and Orphans
-    var $minWidowLines;
-    var $minOrphanLines;
+	// Widows and Orphans
+	var $minWidowLines;
+	var $minOrphanLines;
 
 	var $ispre;
 	var $outerblocktags;
@@ -854,8 +854,8 @@ class mPDF
 	public function __construct($mode = '', $format = 'A4', $default_font_size = 0, $default_font = '', $mgl = 15, $mgr = 15, $mgt = 16, $mgb = 16, $mgh = 9, $mgf = 9, $orientation = 'P')
 	{
 
-         /* where to send debug output */
-         $this->stderr = fopen("php://stderr", "w");
+		 /* where to send debug output */
+		 $this->stderr = fopen("php://stderr", "w");
 
 		/* -- BACKGROUNDS -- */
 		if (!class_exists('grad', false)) {
@@ -1068,12 +1068,12 @@ class mPDF
 		$this->pageoutput = array();
 
 		$this->bufferoutput = false;
-		$this->encrypted = false;      //whether document is protected
+		$this->encrypted = false;	  //whether document is protected
 		$this->BMoutlines = array();
-		$this->ColActive = 0;          //Flag indicating that columns are on (the index is being processed)
-		$this->Reference = array();    //Array containing the references
-		$this->CurrCol = 0;               //Current column number
-		$this->OldCol = 0;               //Current column number
+		$this->ColActive = 0;		  //Flag indicating that columns are on (the index is being processed)
+		$this->Reference = array();	//Array containing the references
+		$this->CurrCol = 0;			   //Current column number
+		$this->OldCol = 0;			   //Current column number
 		$this->ColL = array(0);   // Array of Left pos of columns - absolute - needs Margin correction for Odd-Even
 		$this->ColR = array(0);   // Array of Right pos of columns - absolute pos - needs Margin correction for Odd-Even
 		$this->ChangeColumn = 0;
@@ -1113,10 +1113,10 @@ class mPDF
 		$this->autoPageBreak = true;
 
 		require(_MPDF_PATH . 'config.php'); // config data
-        // now load custom config
-        if(file_exists(_MPDF_PATH . 'config.local.php')) {
-            include _MPDF_PATH . 'config.local.php';
-        }
+		// now load custom config
+		if(file_exists(_MPDF_PATH . 'config.local.php')) {
+			include _MPDF_PATH . 'config.local.php';
+		}
 
 		$this->_setPageSize($format, $orientation);
 		$this->DefOrientation = $orientation;
@@ -1832,7 +1832,7 @@ class mPDF
 			}
 		}
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 	}
 
 	function SetLeftMargin($margin)
@@ -1841,8 +1841,8 @@ class mPDF
 		$this->lMargin = $margin;
 		if ($this->page > 0 and $this->x < $margin) {
 			$this->x = $margin;
-            $this->debugLog("Setting x to: ". $this->x, "red");
-        }
+			$this->debugLog("Setting x to: ". $this->x, "red");
+		}
 	}
 
 	function SetTopMargin($margin)
@@ -1937,9 +1937,9 @@ class mPDF
 	function SetAlpha($alpha, $bm = 'Normal', $return = false, $mode = 'B')
 	{
 		// alpha: real value from 0 (transparent) to 1 (opaque)
-		// bm:    blend mode, one of the following:
-		//          Normal, Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorBurn,
-		//          HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color, Luminosity
+		// bm:	blend mode, one of the following:
+		//		  Normal, Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorBurn,
+		//		  HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color, Luminosity
 		// set alpha for stroking (CA) and non-stroking (ca) operations
 		// mode determines F (fill) S (stroke) B (both)
 		if (($this->PDFA || $this->PDFX) && $alpha != 1) {
@@ -2110,7 +2110,7 @@ class mPDF
 		if ($this->state == 3)
 			return;
 		if ($this->page == 0)
-            $this->debugLog('Adding Page Here', "yellow");
+			$this->debugLog('Adding Page Here', "yellow");
 			$this->AddPage($this->CurOrientation);
 		if (count($this->cellBorderBuffer)) {
 			$this->printcellbuffer();
@@ -2869,7 +2869,7 @@ class mPDF
 		$pagesel = (isset($a['pagesel']) ? $a['pagesel'] : (isset($a['pageselector']) ? $a['pageselector'] : ''));
 		$newformat = (isset($a['newformat']) ? $a['newformat'] : (isset($a['sheet-size']) ? $a['sheet-size'] : ''));
 
-        $this->debugLog("Adding Page Here", "yellow");
+		$this->debugLog("Adding Page Here", "yellow");
 		$this->AddPage($orientation, $condition, $resetpagenum, $pagenumstyle, $suppress, $mgl, $mgr, $mgt, $mgb, $mgh, $mgf, $ohname, $ehname, $ofname, $efname, $ohvalue, $ehvalue, $ofvalue, $efvalue, $pagesel, $newformat);
 	}
 
@@ -2884,7 +2884,7 @@ class mPDF
 				$this->tag->CloseTag($this->blk[$b]['tag'], $arr, $ai);
 			}
 			if ($this->blklvl == 0 && !empty($this->textbuffer)) { //Output previously buffered content
-                $this->debugLog("Printing buffer here", "yellow");
+				$this->debugLog("Printing buffer here", "yellow");
 				$this->printbuffer($this->textbuffer, 1);
 				$this->textbuffer = array();
 			}
@@ -2897,7 +2897,7 @@ class mPDF
 					$this->tag->CloseTag($this->blk[$b]['tag'], $arr, $ai);
 				} else {
 					if ($b == $this->blklvl && !empty($this->textbuffer)) { //Output previously buffered content
-                        $this->debugLog("Printing buffer here", "yellow");
+						$this->debugLog("Printing buffer here", "yellow");
 						$this->printbuffer($this->textbuffer, 1);
 						$this->textbuffer = array();
 					}
@@ -2905,7 +2905,7 @@ class mPDF
 				}
 			}
 		} elseif (!empty($this->textbuffer)) { //Output previously buffered content
-            $this->debugLog("Printing buffer here", "yellow");
+			$this->debugLog("Printing buffer here", "yellow");
 			$this->printbuffer($this->textbuffer, 1);
 			$this->textbuffer = array();
 		}
@@ -2987,7 +2987,7 @@ class mPDF
 					$this->PaintDivBB('pagebottom', 0, $bl);
 				}
 				$this->y = $sy;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->table_rotate = $save_tr; // *TABLES*
 			}
 			$s = $this->PrintPageBackgrounds();
@@ -3011,9 +3011,9 @@ class mPDF
 			$this->ResetMargins();
 			$this->SetAutoPageBreak($this->autoPageBreak, $this->bMargin);
 			$this->x = $this->lMargin;
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			$this->y = $this->tMargin;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			$this->FontFamily = '';
 			$this->_out('2 J');
 			$this->LineWidth = $lw;
@@ -3077,7 +3077,7 @@ class mPDF
 				else {
 					$pbch = false;
 				} // *CSS-PAGE*
-                $this->debugLog("Adding Page Here", "yellow");
+				$this->debugLog("Adding Page Here", "yellow");
 				$this->AddPage($this->CurOrientation, 'O');
 				$this->extrapagebreak = true; // mPDF 6 pagebreaktype
 				if ($pbch) {
@@ -3096,7 +3096,7 @@ class mPDF
 				else {
 					$pbch = false;
 				} // *CSS-PAGE*
-                $this->debugLog("Adding Page Here", "yellow");
+				$this->debugLog("Adding Page Here", "yellow");
 				$this->AddPage($this->CurOrientation, 'E');
 				$this->extrapagebreak = true; // mPDF 6 pagebreaktype
 				if ($pbch) {
@@ -3151,7 +3151,7 @@ class mPDF
 				$this->PaintDivBB('pagebottom', 0, $bl);
 			}
 			$this->y = $sy;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			// RESET block y0 and x0 - see below
 		}
 		$this->extrapagebreak = false; // mPDF 6 pagebreaktype
@@ -4473,7 +4473,7 @@ class mPDF
 		}
 
 
-		/*         * ************** SIMILAR TO Cell() ************************ */
+		/*		 * ************** SIMILAR TO Cell() ************************ */
 
 		// IF corefonts AND NOT SmCaps AND NOT Kerning
 		// Just output text
@@ -4505,7 +4505,7 @@ class mPDF
 		else {
 			$s .= $this->applyGPOSpdf($txt2, $aix, $px, $py, $OTLdata, $textvar);
 		}
-		/*         * ************** END ************************ */
+		/*		 * ************** END ************************ */
 
 		$s .= ' ';
 
@@ -4834,7 +4834,7 @@ class mPDF
 		} else {
 			$bottom = 0;
 		}
-        $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+		$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 		if (!$this->tableLevel && (($this->y + $this->divheight > $this->PageBreakTrigger) || ($this->y + $h > $this->PageBreakTrigger) ||
 			($this->y + ($h * 2) + $bottom > $this->PageBreakTrigger && $this->blk[$this->blklvl]['page_break_after_avoid'])) and ! $this->InFooter and $this->AcceptPageBreak(false)) { // mPDF 5.7.2
 			$x = $this->x; //Current X position
@@ -4843,7 +4843,7 @@ class mPDF
 			$charspacing = $this->charspacing; //Character Spacing
 			$this->ResetSpacing();
 
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($this->CurOrientation);
 			// Added to correct for OddEven Margins
 			$x += $this->MarginCorrection;
@@ -4851,7 +4851,7 @@ class mPDF
 				$currentx += $this->MarginCorrection;
 			}
 			$this->x = $x;
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			// WORD SPACING
 			$this->SetSpacing($charspacing, $ws);
 		}
@@ -5200,7 +5200,7 @@ class mPDF
 			$sub = '';
 			$this->CurrentFont['used'] = true;
 
-			/*             * ************** SIMILAR TO Text() ************************ */
+			/*			 * ************** SIMILAR TO Text() ************************ */
 
 			// IF corefonts AND NOT SmCaps AND NOT Kerning
 			// Just output text; charspacing and wordspacing already set by charspacing (Tc) and ws (Tw)
@@ -5257,7 +5257,7 @@ class mPDF
 				$sub = $this->applyGPOSpdf($txt, $aix, $px, $py, $OTLdata, $textvar);
 			}
 
-			/*             * ************** END SIMILAR TO Text() ************************ */
+			/*			 * ************** END SIMILAR TO Text() ************************ */
 
 			if ($this->shrin_k > 1) {
 				$shrin_k = $this->shrin_k;
@@ -5414,15 +5414,15 @@ class mPDF
 		if ($ln > 0) {
 			//Go to next line
 			$this->y += $h;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			if ($ln == 1) {
 				//Move to next line
 				if ($currentx != 0) {
 					$this->x = $currentx;
-                    $this->debugLog("Setting x to: ". $this->x, "red");
+					$this->debugLog("Setting x to: ". $this->x, "red");
 				} else {
 					$this->x = $this->lMargin;
-                    $this->debugLog("Setting x to: ". $this->x, "red");
+					$this->debugLog("Setting x to: ". $this->x, "red");
 				}
 			}
 		} else
@@ -6134,7 +6134,7 @@ class mPDF
 			$this->Cell($w, $h, substr($s, $j, $i - $j), $b, 2, $align, $fill, $link);
 		}
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 	}
 
 	/* -- DIRECTW -- */
@@ -6253,7 +6253,7 @@ class mPDF
 	}
 
 	//-------------------------FLOWING BLOCK------------------------------------//
-	//The following functions were originally written by Damon Kohler           //
+	//The following functions were originally written by Damon Kohler		   //
 	//--------------------------------------------------------------------------//
 
 	function saveFont()
@@ -6321,13 +6321,13 @@ class mPDF
 
 	function newFlowingBlock($w, $h, $a = '', $is_table = false, $blockstate = 0, $newblock = true, $blockdir = 'ltr', $table_draft = false)
 	{
-        $CurrCol = $this->CurrCol;
-        $OldCol = $this->OldCol;
-        $ChangeCol = $this->ChangeCol;
-        $ColActive = $this->ColActive;
+		$CurrCol = $this->CurrCol;
+		$OldCol = $this->OldCol;
+		$ChangeCol = $this->ChangeCol;
+		$ColActive = $this->ColActive;
 
-        $this->debugLog("-------------------------");
-        $this->debugLog("Starting New Flowing Block || PAGE: " . $this->page . " || X: ". $this->x . " || Y: " . $this->y . ", CurrCol: $CurrCol, OldCol: $OldCol, ChangeCol: $ChangeCol, ColActive: $ColActive");
+		$this->debugLog("-------------------------");
+		$this->debugLog("Starting New Flowing Block || PAGE: " . $this->page . " || X: ". $this->x . " || Y: " . $this->y . ", CurrCol: $CurrCol, OldCol: $OldCol, ChangeCol: $ChangeCol, ColActive: $ColActive");
 
 		if (!$a) {
 			if ($blockdir == 'rtl') {
@@ -6336,7 +6336,7 @@ class mPDF
 				$a = 'L';
 			}
 		}
-        // Save the start position of this block - needed for orphan / widow detection
+		// Save the start position of this block - needed for orphan / widow detection
 		$this->flowingBlockAttr['starts_y'] = $this->y;
 		$this->flowingBlockAttr['widow_break_added'] = false;
 		$this->flowingBlockAttr['orphan_break_added'] = false;
@@ -6370,8 +6370,8 @@ class mPDF
 
 	function finishFlowingBlock($endofblock = false, $next = '')
 	{
-        $this->x = ($this->flowingBlockAttr['newX']) ? $this->flowingBlockAttr['newX'] : $this->x;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->x = ($this->flowingBlockAttr['newX']) ? $this->flowingBlockAttr['newX'] : $this->x;
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$currentx = $this->x;
 		//prints out the last chunk
 		$is_table = $this->flowingBlockAttr['is_table'];
@@ -6391,10 +6391,10 @@ class mPDF
 		$newblock = $this->flowingBlockAttr['newblock'];
 		$blockdir = $this->flowingBlockAttr['blockdir'];
 
-        $CurrCol = $this->CurrCol;
-        $OldCol = $this->OldCol;
+		$CurrCol = $this->CurrCol;
+		$OldCol = $this->OldCol;
 
-        $this->debugLog("Finishing Flowing Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y . ", CurrCol: $CurrCol, OldCol: $OldCol");
+		$this->debugLog("Finishing Flowing Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y . ", CurrCol: $CurrCol, OldCol: $OldCol");
 
 		// *********** BLOCK BACKGROUND COLOR *****************//
 		if ($this->blk[$this->blklvl]['bgcolor'] && !$is_table) {
@@ -6483,7 +6483,7 @@ class mPDF
 
 		if ($table_draft) {
 			$this->y += $stackHeight;
-            $this->debugLog("Setting y to: " . $this->y, "red");
+			$this->debugLog("Setting y to: " . $this->y, "red");
 			$this->objectbuffer = array();
 			return 0;
 		}
@@ -6494,7 +6494,7 @@ class mPDF
 		$contentWidth = 0;
 
 		foreach ($content as $k => $chunk) {
-            $this->debugLog("CHUNK: " . $chunk, "red");
+			$this->debugLog("CHUNK: " . $chunk, "red");
 			$this->restoreFont($font[$k], false);
 			if (!isset($this->objectbuffer[$k]) || (isset($this->objectbuffer[$k]) && !$this->objectbuffer[$k])) {
 				// Soft Hyphens chr(173)
@@ -6541,14 +6541,14 @@ class mPDF
 		// Get PAGEBREAK TO TEST for height including the bottom border/padding
 		$check_h = max($this->divheight, $stackHeight);
 
-        /**
-         * determine if our orphans and widows config should page break before 
-         * printing this block content
-         **/
-        $expectedWidowLines = $this->getExpectedBlockWidowCount();
-        $expectedOrphanLines = $this->getExpectedBlockOrphanCount();
-        $this->addPageBreaksForWidows($expectedWidowLines);
-        $this->addPageBreaksForOrphans($expectedOrphanLines);
+		/**
+		 * determine if our orphans and widows config should page break before 
+		 * printing this block content
+		 **/
+		$expectedWidowLines = $this->getExpectedBlockWidowCount();
+		$expectedOrphanLines = $this->getExpectedBlockOrphanCount();
+		$this->addPageBreaksForWidows($expectedWidowLines);
+		$this->addPageBreaksForOrphans($expectedOrphanLines);
 
 		// This fixes a proven bug...
 		if ($endofblock && $newblock && $blockstate == 0 && !$content) {
@@ -6572,7 +6572,7 @@ class mPDF
 		// Force PAGE break if column height cannot take check-height
 		if ($this->ColActive && $check_h > ($this->PageBreakTrigger - $this->y0)) {
 			$this->SetCol($this->NbCol - 1);
-            $this->debugLog("Setting CurrCol to: " . $this->CurrCol, "red");
+			$this->debugLog("Setting CurrCol to: " . $this->CurrCol, "red");
 		}
 
 		// Avoid just border/background-color moved on to next page
@@ -6583,7 +6583,7 @@ class mPDF
 		}
 
 		// PAGEBREAK
-        $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+		$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 		if (!$is_table && ($this->y + $check_h) > ($this->PageBreakTrigger + $buff) and ! $this->InFooter and $this->AcceptPageBreak()) {
 
 			$this->bak_x = $this->x; //Current X position
@@ -6592,15 +6592,15 @@ class mPDF
 			$charspacing = $this->charspacing; //Character Spacing
 			$this->ResetSpacing();
 
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($this->CurOrientation);
 
 			$this->x = $this->bak_x;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 			// Added to correct for OddEven Margins
 			$currentx += $this->MarginCorrection;
 			$this->x += $this->MarginCorrection;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 
 			// WORD SPACING
 			$this->SetSpacing($charspacing, $ws);
@@ -6613,8 +6613,8 @@ class mPDF
 		if ($this->CurrCol != $this->OldCol) {
 			$currentx += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
 			$this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-            // set X
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			// set X
+			$this->debugLog("Setting x to: " . $this->x, "red");
 			$this->OldCol = $this->CurrCol;
 		}
 
@@ -6659,7 +6659,7 @@ class mPDF
 				$this->breakpoints[$this->CurrCol][] = $this->y;
 			} // *COLUMNS*
 			$this->x = $currentx;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 		}
 
 
@@ -6838,7 +6838,7 @@ class mPDF
 			} // false -> don't advance y
 
 			$this->x = $currentx + $this->cMarginL + $ipaddingL + $fpaddingL;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 			if ($dottab !== false && $blockdir == 'rtl') {
 				$this->x -= $dottab;
 			} elseif ($align == 'R') {
@@ -6848,8 +6848,8 @@ class mPDF
 			} elseif ($align == 'C') {
 				$this->x += ($empty / 2);
 			}
-            // set X
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			// set X
+			$this->debugLog("Setting x to: " . $this->x, "red");
 
 			// Paragraph INDENT
 			$WidthCorrection = 0;
@@ -6857,8 +6857,8 @@ class mPDF
 				$ti = $this->ConvertSize($this->blk[$this->blklvl]['text_indent'], $this->blk[$this->blklvl]['inner_width'], $this->blk[$this->blklvl]['InlineProperties']['size'], false);  // mPDF 5.7.4
 				if ($blockdir != 'rtl') {
 					$this->x += $ti;
-                    // set X
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					// set X
+					$this->debugLog("Setting x to: " . $this->x, "red");
 				} // mPDF 6
 			}
 
@@ -6893,8 +6893,8 @@ class mPDF
 					$s = preg_split('/' . preg_quote($dp, '/') . '/', $content[0], 2);  // ? needs to be /u if not core
 					$s0 = $this->GetStringWidth($s[0], false);
 					$this->x += ($this->decimal_offset - $s0);
-                    // set X
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					// set X
+					$this->debugLog("Setting x to: " . $this->x, "red");
 				}
 
 				$this->SetSpacing(($this->fixedlSpacing * _MPDFK) + $jcharspacing, ($this->fixedlSpacing + $this->minwSpacing) * _MPDFK + $jws);
@@ -6917,8 +6917,8 @@ class mPDF
 				if (!empty($this->spanborddet)) {
 					if (strpos($contentB[$k], 'L') !== false && isset($this->spanborddet['L']))
 						$this->x += $this->spanborddet['L']['w'];
-                        // set X
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						// set X
+						$this->debugLog("Setting x to: " . $this->x, "red");
 					if (strpos($contentB[$k], 'L') === false)
 						$this->spanborddet['L']['s'] = $this->spanborddet['L']['w'] = 0;
 					if (strpos($contentB[$k], 'R') === false)
@@ -6970,8 +6970,8 @@ class mPDF
 				if (!empty($this->spanborddet)) {
 					if (strpos($contentB[$k], 'R') !== false && $aord != $arraysize - 1)
 						$this->x += $this->spanborddet['R']['w'];
-                        // set X
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						// set X
+						$this->debugLog("Setting x to: " . $this->x, "red");
 				}
 				// *********** SPAN BACKGROUND COLOR OFF - RESET BLOCK BGCOLOR ***************** //
 				if (isset($spanfill) && $spanfill) {
@@ -7014,7 +7014,7 @@ class mPDF
 				$drop = max($fry1, $fly1) - $this->y;
 				$this->DivLn($drop);
 				$this->x = $currentx;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 			}
 		}
 		/* -- END CSS-IMAGE-FLOAT -- */
@@ -7039,8 +7039,8 @@ class mPDF
 			// $state = 0 normal; 1 top; 2 bottom; 3 top and bottom
 			$this->DivLn($this->blk[$this->blklvl]['padding_bottom'] + $this->blk[$this->blklvl]['border_bottom']['w'] + $extra, -3, true, false, 2);
 			$this->x = $currentx;
-            $this->debugLog("Setting x to: " . $this->x, "red");
-        
+			$this->debugLog("Setting x to: " . $this->x, "red");
+		
 			if ($this->ColActive) {
 				$this->breakpoints[$this->CurrCol][] = $this->y;
 			} // *COLUMNS*
@@ -7061,10 +7061,10 @@ class mPDF
 			}
 		}
 
-        $this->flowingBlockAttr['newX'] = null;
-        
-        $this->debugLog("Done finishing Flowing Block. X: " . $this->x . " Y: " . $this->y . " CurrCol: " . $this->CurrCol);
-        $this->debugLog("----------------------------\n");
+		$this->flowingBlockAttr['newX'] = null;
+		
+		$this->debugLog("Done finishing Flowing Block. X: " . $this->x . " Y: " . $this->y . " CurrCol: " . $this->CurrCol);
+		$this->debugLog("----------------------------\n");
 	}
 
 	function printobjectbuffer($is_table = false, $blockdir = false)
@@ -7092,9 +7092,9 @@ class mPDF
 				$x = $objattr['OUTER-X'];
 				$y = $objattr['OUTER-Y'];
 				$this->y = $y - $this->FontSize / 2;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->x = $x;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				if ($objattr['type'] == 'bookmark') {
 					$this->Bookmark($objattr['CONTENT'], $objattr['bklevel'], $y - $this->FontSize);
 				} // *BOOKMARKS*
@@ -7122,9 +7122,9 @@ class mPDF
 				// linking $y-1 in the Columnbuffer with entry in $this->columnAnnots
 				// and when columns are split in length will not break annotation from current line
 				$this->y = $y - 1;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->x = $x - 1;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->Line($x - 1, $y - 1, $x - 1, $y - 1);
 				$this->Annotation($objattr['CONTENT'], $x, $y, $objattr['ICON'], $objattr['AUTHOR'], $objattr['SUBJECT'], $objattr['OPACITY'], $objattr['COLOR'], (isset($objattr['POPUP']) ? $objattr['POPUP'] : ''), (isset($objattr['FILE']) ? $objattr['FILE'] : ''));
 			}
@@ -7137,9 +7137,9 @@ class mPDF
 					$texto = $objattr['text'];
 				}
 				$this->y = $y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->x = $x;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				if (isset($objattr['fontfamily'])) {
 					$this->SetFont($objattr['fontfamily'], '', $objattr['fontsize']);
 				}
@@ -7162,7 +7162,7 @@ class mPDF
 				$oldlinewidth = $this->LineWidth;
 				$this->SetLineWidth($objattr['linewidth'] / $k);
 				$this->y += ($objattr['linewidth'] / 2) + $objattr['margin_top'] / $k;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->Line($x, $this->y, $x + $objattr['INNER-WIDTH'], $this->y);
 				$this->SetLineWidth($oldlinewidth);
 				$this->SetDColor($this->ConvertColor(0));
@@ -7469,7 +7469,7 @@ class mPDF
 					}
 					$yadj -= ($this->FontSize * $xh / 1000) * 0.625; // Vertical height of bullet (centre) from baseline= XHeight * 0.625
 					$this->y += $yadj;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 
 					$this->_printListBullet($this->x, $this->y, $size, $type, $col);
 				} else {
@@ -7561,9 +7561,9 @@ class mPDF
 		}
 		$this->SetFont($save_currentfontfamily, $save_currentfontstyle, $save_currentfontsize);
 		$this->y = $save_y;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->x = $save_x;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		unset($content);
 	}
 
@@ -7638,37 +7638,37 @@ class mPDF
 
 	function EstimateFlowingBlockWriteLines($s, $sOTLdata)
 	{
-        /**
-         * We will run the writes on a cloned version of the
-         * current document so that we can estimate how many lines
-         * are required before actually printing the lines
-         */
-        $mock = clone $this;
-        $mock->WriteFlowingBlock($s, $sOTLdata, true);
-        $lineCount = $mock->flowingBlockAttr['lineCount']; 
+		/**
+		 * We will run the writes on a cloned version of the
+		 * current document so that we can estimate how many lines
+		 * are required before actually printing the lines
+		 */
+		$mock = clone $this;
+		$mock->WriteFlowingBlock($s, $sOTLdata, true);
+		$lineCount = $mock->flowingBlockAttr['lineCount']; 
 
-        $BeforeCol = $this->CurrCol;
-        $AfterCol = $mock->CurrCol;
-        $ChangeCol = $mock->ChangeCol;
-    
-        $this->debugLog("BeforeCol: $BeforeCol, AfterCol: $AfterCol, ChangeCol: $ChangeCol", "yellow");
-        if ($BeforeCol < $AfterCol) {
-            $this->flowingBlockAttr['expect_col_change'] = true;
-        }
+		$BeforeCol = $this->CurrCol;
+		$AfterCol = $mock->CurrCol;
+		$ChangeCol = $mock->ChangeCol;
+	
+		$this->debugLog("BeforeCol: $BeforeCol, AfterCol: $AfterCol, ChangeCol: $ChangeCol", "yellow");
+		if ($BeforeCol < $AfterCol) {
+			$this->flowingBlockAttr['expect_col_change'] = true;
+		}
 
-        if ($mock->flowingBlockAttr['expect_col_change']) {
-            $this->flowingBlockAttr['expect_col_change'] = true;
-        }
+		if ($mock->flowingBlockAttr['expect_col_change']) {
+			$this->flowingBlockAttr['expect_col_change'] = true;
+		}
 
-        $this->flowingBlockAttr['expected_lines'] += $lineCount;
+		$this->flowingBlockAttr['expected_lines'] += $lineCount;
 
-        return $lineCount;
-    }
+		return $lineCount;
+	}
 
 	function WriteFlowingBlock($s, $sOTLdata, $draft = false)
 	{ // mPDF 5.7.1
-        $this->x = ($this->flowingBlockAttr['newX']) ? $this->flowingBlockAttr['newX'] : $this->x;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->x = ($this->flowingBlockAttr['newX']) ? $this->flowingBlockAttr['newX'] : $this->x;
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$currentx = $this->x;
 		$is_table = $this->flowingBlockAttr['is_table'];
 		$table_draft = $this->flowingBlockAttr['table_draft'];
@@ -7690,11 +7690,11 @@ class mPDF
 		$newblock = $this->flowingBlockAttr['newblock'];
 		$blockdir = $this->flowingBlockAttr['blockdir'];
 
-        if ($draft) {
-            $this->debugLog("    Drafting Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
-        } else {
-            $this->debugLog("  Writing Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
-        }
+		if ($draft) {
+			$this->debugLog("	Drafting Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
+		} else {
+			$this->debugLog("  Writing Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
+		}
 
 		// *********** BLOCK BACKGROUND COLOR ***************** //
 		if ($this->blk[$this->blklvl]['bgcolor'] && !$is_table) {
@@ -7812,7 +7812,7 @@ class mPDF
 			$clen = mb_strlen($s, $this->mb_enc);
 		}
 
-        $this->debugLog("STRING: $s", "red");
+		$this->debugLog("STRING: $s", "red");
 
 		// for every character in the string
 		for ($i = 0; $i < $clen; $i++) {
@@ -7913,7 +7913,7 @@ class mPDF
 
 			// try adding another char
 			if (( $contentWidth + $cw > $maxWidth - $WidthCorrection - (($this->cMarginL + $this->cMarginR) * _MPDFK) - ($paddingL + $paddingR + (($fpaddingL + $fpaddingR) * _MPDFK) ) + 0.001)) {
-                // 0.001 is to correct for deviations converting mm=>pts
+				// 0.001 is to correct for deviations converting mm=>pts
 				// it won't fit, output what we already have
 				$lineCount++;
 
@@ -8380,18 +8380,18 @@ class mPDF
 					}
 
 					if ($this->ColActive && $check_h > ($this->PageBreakTrigger - $this->y0)) {
-                        $this->debugLog("Changing Columns HERE!!!!!!!!!!!!!!!!!!!!!!!", "yellow");
+						$this->debugLog("Changing Columns HERE!!!!!!!!!!!!!!!!!!!!!!!", "yellow");
 						$this->SetCol($this->NbCol - 1);
 					}
 
 					// PAGEBREAK
-                    $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+					$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 					// 'If' below used in order to fix "first-line of other page with justify on" bug <-- I didn't add this comment, M. Lewis
-                    // but I did add this one:
-                    // TODO: The AcceptPageBreak here causes issues in some multicolumn docs.  In reference to amnesty2014-report-english-litho-full.php
-                    // page 69 will print column 2 over column 1 when AcceptPageBreak is allowed to increment the column within the function.
-                    // However, calling it with false, to NOT allow the column increment, understandably breaks several pages where column breaks are expected
-                    // in place of page breaks
+					// but I did add this one:
+					// TODO: The AcceptPageBreak here causes issues in some multicolumn docs.  In reference to amnesty2014-report-english-litho-full.php
+					// page 69 will print column 2 over column 1 when AcceptPageBreak is allowed to increment the column within the function.
+					// However, calling it with false, to NOT allow the column increment, understandably breaks several pages where column breaks are expected
+					// in place of page breaks
 					if (!$is_table && ($this->y + $check_h) > $this->PageBreakTrigger and ! $this->InFooter and $this->AcceptPageBreak()) {
 						$this->bak_x = $this->x; //Current X position
 						// WORD SPACING
@@ -8399,38 +8399,38 @@ class mPDF
 						$charspacing = $this->charspacing; //Character Spacing
 						$this->ResetSpacing();
 
-                        $this->debugLog("Adding Page Here - IN WriteFlowingBlock", "yellow");
+						$this->debugLog("Adding Page Here - IN WriteFlowingBlock", "yellow");
 						$this->AddPage($this->CurOrientation);
 
 						$this->x = $this->bak_x;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 						// Added to correct for OddEven Margins
 						$currentx += $this->MarginCorrection;
 						$this->x += $this->MarginCorrection;
 
-                        // Adjust here for columns
-                        if ($this->ColActive) {
-                            //Go back to the first column - NEW PAGE
-                            $this->y0 = $this->tMargin;
-                            $this->ChangeColumn = -($this->NbCol - 1);
-                            // DIRECTIONALITY RTL
-                            if ($this->directionality == 'rtl') {
-                                $this->ChangeColumn = -($this->ChangeColumn);
-                            }
-						    $currentx = $this->lMargin;
-                            // set X
-			                $this->x = $this->lMargin;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
-                            $this->flowingBlockAttr['newX'] = $this->x; 
+						// Adjust here for columns
+						if ($this->ColActive) {
+							//Go back to the first column - NEW PAGE
+							$this->y0 = $this->tMargin;
+							$this->ChangeColumn = -($this->NbCol - 1);
+							// DIRECTIONALITY RTL
+							if ($this->directionality == 'rtl') {
+								$this->ChangeColumn = -($this->ChangeColumn);
+							}
+							$currentx = $this->lMargin;
+							// set X
+							$this->x = $this->lMargin;
+							$this->debugLog("Setting x to: " . $this->x, "red");
+							$this->flowingBlockAttr['newX'] = $this->x; 
 
-                            // TODO: Why does setting this to 20 or tMargin cause the next block to be written
-                            // over this block?  It also causes the rest of the blocks after this to only print 
-                            // in the first column.  Changing $this->y to ANYTHING > 20(tMargin) solves 
-                            // this issue.  no idea why.
-                            //$this->y = $this->tMargin;
-                            $this->y = ($this->tMargin + 1);
-                            $this->debugLog("Setting y to: " . $this->y, "red");
-                        }
+							// TODO: Why does setting this to 20 or tMargin cause the next block to be written
+							// over this block?  It also causes the rest of the blocks after this to only print 
+							// in the first column.  Changing $this->y to ANYTHING > 20(tMargin) solves 
+							// this issue.  no idea why.
+							//$this->y = $this->tMargin;
+							$this->y = ($this->tMargin + 1);
+							$this->debugLog("Setting y to: " . $this->y, "red");
+						}
 
 						// WORD SPACING
 						$this->SetSpacing($charspacing, $ws);
@@ -8447,9 +8447,9 @@ class mPDF
 					// COLUMN CHANGE
 					if ($this->CurrCol != $this->OldCol) {
 						$currentx += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-                        // set X
+						// set X
 						$this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 						$this->OldCol = $this->CurrCol;
 					}
 
@@ -8495,28 +8495,28 @@ class mPDF
 					} // false -> don't advance y
 
 // TODO: COME BACk HERE
-                    $this->debugLog("X WAS: " . $this->x . " currentX was: $currentx!!!!!", "red");
-                    $this->x = $currentx + $this->cMarginL + $ipaddingL + $fpaddingL;
-                    if ($align == 'R') {
-                        $this->x += $empty;
-                    } elseif ($align == 'C') {
-                        $this->x += ($empty / 2);
-                    }
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					$this->debugLog("X WAS: " . $this->x . " currentX was: $currentx!!!!!", "red");
+					$this->x = $currentx + $this->cMarginL + $ipaddingL + $fpaddingL;
+					if ($align == 'R') {
+						$this->x += $empty;
+					} elseif ($align == 'C') {
+						$this->x += ($empty / 2);
+					}
+					$this->debugLog("Setting x to: " . $this->x, "red");
 
 					// Paragraph INDENT
 					if (isset($this->blk[$this->blklvl]['text_indent']) && ($newblock) && ($blockstate == 1 || $blockstate == 3) && ($lineCount == 1) && (!$is_table) && ($blockdir != 'rtl') && ($align != 'C')) {
 						$ti = $this->ConvertSize($this->blk[$this->blklvl]['text_indent'], $this->blk[$this->blklvl]['inner_width'], $this->blk[$this->blklvl]['InlineProperties']['size'], false);  // mPDF 5.7.4
-                        // set X
+						// set X
 						$this->x += $ti;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 					}
 
 					// BIDI magic_reverse moved upwards from here
 
 					foreach ($chunkorder AS $aord => $k) { // mPDF 5.7
 						$chunk = $content[$aord];
-                        $this->debugLog("CHUNK: " . $chunk, "red");
+						$this->debugLog("CHUNK: " . $chunk, "red");
 						if (isset($this->objectbuffer[$k]) && $this->objectbuffer[$k]) {
 							$xadj = $this->x - $this->objectbuffer[$k]['OUTER-X'];
 							$this->objectbuffer[$k]['OUTER-X'] += $xadj;
@@ -8559,7 +8559,7 @@ class mPDF
 						}
 						if (!empty($this->spanborddet)) {
 							if (strpos($contentB[$k], 'L') !== false)
-                                // set x
+								// set x
 								$this->x += (isset($this->spanborddet['L']['w']) ? $this->spanborddet['L']['w'] : 0);
 							if (strpos($contentB[$k], 'L') === false)
 								$this->spanborddet['L']['s'] = $this->spanborddet['L']['w'] = 0;
@@ -8609,9 +8609,9 @@ class mPDF
 
 						if (!empty($this->spanborddet)) {
 							if (strpos($contentB[$k], 'R') !== false && $aord != $arraysize - 1)
-                                // set X
+								// set X
 								$this->x += $this->spanborddet['R']['w'];
-                                $this->debugLog("Setting x to: " . $this->x, "red");
+								$this->debugLog("Setting x to: " . $this->x, "red");
 						}
 						// *********** SPAN BACKGROUND COLOR OFF - RESET BLOCK BGCOLOR ***************** //
 						if (isset($spanfill) && $spanfill) {
@@ -8627,7 +8627,7 @@ class mPDF
 					}
 				} elseif ($table_draft) {
 					$this->y += $stackHeight;
-                    $this->debugLog("Setting y to: " . $this->y, "red");
+					$this->debugLog("Setting y to: " . $this->y, "red");
 				}
 
 				if (!$is_table) {
@@ -8733,7 +8733,7 @@ class mPDF
 				$currContent .= $c;
 			}
 		}
-    
+	
 		unset($content);
 		unset($contentB);
 	}
@@ -8990,9 +8990,9 @@ class mPDF
 			$changedpage = false;
 			$this->OldCol = $this->CurrCol;
 			//Avoid drawing out of the page.
-            $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+			$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 			if ($y + $h > $this->PageBreakTrigger and ! $this->InFooter and $this->AcceptPageBreak()) {
-                $this->debugLog("Adding Page Here", "yellow");
+				$this->debugLog("Adding Page Here", "yellow");
 				$this->AddPage($this->CurOrientation);
 				// Added to correct for OddEven Margins
 				$x = $x + $this->MarginCorrection;
@@ -9006,7 +9006,7 @@ class mPDF
 				$y = $this->y0;
 				$x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
 				$this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 			}
 			/* -- END COLUMNS -- */
 		} // end of IF constrain
@@ -9033,7 +9033,7 @@ class mPDF
 
 			// Avoid writing text on top of the image. // THIS WAS OUTSIDE THE if ($paint) bit!!!!!!!!!!!!!!!!
 			$this->y = $y + $h;
-            $this->debugLog("Setting y to: " . $this->y, "red");
+			$this->debugLog("Setting y to: " . $this->y, "red");
 		}
 
 		//Return width-height array
@@ -9334,7 +9334,7 @@ class mPDF
 		// Added collapsible to allow collapsible top-margin on new page
 		//Line feed; default value is last cell height
 		$this->x = $this->lMargin + $this->blk[$this->blklvl]['outer_left_margin'];
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		if ($collapsible && ($this->y == $this->tMargin) && (!$this->ColActive)) {
 			$h = 0;
 		}
@@ -9369,7 +9369,7 @@ class mPDF
 		if (!$this->ColActive && !$this->kwt) {
 			if ($move_y && !$this->ColActive) {
 				$this->y += $h;
-                $this->debugLog("Setting y to: " . $this->y, "red");
+				$this->debugLog("Setting y to: " . $this->y, "red");
 			}
 			return;
 		}
@@ -9382,14 +9382,14 @@ class mPDF
 			$last_x = 0;
 			$last_w = 0;
 			$last_fc = $this->FillColor;
-            $this->debugLog("X WAS: " . $this->x . "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "red");
-            $this->debugLog("Setting bak_x to: " . $this->x . "!!!!!!!!!!!!!!!!!!!!", "red");
+			$this->debugLog("X WAS: " . $this->x . "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "red");
+			$this->debugLog("Setting bak_x to: " . $this->x . "!!!!!!!!!!!!!!!!!!!!", "red");
 			$this->bak_x = $this->x;
 			$bak_h = $this->divheight;
 			$this->divheight = 0; // Temporarily turn off divheight - as Cell() uses it to check for PageBreak
 			for ($blvl = $firstblockfill; $blvl <= $level; $blvl++) {
 				$this->x = $this->lMargin + $this->blk[$blvl]['outer_left_margin'];
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				// mPDF 6
 				if ($this->blk[$blvl]['bgcolor']) {
 					$this->SetFColor($this->blk[$blvl]['bgcolorarray']);
@@ -9398,7 +9398,7 @@ class mPDF
 					$x = $this->x;
 					$this->Cell(($this->blk[$blvl]['width']), $h, '', '', 0, '', 1);
 					$this->x = $x;
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					$this->debugLog("Setting x to: " . $this->x, "red");
 					if (!$this->keep_block_together && !$this->writingHTMLheader && !$this->writingHTMLfooter) {
 						// $state = 0 normal; 1 top; 2 bottom; 3 top and bottom
 						if ($blvl == $this->blklvl) {
@@ -9418,14 +9418,14 @@ class mPDF
 				$this->SetFColor($bcor);
 			}
 //TODO: COME BACK HERE
-            $this->debugLog("X WAS: " . $this->x . "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "red");
+			$this->debugLog("X WAS: " . $this->x . "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "red");
 			$this->x = $this->bak_x;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 			$this->divheight = $bak_h;
 		}
 		if ($move_y) {
 			$this->y += $h;
-            $this->debugLog("Setting y to: " . $this->y, "red");
+			$this->debugLog("Setting y to: " . $this->y, "red");
 		}
 	}
 
@@ -9436,23 +9436,23 @@ class mPDF
 		//Set x position
 		if ($x >= 0) {
 			$this->x = $x;
-            $this->debugLog("Setting x to: " . $this->x, "red");
+			$this->debugLog("Setting x to: " . $this->x, "red");
 		} else {
 			$this->x = $this->w + $x;
-            $this->debugLog("Setting x to: " . $this->x, "red");
-        }
+			$this->debugLog("Setting x to: " . $this->x, "red");
+		}
 	}
 
 	function SetY($y)
 	{
 		//Set y position and reset x
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		if ($y >= 0)
 			$this->y = $y;
 		else
 			$this->y = $this->h + $y;
-        $this->debugLog("Setting y to: " . $this->y, "red");
+		$this->debugLog("Setting y to: " . $this->y, "red");
 	}
 
 	function SetXY($x, $y)
@@ -9670,9 +9670,9 @@ class mPDF
 	}
 
 	// *****************************************************************************
-	//                                                                             *
-	//                             Protected methods                               *
-	//                                                                             *
+	//																			 *
+	//							 Protected methods							   *
+	//																			 *
 	// *****************************************************************************
 	function _dochecks()
 	{
@@ -9727,9 +9727,9 @@ class mPDF
 				$this->pageoutput[$n] = array();
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->x = $this->lMargin;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->y = $this->margin_header;
-                $this->debugLog('Setting y to: ' . $this->y, "red");
+				$this->debugLog('Setting y to: ' . $this->y, "red");
 				$html = str_replace('{PAGENO}', $pnstr, $html);
 				$html = str_replace($this->aliasNbPgGp, $pntstr, $html); // {nbpg}
 				$html = str_replace($this->aliasNbPg, $nb, $html); // {nb}
@@ -9800,7 +9800,7 @@ class mPDF
 				$this->pageoutput[$n] = array();
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->x = $this->lMargin;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$top_y = $this->y = $this->h - $this->margin_footer;
 
 				// if bottom-margin==0, corrects to avoid division by zero
@@ -11208,47 +11208,47 @@ class mPDF
 		$m .= ' <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="3.1-701">' . "\n";
 		$m .= '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">' . "\n";
 		$m .= '   <rdf:Description rdf:about="uuid:' . $uuid . '" xmlns:pdf="http://ns.adobe.com/pdf/1.3/">' . "\n";
-		$m .= '    <pdf:Producer>' . $Producer . '</pdf:Producer>' . "\n";
+		$m .= '	<pdf:Producer>' . $Producer . '</pdf:Producer>' . "\n";
 		if (!empty($this->keywords)) {
-			$m .= '    <pdf:Keywords>' . $this->keywords . '</pdf:Keywords>' . "\n";
+			$m .= '	<pdf:Keywords>' . $this->keywords . '</pdf:Keywords>' . "\n";
 		}
 		$m .= '   </rdf:Description>' . "\n";
 
 		$m .= '   <rdf:Description rdf:about="uuid:' . $uuid . '" xmlns:xmp="http://ns.adobe.com/xap/1.0/">' . "\n";
-		$m .= '    <xmp:CreateDate>' . $CreationDate . '</xmp:CreateDate>' . "\n";
-		$m .= '    <xmp:ModifyDate>' . $CreationDate . '</xmp:ModifyDate>' . "\n";
-		$m .= '    <xmp:MetadataDate>' . $CreationDate . '</xmp:MetadataDate>' . "\n";
+		$m .= '	<xmp:CreateDate>' . $CreationDate . '</xmp:CreateDate>' . "\n";
+		$m .= '	<xmp:ModifyDate>' . $CreationDate . '</xmp:ModifyDate>' . "\n";
+		$m .= '	<xmp:MetadataDate>' . $CreationDate . '</xmp:MetadataDate>' . "\n";
 		if (!empty($this->creator)) {
-			$m .= '    <xmp:CreatorTool>' . $this->creator . '</xmp:CreatorTool>' . "\n";
+			$m .= '	<xmp:CreatorTool>' . $this->creator . '</xmp:CreatorTool>' . "\n";
 		}
 		$m .= '   </rdf:Description>' . "\n";
 
 		// DC elements
 		$m .= '   <rdf:Description rdf:about="uuid:' . $uuid . '" xmlns:dc="http://purl.org/dc/elements/1.1/">' . "\n";
-		$m .= '    <dc:format>application/pdf</dc:format>' . "\n";
+		$m .= '	<dc:format>application/pdf</dc:format>' . "\n";
 		if (!empty($this->title)) {
-			$m .= '    <dc:title>
+			$m .= '	<dc:title>
 	 <rdf:Alt>
 	  <rdf:li xml:lang="x-default">' . $this->title . '</rdf:li>
 	 </rdf:Alt>
 	</dc:title>' . "\n";
 		}
 		if (!empty($this->keywords)) {
-			$m .= '    <dc:subject>
+			$m .= '	<dc:subject>
 	 <rdf:Bag>
 	  <rdf:li>' . $this->keywords . '</rdf:li>
 	 </rdf:Bag>
 	</dc:subject>' . "\n";
 		}
 		if (!empty($this->subject)) {
-			$m .= '    <dc:description>
+			$m .= '	<dc:description>
 	 <rdf:Alt>
 	  <rdf:li xml:lang="x-default">' . $this->subject . '</rdf:li>
 	 </rdf:Alt>
 	</dc:description>' . "\n";
 		}
 		if (!empty($this->author)) {
-			$m .= '    <dc:creator>
+			$m .= '	<dc:creator>
 	 <rdf:Seq>
 	  <rdf:li>' . $this->author . '</rdf:li>
 	 </rdf:Seq>
@@ -11265,14 +11265,14 @@ class mPDF
 		// This bit is specific to PDFA-1b
 		elseif ($this->PDFA) {
 			$m .= '   <rdf:Description rdf:about="uuid:' . $uuid . '" xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/" >' . "\n";
-			$m .= '    <pdfaid:part>1</pdfaid:part>' . "\n";
-			$m .= '    <pdfaid:conformance>B</pdfaid:conformance>' . "\n";
-			$m .= '    <pdfaid:amd>2005</pdfaid:amd>' . "\n";
+			$m .= '	<pdfaid:part>1</pdfaid:part>' . "\n";
+			$m .= '	<pdfaid:conformance>B</pdfaid:conformance>' . "\n";
+			$m .= '	<pdfaid:amd>2005</pdfaid:amd>' . "\n";
 			$m .= '   </rdf:Description>' . "\n";
 		}
 
 		$m .= '   <rdf:Description rdf:about="uuid:' . $uuid . '" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/">' . "\n";
-		$m .= '    <xmpMM:DocumentID>uuid:' . $uuid . '</xmpMM:DocumentID>' . "\n";
+		$m .= '	<xmpMM:DocumentID>uuid:' . $uuid . '</xmpMM:DocumentID>' . "\n";
 		$m .= '   </rdf:Description>' . "\n";
 		$m .= '  </rdf:RDF>' . "\n";
 		$m .= ' </x:xmpmeta>' . "\n";
@@ -11774,9 +11774,9 @@ class mPDF
 		$this->y0 = $this->tMargin;
 
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$this->y = $this->tMargin;
-        $this->debugLog('Setting y to: ' . $this->y, "red");
+		$this->debugLog('Setting y to: ' . $this->y, "red");
 		$this->FontFamily = '';
 
 		// HEADERS AND FOOTERS	// mPDF 6
@@ -11866,9 +11866,9 @@ class mPDF
 		$this->y0 = $this->tMargin;
 
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$this->y = $this->tMargin;
-        $this->debugLog('Setting y to: ' . $this->y, "red");
+		$this->debugLog('Setting y to: ' . $this->y, "red");
 	}
 
 	// mPDF 6
@@ -13353,7 +13353,7 @@ class mPDF
 					'col' => $this->CurrCol, // Column when printed
 					'x' => $this->x, // x when printed
 					'y' => $this->y, // this->y when printed (after column break)
-					'h' => $h        // actual y at bottom when printed = y+h
+					'h' => $h		// actual y at bottom when printed = y+h
 				);
 			}
 			/* -- END COLUMNS -- */
@@ -14681,7 +14681,7 @@ class mPDF
 				if ($adv) {
 					if ($this->table_rotate) {
 						$this->y += ($adv);
-                        $this->debugLog('Setting y to: ' . $this->y, "red");
+						$this->debugLog('Setting y to: ' . $this->y, "red");
 					} else {
 						$this->DivLn($adv, $this->blklvl, true);
 					}
@@ -14708,7 +14708,7 @@ class mPDF
 							$bcor = $this->blk[$this->blklvl]['bgcolorarray'];
 							$this->SetFColor($bcor);
 							$this->x = $this->bak_x;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 						}
 					}
 				}
@@ -14719,7 +14719,7 @@ class mPDF
 					$colctr++;
 					$y = $tablehf['y'] - $topy;
 					$this->y = $y;
-                    $this->debugLog('Setting y to: ' . $this->y, "red");
+					$this->debugLog('Setting y to: ' . $this->y, "red");
 					//Set some cell values
 					$x = $tablehf['x'];
 					if (($this->mirrorMargins) && ($tablestartpage == 'ODD') && (($this->page) % 2 == 0)) { // EVEN
@@ -14780,7 +14780,7 @@ class mPDF
 					$this->cellLineStackingShift = $tablehf['cellLineStackingShift'];
 
 					$this->x = $x;
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					$this->debugLog("Setting x to: " . $this->x, "red");
 
 					if ($this->ColActive) {
 						if ($table['borders_separate']) {
@@ -14826,11 +14826,11 @@ class mPDF
 
 					if (!isset($va) || empty($va) || $va == 'M') {
 						$this->y += ($h - $mih) / 2;
-                        $this->debugLog('Setting y to: ' . $this->y, "red");
-                    } elseif (isset($va) && $va == 'B') {
+						$this->debugLog('Setting y to: ' . $this->y, "red");
+					} elseif (isset($va) && $va == 'B') {
 						$this->y += $h - $mih;
-                        $this->debugLog('Setting y to: ' . $this->y, "red");
-                    }
+						$this->debugLog('Setting y to: ' . $this->y, "red");
+					}
 
 
 					//TABLE ROW OR CELL FILL BGCOLOR
@@ -14986,31 +14986,31 @@ class mPDF
 
 							if (!isset($va) || $va == 'M') {
 								$this->y -= ($h - $mih) / 2; //Undo what was added earlier VERTICAL ALIGN
-                                $this->debugLog('Setting y to: ' . $this->y, "red");
+								$this->debugLog('Setting y to: ' . $this->y, "red");
 								if ($angle > 0) {
 									$this->y += (($h - $mih) / 2) + ($padding['T'] + $border_details['T']['w']) + ($mih - ($padding['T'] + $border_details['T']['w'] + $border_details['B']['w'] + $padding['B']));
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += (($h - $mih) / 2) + ($padding['T'] + $border_details['T']['w']);
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								}
 							} elseif (isset($va) && $va == 'B') {
 								$this->y -= $h - $mih; //Undo what was added earlier VERTICAL ALIGN
-                                $this->debugLog('Setting y to: ' . $this->y, "red");
+								$this->debugLog('Setting y to: ' . $this->y, "red");
 								if ($angle > 0) {
 									$this->y += $h - ($border_details['B']['w'] + $padding['B']);
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += $h - $mih + ($padding['T'] + $border_details['T']['w']);
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								}
 							} elseif (isset($va) && $va == 'T') {
 								if ($angle > 0) {
 									$this->y += $mih - ($border_details['B']['w'] + $padding['B']);
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += ($padding['T'] + $border_details['T']['w']);
-                                    $this->debugLog('Setting y to: ' . $this->y, "red");
+									$this->debugLog('Setting y to: ' . $this->y, "red");
 								}
 							}
 
@@ -15030,9 +15030,9 @@ class mPDF
 							$this->SetFont($s_f, $s_st, $s_fs, true, true);
 							$this->SetTColor(0);
 							$this->x = $opx;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 							$this->y = $opy;
-                            $this->debugLog('Setting y to: ' . $this->y, "red");
+							$this->debugLog('Setting y to: ' . $this->y, "red");
 						} else {
 							if ($table['borders_separate']) { // NB twice border width
 								$xadj = $border_details['L']['w'] + $padding['L'] + ($table['border_spacing_H'] / 2);
@@ -15047,8 +15047,8 @@ class mPDF
 							$this->divwidth = $w - ($wadj);
 							$this->x += $xadj;
 							$this->y += $yadj;
-                            $this->debugLog("Setting y to: " . $this->y, "red");
-                            $this->debugLog("Printing buffer here", "yellow");
+							$this->debugLog("Setting y to: " . $this->y, "red");
+							$this->debugLog("Printing buffer here", "yellow");
 							$this->printbuffer($textbuffer, '', true, false, $direction);
 						}
 					}
@@ -15171,7 +15171,7 @@ class mPDF
 					}
 				}// end column $content
 				$this->y = $y + $h; //Update y coordinate
-                $this->debugLog('Setting y to: ' . $this->y, "red");
+				$this->debugLog('Setting y to: ' . $this->y, "red");
 			}// end row $i
 			unset($table);
 			$this->colsums = array();
@@ -15312,7 +15312,7 @@ class mPDF
 	{
 		$save_state = $this->state;
 		if ($this->state == 0) {
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($this->CurOrientation);
 		}
 		$this->state = 2;
@@ -15321,7 +15321,7 @@ class mPDF
 		$save_x = $this->x;
 		$save_y = $this->y;
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$this->y = $this->margin_header;
 		$html = str_replace('{PAGENO}', $this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix, $html);
 		$html = str_replace($this->aliasNbPgGp, $this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $html);
@@ -15344,9 +15344,9 @@ class mPDF
 		$this->headerbuffer = '';
 		$this->pageBackgrounds = $savepb;
 		$this->x = $save_x;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$this->y = $save_y;
-        $this->debugLog("Setting y to: " . $this->y, "red");
+		$this->debugLog("Setting y to: " . $this->y, "red");
 		$this->state = $save_state;
 		if ($save_state == 0) {
 			unset($this->pages[1]);
@@ -15892,9 +15892,9 @@ class mPDF
 				$this->SetTColor($this->ConvertColor(0));
 				$this->SetFont('arial', '', 7.5, true, true);
 				$this->x = $this->page_box['outer_width_LR'] + 1.5;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->y = 1;
-                $this->debugLog("Setting y to: " . $this->y, "red");
+				$this->debugLog("Setting y to: " . $this->y, "red");
 				$this->Cell($headerpgwidth, $this->FontSize, $hd, 0, 0, 'L', 0, '', 0, 0, 0, 'M');
 				$this->SetFont($this->default_font, '', $this->original_default_font_size);
 			}
@@ -16264,7 +16264,7 @@ class mPDF
 			}
 			// Output any text left in buffer
 			if (count($this->textbuffer)) {
-                $this->debugLog("Printing buffer here", "yellow");
+				$this->debugLog("Printing buffer here", "yellow");
 				$this->printbuffer($this->textbuffer);
 			}
 			$this->textbuffer = array();
@@ -16277,7 +16277,7 @@ class mPDF
 			}
 			// Output any text left in buffer
 			if (count($this->textbuffer)) {
-                $this->debugLog("Printing buffer here", "yellow");
+				$this->debugLog("Printing buffer here", "yellow");
 				$this->printbuffer($this->textbuffer);
 			}
 			$this->bufferoutput = true;
@@ -16314,7 +16314,7 @@ class mPDF
 		$html = preg_replace('/<htmlpagefooter.*?<\/htmlpagefooter>/si', '', $html);
 
 		if ($this->state == 0 && $sub != 1 && $sub != 3 && $sub != 4) {
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($this->CurOrientation);
 		}
 
@@ -16801,7 +16801,7 @@ class mPDF
 
 			// Output any text left in buffer
 			if (count($this->textbuffer) && !$parseonly) {
-                $this->debugLog("Printing buffer here", "yellow");
+				$this->debugLog("Printing buffer here", "yellow");
 				$this->printbuffer($this->textbuffer);
 			}
 			if (!$parseonly)
@@ -16878,7 +16878,7 @@ class mPDF
 
 		$overflow = strtolower($overflow);
 		if ($this->state == 0) {
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($this->CurOrientation);
 		}
 		$save_y = $this->y;
@@ -17342,9 +17342,9 @@ class mPDF
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->pageoutput[$this->page] = array();
 				$this->x = $x;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->y = $y;
-                $this->debugLog("Setting y to: " . $this->y, "red");
+				$this->debugLog("Setting y to: " . $this->y, "red");
 				$this->HTMLheaderPageLinks = array();
 				$this->HTMLheaderPageAnnots = array();
 				$this->HTMLheaderPageForms = array();
@@ -17373,9 +17373,9 @@ class mPDF
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->pageoutput[$this->page] = array();
 				$this->x = $x;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->y = $y;
-                $this->debugLog("Setting y to: " . $this->y, "red");
+				$this->debugLog("Setting y to: " . $this->y, "red");
 				$this->HTMLheaderPageLinks = array();
 				$this->HTMLheaderPageAnnots = array();
 				$this->HTMLheaderPageForms = array();
@@ -17426,9 +17426,9 @@ class mPDF
 		$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 		$this->pageoutput[$this->page] = array();
 		$this->x = $x;
-        $this->debugLog("Setting x to: " . $this->x, "red");
+		$this->debugLog("Setting x to: " . $this->x, "red");
 		$this->y = $y;
-        $this->debugLog("Setting y to: " . $this->y, "red");
+		$this->debugLog("Setting y to: " . $this->y, "red");
 		$this->HTMLheaderPageLinks = array();
 		$this->HTMLheaderPageAnnots = array();
 		$this->HTMLheaderPageForms = array();
@@ -17456,9 +17456,9 @@ class mPDF
 				} // *PROGRESS-BAR*
 
 				$this->x = $x;
-                $this->debugLog("Setting x to: " . $this->x, "red");
+				$this->debugLog("Setting x to: " . $this->x, "red");
 				$this->y = $y;
-                $this->debugLog("Setting y to: " . $this->y, "red");
+				$this->debugLog("Setting y to: " . $this->y, "red");
 
 				if (($ratio / $target) > 1.5 || ($ratio / $target) < 0.6) {
 					$use_w += ($w / $this->incrementFPR1);
@@ -17739,8 +17739,8 @@ class mPDF
 		$blk['bgcolor'] = false;
 		$blk['page_break_after_avoid'] = false;
 		$blk['keep_block_together'] = false;
-        $blk['min_orphans'] = $this->minOrphanLines; // global defined in config.php
-        $blk['min_widows'] = $this->minWidowLines; // global defined in config.php
+		$blk['min_orphans'] = $this->minOrphanLines; // global defined in config.php
+		$blk['min_widows'] = $this->minWidowLines; // global defined in config.php
 		$blk['float'] = false;
 		$blk['line_height'] = '';
 		$blk['margin_collapse'] = false;
@@ -18261,7 +18261,7 @@ class mPDF
 		$this->ResetMargins();
 		$this->pageoutput[$this->page] = array();
 		$this->y = (($end * 1000) % 1000000) / 1000; // mod changes operands to integers before processing
-        $this->debugLog("Setting y to: " . $this->y, "red");
+		$this->debugLog("Setting y to: " . $this->y, "red");
 	}
 
 	// Added mPDF 3.0 Float DIV
@@ -18834,7 +18834,7 @@ class mPDF
 
 	function printbuffer($arrayaux, $blockstate = 0, $is_table = false, $table_draft = false, $cell_dir = '')
 	{
-        $this->debugLog("In printbuffer() function here", "yellow");
+		$this->debugLog("In printbuffer() function here", "yellow");
 		// $blockstate = 0;	// NO margins/padding
 		// $blockstate = 1;	// Top margins/padding only
 		// $blockstate = 2;	// Bottom margins/padding only
@@ -18896,7 +18896,7 @@ class mPDF
 		if (!$table_draft)
 			$this->SetFont($this->default_font, '', $this->default_font_size, true, true); // force output to page
 
-        $this->debugLog('newFlowingBlock starts here', "yellow"); 
+		$this->debugLog('newFlowingBlock starts here', "yellow"); 
 		$this->newFlowingBlock($this->divwidth, $this->divheight, $align, $is_table, $blockstate, true, $blockdir, $table_draft);
 
 		$array_size = count($arrayaux);
@@ -18974,46 +18974,46 @@ class mPDF
 			}
 		}
 
-        /**
-         * Determine if this block has multiple writes, if so
-         * process it with a clone object and determine
-         * if a page break will be required for and expecte
-         * orphans or widows
-         */
-        if ($array_size > 0) {
-            $this->debugLog("  Writes in this Block: $array_size");
-            $linesRequired = 1;
-            for ($i = 0; $i < $array_size; $i++) {
-                $vetor = isset($arrayaux[$i]) ? $arrayaux[$i] : NULL;
+		/**
+		 * Determine if this block has multiple writes, if so
+		 * process it with a clone object and determine
+		 * if a page break will be required for and expecte
+		 * orphans or widows
+		 */
+		if ($array_size > 0) {
+			$this->debugLog("  Writes in this Block: $array_size");
+			$linesRequired = 1;
+			for ($i = 0; $i < $array_size; $i++) {
+				$vetor = isset($arrayaux[$i]) ? $arrayaux[$i] : NULL;
 
-                //Ignore empty text and not carrying an internal link
-                if (empty($vetor[0]) && !($vetor[0] === '0') && empty($vetor[7])) {
-                    continue;
-                }
-                // get line estimates
-                $linesRequired += $this->EstimateFlowingBlockWriteLines($vetor[0], $vetor[18]);
-                $this->debugLog("\n\nvetor0: " . print_r($vetor[0], true) . "\n");
-            }
-            $this->debugLog("  Writes in this Block: $array_size, Lines in this Block: $linesRequired");
-            /**
-             * determine if our orphans and widows config should page break before 
-             * printing this block content
-             **/
-            $expectedWidowLines = $this->getExpectedBlockWidowCount($linesRequired);
-            $expectedOrphanLines = $this->getExpectedBlockOrphanCount($linesRequired);
+				//Ignore empty text and not carrying an internal link
+				if (empty($vetor[0]) && !($vetor[0] === '0') && empty($vetor[7])) {
+					continue;
+				}
+				// get line estimates
+				$linesRequired += $this->EstimateFlowingBlockWriteLines($vetor[0], $vetor[18]);
+				$this->debugLog("\n\nvetor0: " . print_r($vetor[0], true) . "\n");
+			}
+			$this->debugLog("  Writes in this Block: $array_size, Lines in this Block: $linesRequired");
+			/**
+			 * determine if our orphans and widows config should page break before 
+			 * printing this block content
+			 **/
+			$expectedWidowLines = $this->getExpectedBlockWidowCount($linesRequired);
+			$expectedOrphanLines = $this->getExpectedBlockOrphanCount($linesRequired);
 
-            // check for required col breaks first
-            if ($this->flowingBlockAttr['expect_col_change']) {
-                $this->debugLog("Attempting to add a COLUMN BREAK HERE", "red");
-                $this->addColBreaksForWidows($expectedWidowLines, true);
-                $this->addColBreaksForOrphans($expectedOrphanLines, true);
-            } else {
-                $this->debugLog("Attempting to add a PAGE BREAK HERE", "red");
-                $this->addPageBreaksForWidows($expectedWidowLines, true);
-                $this->addPageBreaksForOrphans($expectedOrphanLines, true);
-            }
-        }
-        
+			// check for required col breaks first
+			if ($this->flowingBlockAttr['expect_col_change']) {
+				$this->debugLog("Attempting to add a COLUMN BREAK HERE", "red");
+				$this->addColBreaksForWidows($expectedWidowLines, true);
+				$this->addColBreaksForOrphans($expectedOrphanLines, true);
+			} else {
+				$this->debugLog("Attempting to add a PAGE BREAK HERE", "red");
+				$this->addPageBreaksForWidows($expectedWidowLines, true);
+				$this->addPageBreaksForOrphans($expectedOrphanLines, true);
+			}
+		}
+		
 
 		for ($i = 0; $i < $array_size; $i++) {
 			// COLS
@@ -19034,7 +19034,7 @@ class mPDF
 					$this->finishFlowingBlock(true);
 				} // true = END of flowing block
 				continue;
-            }
+			}
 
 			//Activating buffer properties
 			if (isset($vetor[11]) && $vetor[11] != '') {   // Font Size
@@ -19134,7 +19134,7 @@ class mPDF
 					$this->internallink[$vetor[1]] = $this->AddLink();
 					$vetor[1] = $this->internallink[$vetor[1]];
 				}
-				$this->HREF = $vetor[1];     // HREF link style set here ******
+				$this->HREF = $vetor[1];	 // HREF link style set here ******
 			}
 
 			// SPECIAL CONTENT - IMAGES & FORM OBJECTS
@@ -19150,7 +19150,7 @@ class mPDF
 
 						if ($table_draft) {
 							$this->y += $this->table[($level + 1)][$objattr['nestedcontent']]['h']; // nested table height
-                            $this->debugLog("Setting y to: " . $this->y, "red");
+							$this->debugLog("Setting y to: " . $this->y, "red");
 							$this->finishFlowingBlock(false, 'nestedtable');
 						} else {
 
@@ -19187,16 +19187,16 @@ class mPDF
 								$ncx += $innerw - $ntw;
 							}
 							$this->x = $ncx;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 
 							$this->_tableWrite($this->table[($level + 1)][$objattr['nestedcontent']]);
 							$this->cellBorderBuffer = $save_buffer;
 							$this->x = $this->bak_x;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 							$this->divwidth = $save_dw;
 						}
 
-                        $this->debugLog('newFlowingBlock starts here', "yellow"); 
+						$this->debugLog('newFlowingBlock starts here', "yellow"); 
 						$this->newFlowingBlock($this->divwidth, $this->divheight, $align, $is_table, $blockstate, false, $blockdir, $table_draft);
 					}
 				} else {
@@ -19227,7 +19227,7 @@ class mPDF
 					$this->OldCol = $this->CurrCol;
 					if (($skipln == 1 || $skipln == -2) && !isset($objattr['float'])) {
 						$this->finishFlowingBlock(false, $objattr['type']);
-                        $this->debugLog('newFlowingBlock starts here', "yellow"); 
+						$this->debugLog('newFlowingBlock starts here', "yellow"); 
 						$this->newFlowingBlock($this->divwidth, $this->divheight, $align, $is_table, $blockstate, false, $blockdir, $table_draft);
 					}
 
@@ -19240,9 +19240,9 @@ class mPDF
 						}
 
 						// the previous lines can already have triggered page break or column change
-                        $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+						$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 						if (!$changedcol && $skipln < 0 && $this->AcceptPageBreak(false) && $thispage == $oldpage) {
-                            $this->debugLog("Adding Page Here", "yellow");
+							$this->debugLog("Adding Page Here", "yellow");
 							$this->AddPage($this->CurOrientation);
 
 							// Added to correct Images already set on line before page advanced
@@ -19270,11 +19270,11 @@ class mPDF
 							$this->oldy = $this->tMargin - $paint_ht_corr;
 						}
 						$this->x = $this->bak_x;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 						/* -- COLUMNS -- */
 						// COLS
-                        // OR COLUMN CHANGE
-                        //
+						// OR COLUMN CHANGE
+						//
 						if ($this->CurrCol != $this->OldCol) {
 							if ($this->directionality == 'rtl') { // *OTL*
 								$this->bak_x -= ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap); // *OTL*
@@ -19283,7 +19283,7 @@ class mPDF
 								$this->bak_x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
 							} // *OTL*
 							$this->x = $this->bak_x;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 							$this->OldCol = $this->CurrCol;
 							$y = $this->y0 - $paint_ht_corr;
 							$this->oldy = $this->y0 - $paint_ht_corr;
@@ -19449,7 +19449,7 @@ class mPDF
 						$this->oldy = $this->tMargin - $paint_ht_corr;
 					}
 					$this->x = $this->bak_x;
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					$this->debugLog("Setting x to: " . $this->x, "red");
 					/* -- COLUMNS -- */
 					// COLS
 					// OR COLUMN CHANGE
@@ -19461,13 +19461,13 @@ class mPDF
 							$this->bak_x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
 						} // *OTL*
 						$this->x = $this->bak_x;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 						$this->OldCol = $this->CurrCol;
 						$y = $this->y0 - $paint_ht_corr;
 						$this->oldy = $this->y0 - $paint_ht_corr;
 					}
 					/* -- END COLUMNS -- */
-                    $this->debugLog('newFlowingBlock starts here', "yellow"); 
+					$this->debugLog('newFlowingBlock starts here', "yellow"); 
 					$this->newFlowingBlock($this->divwidth, $this->divheight, $align, $is_table, $blockstate, false, $blockdir, $table_draft);
 				} else {
 					$this->WriteFlowingBlock($vetor[0], $vetor[18]);  // mPDF 5.7.1
@@ -19476,7 +19476,7 @@ class mPDF
 						if (($this->page - $oldpage) % 2 == 1) {
 							$this->bak_x += $this->MarginCorrection;
 							$this->x = $this->bak_x;
-                            $this->debugLog("Setting x to: " . $this->x, "red");
+							$this->debugLog("Setting x to: " . $this->x, "red");
 						}
 						$oldpage = $this->page;
 						$y = $this->tMargin - $paint_ht_corr;
@@ -19493,7 +19493,7 @@ class mPDF
 							$this->bak_x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
 						} // *OTL*
 						$this->x = $this->bak_x;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 						$this->OldCol = $this->CurrCol;
 						$y = $this->y0 - $paint_ht_corr;
 						$this->oldy = $this->y0 - $paint_ht_corr;
@@ -19511,7 +19511,7 @@ class mPDF
 					if (($this->page - $oldpage) % 2 == 1) {
 						$this->bak_x += $this->MarginCorrection;
 						$this->x = $this->bak_x;
-                        $this->debugLog("Setting x to: " . $this->x, "red");
+						$this->debugLog("Setting x to: " . $this->x, "red");
 					}
 					$oldpage = $this->page;
 					$y = $this->tMargin - $paint_ht_corr;
@@ -19529,9 +19529,9 @@ class mPDF
 						$this->bak_x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
 					} // *OTL*
 					$this->x = $this->bak_x;
-                    $this->debugLog("Setting x to: " . $this->x, "red");
+					$this->debugLog("Setting x to: " . $this->x, "red");
 					$this->OldCol = $this->CurrCol;
-                    // TODO: I DONT THINK $y IS EVER ACTUALLY USED, remove it?
+					// TODO: I DONT THINK $y IS EVER ACTUALLY USED, remove it?
 					$y = $this->y0 - $paint_ht_corr;
 					$this->oldy = $this->y0 - $paint_ht_corr;
 				}
@@ -19580,19 +19580,19 @@ class mPDF
 
 		$this->Reset(); // mPDF 6
 		// PAINT DIV BORDER	// DISABLED IN COLUMNS AS DOESN'T WORK WHEN BROKEN ACROSS COLS??
-        if (!$this->ColActive) {
-            if ((isset($this->blk[$this->blklvl]['border']) || isset($this->blk[$this->blklvl]['bgcolor']) || isset($this->blk[$this->blklvl]['box_shadow'])) && $blockstate && ($this->y != $this->oldy)) {
-                $bottom_y = $this->y; // Does not include Bottom Margin
-                if (isset($this->blk[$this->blklvl]['startpage']) && $this->blk[$this->blklvl]['startpage'] != $this->page && $blockstate != 1) {
-                    $this->PaintDivBB('pagetop', $blockstate);
-                } elseif ($blockstate != 1) {
-                    $this->PaintDivBB('', $blockstate);
-                }
-                $this->y = $bottom_y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
-                $this->x = $this->bak_x;
-                $this->debugLog("Setting x to: ". $this->x, "red");
-            }
+		if (!$this->ColActive) {
+			if ((isset($this->blk[$this->blklvl]['border']) || isset($this->blk[$this->blklvl]['bgcolor']) || isset($this->blk[$this->blklvl]['box_shadow'])) && $blockstate && ($this->y != $this->oldy)) {
+				$bottom_y = $this->y; // Does not include Bottom Margin
+				if (isset($this->blk[$this->blklvl]['startpage']) && $this->blk[$this->blklvl]['startpage'] != $this->page && $blockstate != 1) {
+					$this->PaintDivBB('pagetop', $blockstate);
+				} elseif ($blockstate != 1) {
+					$this->PaintDivBB('', $blockstate);
+				}
+				$this->y = $bottom_y;
+				$this->debugLog("Setting y to: ". $this->y, "red");
+				$this->x = $this->bak_x;
+				$this->debugLog("Setting x to: ". $this->x, "red");
+			}
 		}
 
 		// Reset Font
@@ -19600,9 +19600,9 @@ class mPDF
 		if ($table_draft) {
 			$ch = $this->y - $this->bak_y;
 			$this->y = $this->bak_y;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			$this->x = $this->bak_x;
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			return $ch;
 		}
 	}
@@ -19829,9 +19829,9 @@ class mPDF
 				$save_currentfontsize = $this->FontSizePt;
 				$save_currentfontstyle = $this->FontStyle;
 				$this->y = $y0 - $this->FontSize / 2 + $this->blk[$blvl]['border_top']['w'] / 2;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->x = $x0 + $this->blk[$blvl]['padding_left'] + $this->blk[$blvl]['border_left']['w'];
-                $this->debugLog("Setting x to: ". $this->x, "red");
+				$this->debugLog("Setting x to: ". $this->x, "red");
 
 				// Set the distance from the border line to the text ? make configurable variable
 				$gap = 0.2 * $this->FontSize;
@@ -19842,9 +19842,9 @@ class mPDF
 				$this->Cell($stringWidth, $this->FontSize, $txt, '', 0, 'C', $fill, '', 0, 0, 0, 'M', $fill, false, $legend[18], $legend[8]);
 				// Reset
 				$this->x = $save_x;
-                $this->debugLog("Setting x to: ". $this->x, "red");
+				$this->debugLog("Setting x to: ". $this->x, "red");
 				$this->y = $save_y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->SetFont($save_currentfontfamily, $save_currentfontstyle, $save_currentfontsize);
 				$this->SetTColor($this->ConvertColor(0));
 			}
@@ -20139,7 +20139,7 @@ class mPDF
 
 		$this->SetDash();
 		$this->y = $save_y;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 
 
 		// BACKGROUNDS are disabled in columns/kbt/headers - messes up the repositioning in printcolumnbuffer
@@ -20374,7 +20374,7 @@ class mPDF
 				$p1x = $x00 + $w00 - $bl;  // control points only matches p3 preceding
 				$p1y = $y00 + $h00 - $d1 - $brbgBR_V;
 				$p1c2y = $p1y + ($d2 + $brbgBR_V) * $mag;
-				$p2x = $x00 + $w00;     // control point only matches p4 preceding
+				$p2x = $x00 + $w00;	 // control point only matches p4 preceding
 				$p2y = $y00 + $h00 - $d1 - $brbgBR_V;
 				$p2c2y = $p2y + ($d1 + $brbgBR_V) * $mag;
 				$p3x = $x00 + $w00 - $d1 - $brbgBR_H;
@@ -20763,8 +20763,8 @@ class mPDF
 		$save_y = $this->y;
 
 		$w = $this->blk[$blvl]['width'];
-		$x0 = $this->x;    // left
-		$y0 = $this->y;    // top
+		$x0 = $this->x;	// left
+		$y0 = $this->y;	// top
 		$x1 = $this->x + $w;   // bottom
 		$y1 = $this->y + $h;   // bottom
 
@@ -20773,7 +20773,7 @@ class mPDF
 			if (isset($tbd['s']) && $tbd['s']) {
 				$this->_setBorderLine($tbd);
 				$this->y = $y0 + ($tbd['w'] / 2);
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				if ($tbd['style'] == 'dotted' || $tbd['style'] == 'dashed') {
 					$this->_setDashBorder($tbd['style'], '', $continuingpage, 'T');
 					$this->Line($x0 + ($tbd['w'] / 2), $this->y, $x0 + $w - ($tbd['w'] / 2), $this->y);
@@ -20783,7 +20783,7 @@ class mPDF
 					$this->Line($x0, $this->y, $x0 + $w, $this->y);
 				}
 				$this->y += $tbd['w'];
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				// Reset Corners and Dash off
 				$this->SetLineJoin(2);
 				$this->SetLineCap(2);
@@ -20796,18 +20796,18 @@ class mPDF
 				$this->_setBorderLine($tbd);
 				if ($tbd['style'] == 'dotted' || $tbd['style'] == 'dashed') {
 					$this->y = $y0 + ($tbd['w'] / 2);
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 					$this->_setDashBorder($tbd['style'], '', $continuingpage, 'L');
 					$this->Line($x0 + ($tbd['w'] / 2), $this->y, $x0 + ($tbd['w'] / 2), $y0 + $h - ($tbd['w'] / 2));
 				} else {
 					$this->y = $y0;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 					$this->SetLineJoin(0);
 					$this->SetLineCap(0);
 					$this->Line($x0 + ($tbd['w'] / 2), $this->y, $x0 + ($tbd['w'] / 2), $y0 + $h);
 				}
 				$this->y += $tbd['w'];
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				// Reset Corners and Dash off
 				$this->SetLineJoin(2);
 				$this->SetLineCap(2);
@@ -20820,18 +20820,18 @@ class mPDF
 				$this->_setBorderLine($tbd);
 				if ($tbd['style'] == 'dotted' || $tbd['style'] == 'dashed') {
 					$this->y = $y0 + ($tbd['w'] / 2);
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 					$this->_setDashBorder($tbd['style'], '', $continuingpage, 'R');
 					$this->Line($x0 + $w - ($tbd['w'] / 2), $this->y, $x0 + $w - ($tbd['w'] / 2), $y0 + $h - ($tbd['w'] / 2));
 				} else {
 					$this->y = $y0;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 					$this->SetLineJoin(0);
 					$this->SetLineCap(0);
 					$this->Line($x0 + $w - ($tbd['w'] / 2), $this->y, $x0 + $w - ($tbd['w'] / 2), $y0 + $h);
 				}
 				$this->y += $tbd['w'];
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				// Reset Corners and Dash off
 				$this->SetLineJoin(2);
 				$this->SetLineCap(2);
@@ -20843,7 +20843,7 @@ class mPDF
 			if (isset($tbd['s']) && $tbd['s']) {
 				$this->_setBorderLine($tbd);
 				$this->y = $y0 + $h - ($tbd['w'] / 2);
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				if ($tbd['style'] == 'dotted' || $tbd['style'] == 'dashed') {
 					$this->_setDashBorder($tbd['style'], '', $continuingpage, 'B');
 					$this->Line($x0 + ($tbd['w'] / 2), $this->y, $x0 + $w - ($tbd['w'] / 2), $this->y);
@@ -20853,7 +20853,7 @@ class mPDF
 					$this->Line($x0, $this->y, $x0 + $w, $this->y);
 				}
 				$this->y += $tbd['w'];
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				// Reset Corners and Dash off
 				$this->SetLineJoin(2);
 				$this->SetLineCap(2);
@@ -20862,7 +20862,7 @@ class mPDF
 		}
 		$this->SetDash();
 		$this->y = $save_y;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 	}
 
 	function PaintImgBorder($objattr, $is_table)
@@ -23265,7 +23265,7 @@ class mPDF
 							$this->cellLineStackingStrategy = $c['cellLineStackingStrategy'];
 							$this->cellLineStackingShift = $c['cellLineStackingShift'];
 							$this->divwidth = $cw - $extraWLR;
-                            $this->debugLog("Printing buffer here", "yellow");
+							$this->debugLog("Printing buffer here", "yellow");
 							$tempch = $this->printbuffer($c['textbuffer'], '', true, true);
 						} else {
 							$tempch = 0;
@@ -24662,7 +24662,7 @@ class mPDF
 					$this->DivLn($table['margin']['T'], $this->blklvl, true, 1);  // collapsible
 				} else {
 					$this->y += ($table['margin']['T']);
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 				}
 			}
 			// Advance down page by half width of top border
@@ -24679,13 +24679,13 @@ class mPDF
 				$this->DivLn($adv);
 			} else {
 				$this->y += $adv;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			}
 		}
 
 		if ($level == 1) {
 			$this->x = $this->lMargin + $this->blk[$this->blklvl]['outer_left_margin'] + $this->blk[$this->blklvl]['padding_left'] + $this->blk[$this->blklvl]['border_left']['w'];
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			$x0 = $this->x;
 			$y0 = $this->y;
 			$right = $x0 + $this->blk[$this->blklvl]['inner_width'];
@@ -24923,7 +24923,7 @@ class mPDF
 
 							if (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && $i > 0) {
 								$this->y = $y;
-                                $this->debugLog("Setting y to: ". $this->y, "red");
+								$this->debugLog("Setting y to: ". $this->y, "red");
 								$ya = $this->y;
 								$this->TableHeaderFooter($tablefooter, $tablestartpage, $tablestartcolumn, 'F', $level, $firstSpread, $finalSpread);
 								if ($this->table_rotate) {
@@ -24935,11 +24935,11 @@ class mPDF
 							$returny += $y;
 
 							$this->OldCol = $this->CurrCol;
-                            $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+							$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
 							if ($this->AcceptPageBreak()) {
 								$newpagestarted = true;
 								$this->y = $y + $y0;
-                                $this->debugLog("Setting y to: ". $this->y, "red");
+								$this->debugLog("Setting y to: ". $this->y, "red");
 
 								// Move down to account for border-spacing or
 								// extra half border width in case page breaks in middle
@@ -24991,7 +24991,7 @@ class mPDF
 										$adv = $maxbwbottom / 2;
 									}
 									$this->y += $adv;
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 
 								// Rotated table split over pages - needs this->y for borders/backgrounds
@@ -25140,7 +25140,7 @@ class mPDF
 									}
 									return array(false, $startrow, $startcol, $splitpg, $returny, $y0);
 								}
-                                $this->debugLog("Adding Page Here", "yellow");
+								$this->debugLog("Adding Page Here", "yellow");
 								$this->AddPage($this->CurOrientation);
 
 								$this->_out('___TABLE___BACKGROUNDS' . $this->uniqstr);
@@ -25194,7 +25194,7 @@ class mPDF
 										$adv = $maxbwtop / 2;
 									}
 									$this->y += $adv;
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 
 
@@ -25233,7 +25233,7 @@ class mPDF
 									if ($adv) {
 										if ($this->table_rotate) {
 											$this->y += ($adv);
-                                            $this->debugLog("Setting y to: ". $this->y, "red");
+											$this->debugLog("Setting y to: ". $this->y, "red");
 										} else {
 											$this->DivLn($adv, $this->blklvl, true);
 										}
@@ -25260,9 +25260,9 @@ class mPDF
 								$outerfilled = 0;
 								if ($this->CurrCol != 0 && ($this->keepColumns && $this->ColActive) && !empty($tableheader) && $i > 0) {
 									$this->x = $x;
-                                    $this->debugLog("Setting x to: ". $this->x, "red");
+									$this->debugLog("Setting x to: ". $this->x, "red");
 									$this->y = $y;
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 									$this->TableHeaderFooter($tableheader, $tablestartpage, $tablestartcolumn, 'H', $level);
 									$y0 = $y = $this->y;
 								}
@@ -25273,9 +25273,9 @@ class mPDF
 					}
 
 					$this->x = $x;
-                    $this->debugLog("Setting x to: ". $this->x, "red");
+					$this->debugLog("Setting x to: ". $this->x, "red");
 					$this->y = $y;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
+					$this->debugLog("Setting y to: ". $this->y, "red");
 
 					if ($this->kwt_saved && $level == 1) {
 						$this->printkwtbuffer();
@@ -25288,9 +25288,9 @@ class mPDF
 
 					// Set the Page & Column where table actually starts
 					if ($i == 0 && $j == 0 && $level == 1) {
-						if (($this->mirrorMargins) && (($this->page) % 2 == 0)) {    // EVEN
+						if (($this->mirrorMargins) && (($this->page) % 2 == 0)) {	// EVEN
 							$tablestartpage = 'EVEN';
-						} elseif (($this->mirrorMargins) && (($this->page) % 2 == 1)) {    // ODD
+						} elseif (($this->mirrorMargins) && (($this->page) % 2 == 1)) {	// ODD
 							$tablestartpage = 'ODD';
 						} else {
 							$tablestartpage = '';
@@ -25330,7 +25330,7 @@ class mPDF
 									if ($outerfilled > $this->y) {
 										$divh = ($this->y + $divh) - $outerfilled;
 										$this->y = $outerfilled;
-                                        $this->debugLog("Setting y to: ". $this->y, "red");
+										$this->debugLog("Setting y to: ". $this->y, "red");
 									}
 
 									$this->DivLn($divh, -3, false);
@@ -25340,9 +25340,9 @@ class mPDF
 									if ($bcor)
 										$this->SetFColor($bcor);
 									$this->x = $this->bak_x;
-                                    $this->debugLog("Setting x to: ". $this->x, "red");
+									$this->debugLog("Setting x to: ". $this->x, "red");
 									$this->y = $this->bak_y;
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 							}
 						}
@@ -25607,11 +25607,11 @@ class mPDF
 					}
 					if (!isset($cell['va']) || $cell['va'] == 'M') {
 						$this->y += ($h - $cell['mih']) / 2;
-                        $this->debugLog("Setting y to: ". $this->y, "red");
+						$this->debugLog("Setting y to: ". $this->y, "red");
 					} elseif (isset($cell['va']) && $cell['va'] == 'B') {
 						$this->y += $h - $cell['mih'];
-                        $this->debugLog("Setting y to: ". $this->y, "red");
-                    }
+						$this->debugLog("Setting y to: ". $this->y, "red");
+					}
 
 					// NESTED CONTENT
 					// TEXT (and nested tables)
@@ -25684,31 +25684,31 @@ class mPDF
 							$str = rtrim($str);
 							if (!isset($cell['va']) || $cell['va'] == 'M') {
 								$this->y -= ($h - $cell['mih']) / 2; //Undo what was added earlier VERTICAL ALIGN
-                                $this->debugLog("Setting y to: ". $this->y, "red");
+								$this->debugLog("Setting y to: ". $this->y, "red");
 								if ($angle > 0) {
 									$this->y += (($h - $cell['mih']) / 2) + $cell['padding']['T'] + ($cell['mih'] - ($cell['padding']['T'] + $cell['padding']['B']));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += (($h - $cell['mih']) / 2) + ($cell['padding']['T'] + ($table['border_spacing_V'] / 2));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 							} elseif (isset($cell['va']) && $cell['va'] == 'B') {
 								$this->y -= $h - $cell['mih']; //Undo what was added earlier VERTICAL ALIGN
-                                $this->debugLog("Setting y to: ". $this->y, "red");
+								$this->debugLog("Setting y to: ". $this->y, "red");
 								if ($angle > 0) {
 									$this->y += $h - ($cell['padding']['B'] + ($table['border_spacing_V'] / 2));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += $h - $cell['mih'] + ($cell['padding']['T'] + ($table['border_spacing_V'] / 2));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 							} elseif (isset($cell['va']) && $cell['va'] == 'T') {
 								if ($angle > 0) {
 									$this->y += $cell['mih'] - ($cell['padding']['B'] + ($table['border_spacing_V'] / 2));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								} elseif ($angle < 0) {
 									$this->y += ($cell['padding']['T'] + ($table['border_spacing_V'] / 2));
-                                    $this->debugLog("Setting y to: ". $this->y, "red");
+									$this->debugLog("Setting y to: ". $this->y, "red");
 								}
 							}
 							$this->Rotate($angle, $this->x, $this->y);
@@ -25727,7 +25727,7 @@ class mPDF
 							$this->SetFont($s_f, $s_st, $s_fs, true, true);
 							$this->SetTColor(0);
 							$this->x = $opx;
-                            $this->debugLog("Setting x to: ". $this->x, "red");
+							$this->debugLog("Setting x to: ". $this->x, "red");
 						} else {
 
 							if (!$this->simpleTables) {
@@ -25784,12 +25784,12 @@ class mPDF
 							}
 							$this->x += $xadj;
 							$this->y += $yadj;
-                            $this->debugLog("Setting y to: ". $this->y, "red");
-                            $this->debugLog("Printing buffer here", "yellow");
+							$this->debugLog("Setting y to: ". $this->y, "red");
+							$this->debugLog("Printing buffer here", "yellow");
 							$this->printbuffer($cell['textbuffer'], '', true, false, $cell['direction']);
 						}
 						$this->y = $opy;
-                        $this->debugLog("Setting y to: ". $this->y, "red");
+						$this->debugLog("Setting y to: ". $this->y, "red");
 					}
 
 					/* -- BACKGROUNDS -- */
@@ -25930,7 +25930,7 @@ class mPDF
 
 			if ($i == $numrows - 1) {
 				$this->y = $y + $h;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			} //last row jump (update this->y position)
 			if ($this->table_rotate && $level == 1) {
 				$this->tbrot_h += $h;
@@ -25954,10 +25954,10 @@ class mPDF
 		// Advance down page by half width of bottom border
 		if ($table['borders_separate']) {
 			$this->y += $table['padding']['B'] + $table['border_details']['B']['w'] + $table['border_spacing_V'] / 2;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 		} else {
 			$this->y += $table['max_cell_border_width']['B'] / 2;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 		}
 
 		if ($table['borders_separate'] && $level == 1) {
@@ -26088,7 +26088,7 @@ class mPDF
 				$this->DivLn($table['margin']['B'], $this->blklvl, true);  // collapsible
 			} else {
 				$this->y += ($table['margin']['B']);
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			}
 		}
 
@@ -27273,7 +27273,7 @@ class mPDF
 		} // mPDF 6
 		//Start a new page
 		if ($this->state == 0)
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage();
 		if ($this->y == $this->tMargin && (!$this->mirrorMargins || ($this->mirrorMargins && $this->page % 2 == 1))) {
 			// Don't add a page
@@ -27285,7 +27285,7 @@ class mPDF
 			}
 			$this->PageNumSubstitutions[] = array('from' => $this->page, 'reset' => $resetpagenum, 'type' => $pagenumstyle, 'suppress' => $suppress);
 		} else {
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage($orientation, 'NEXT-ODD', $resetpagenum, $pagenumstyle, $suppress, $mgl, $mgr, $mgt, $mgb, $mgh, $mgf, $ohname, $ehname, $ofname, $efname, $ohvalue, $ehvalue, $ofvalue, $efvalue, $pagesel, $sheetsize);
 		}
 		$this->tocontents->TOCpagebreak($tocfont, $tocfontsize, $tocindent, $TOCusePaging, $TOCuseLinking, $toc_orientation, $toc_mgl, $toc_mgr, $toc_mgt, $toc_mgb, $toc_mgh, $toc_mgf, $toc_ohname, $toc_ehname, $toc_ofname, $toc_efname, $toc_ohvalue, $toc_ehvalue, $toc_ofvalue, $toc_efvalue, $toc_preHTML, $toc_postHTML, $toc_bookmarkText, $resetpagenum, $pagenumstyle, $suppress, $orientation, $mgl, $mgr, $mgt, $mgb, $mgh, $mgf, $ohname, $ehname, $ofname, $efname, $ohvalue, $ehvalue, $ofvalue, $efvalue, $toc_id, $pagesel, $toc_pagesel, $sheetsize, $toc_sheetsize, $tocoutdent);
@@ -27337,7 +27337,7 @@ class mPDF
 		}
 		/* -- END TABLES -- */ elseif ($this->ColActive) {  // *COLUMNS*
 			$this->col_toc[] = $btoc; // *COLUMNS*
-		}      // *COLUMNS*
+		}	  // *COLUMNS*
 		else {
 			$this->tocontents->_toc[] = $btoc;
 		}
@@ -28045,12 +28045,12 @@ class mPDF
 
 	/* -- END INDEX -- */
 
-    /*
-    * TODO: It is deceptive that AcceptPageBreak, which returns a bool
-    * actually increments the current column when a page break is not
-    * appropriate.  This should be broken out into its own function and
-    * called separately if AcceptPageBreak returns false.
-    */
+	/*
+	* TODO: It is deceptive that AcceptPageBreak, which returns a bool
+	* actually increments the current column when a page break is not
+	* appropriate.  This should be broken out into its own function and
+	* called separately if AcceptPageBreak returns false.
+	*/
 	function AcceptPageBreak($updateColumn = true)
 	{
 		if (count($this->cellBorderBuffer)) {
@@ -28059,39 +28059,39 @@ class mPDF
 		/* -- COLUMNS -- */
 		if ($this->ColActive == 1) {
 			if ($this->CurrCol < $this->NbCol - 1) {
-                if ($updateColumn) {
-                    //Go to the next column
-                    // TODO: last column before broken page is here
-                    $this->debugLog("Going to new columns here, currently at " . $this->CurrCol . " before change", "yellow");
-                    $this->CurrCol++;
-                    $this->SetCol($this->CurrCol);
-                    $this->y = $this->y0;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
-                    $this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
-                    // DIRECTIONALITY RTL
-                    if ($this->directionality == 'rtl') {
-                        $this->ChangeColumn = -($this->ChangeColumn);
-                    }
-                    //Stay on the page
-                }
+				if ($updateColumn) {
+					//Go to the next column
+					// TODO: last column before broken page is here
+					$this->debugLog("Going to new columns here, currently at " . $this->CurrCol . " before change", "yellow");
+					$this->CurrCol++;
+					$this->SetCol($this->CurrCol);
+					$this->y = $this->y0;
+					$this->debugLog("Setting y to: ". $this->y, "red");
+					$this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
+					// DIRECTIONALITY RTL
+					if ($this->directionality == 'rtl') {
+						$this->ChangeColumn = -($this->ChangeColumn);
+					}
+					//Stay on the page
+				}
 				return false;
 			} else {
-                if ($updateColumn) {
-                    //Go back to the first column - NEW PAGE
-                    $this->debugLog("Going to FIRST columns here", "yellow");
-                    if (count($this->columnbuffer)) {
-                        $this->printcolumnbuffer();
-                    }
-                    $this->SetCol(0);
-                    $this->y0 = $this->tMargin;
-                    $this->debugLog("Setting y to: ". $this->y, "red");
-                    $this->ChangeColumn = -($this->NbCol - 1);
-                    // DIRECTIONALITY RTL
-                    if ($this->directionality == 'rtl') {
-                        $this->ChangeColumn = -($this->ChangeColumn);
-                    } // *OTL*
-                    //Page break
-                }
+				if ($updateColumn) {
+					//Go back to the first column - NEW PAGE
+					$this->debugLog("Going to FIRST columns here", "yellow");
+					if (count($this->columnbuffer)) {
+						$this->printcolumnbuffer();
+					}
+					$this->SetCol(0);
+					$this->y0 = $this->tMargin;
+					$this->debugLog("Setting y to: ". $this->y, "red");
+					$this->ChangeColumn = -($this->NbCol - 1);
+					// DIRECTIONALITY RTL
+					if ($this->directionality == 'rtl') {
+						$this->ChangeColumn = -($this->ChangeColumn);
+					} // *OTL*
+					//Page break
+				}
 				return true;
 			}
 		}
@@ -28190,7 +28190,7 @@ class mPDF
 			$this->y0 = $this->y;
 		}
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 	}
 
 	function SetCol($CurrCol)
@@ -28198,10 +28198,10 @@ class mPDF
 		// Used internally to set column by number: 0 is 1st column
 		//Set position on a column
 		$this->CurrCol = $CurrCol;
-        // unset OldCol since this is the  first column
-        if ($CurrCol == 0) {
-            $this->OldCol = null;
-        }
+		// unset OldCol since this is the  first column
+		if ($CurrCol == 0) {
+			$this->OldCol = null;
+		}
 		$x = $this->ColL[$CurrCol];
 		$xR = $this->ColR[$CurrCol]; // NB This is not R margin -> R pos
 		if (($this->mirrorMargins) && (($this->page) % 2 == 0)) { // EVEN
@@ -28225,7 +28225,7 @@ class mPDF
 				$this->CurrCol++;
 				$this->SetCol($this->CurrCol);
 				$this->y = $this->y0;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 				$this->ChangeColumn = 1;
 				// DIRECTIONALITY RTL
 				if ($this->directionality == 'rtl') {
@@ -28238,7 +28238,7 @@ class mPDF
 				if (count($this->columnbuffer)) {
 					$this->printcolumnbuffer();
 				}
-                $this->debugLog("Adding Page Here", "yellow");
+				$this->debugLog("Adding Page Here", "yellow");
 				$this->AddPage($this->CurOrientation);
 				$this->SetCol(0);
 				$this->y0 = $this->tMargin;
@@ -28249,7 +28249,7 @@ class mPDF
 				} // *OTL*
 			}
 			$this->x = $this->lMargin;
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 		} else {
 			$this->AddPage($this->CurOrientation);
 		}
@@ -28524,7 +28524,7 @@ class mPDF
 			}
 			if ($lowest_bottom_y > 0) {
 				$this->y = $lowest_bottom_y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			}
 		}
 
@@ -28638,7 +28638,7 @@ class mPDF
 
 			if ($lowest_bottom_y > 0) {
 				$this->y = $lowest_bottom_y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			}
 		}
 
@@ -28674,7 +28674,7 @@ class mPDF
 			}
 			if ($lowest_bottom_y > 0) {
 				$this->y = $lowest_bottom_y;
-                $this->debugLog("Setting y to: ". $this->y, "red");
+				$this->debugLog("Setting y to: ". $this->y, "red");
 			}
 			/* -- BOOKMARKS -- */
 			// Output Bookmarks
@@ -28923,9 +28923,9 @@ class mPDF
 
 
 		$this->y = $this->tbrot_y0 + $this->tbrot_w;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->x = $this->lMargin;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 
 		$this->tablebuffer = '';
 	}
@@ -29093,7 +29093,7 @@ class mPDF
 		$this->kwt_buffer = array();
 
 		$this->y += $this->kwt_height;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->pageoutput[$this->page] = array(); // mPDF 6
 	}
 
@@ -29900,9 +29900,9 @@ class mPDF
 
 		$fbwi = $fbw - 2; // Full barcode width incl. light margins - 2mm - for isbn string
 		// cf. http://www.gs1uk.org/downloads/bar_code/Bar coding getting it right.pdf
-		$num_height = 3 * $size;     // Height of numerals
+		$num_height = 3 * $size;	 // Height of numerals
 		$fbh = $arrcode['nom-H'] * $size * $height;  // Full barcode height incl. numerals
-		$bch = $fbh - (1.5 * $size);     // Barcode height of bars	 (3mm for numerals)
+		$bch = $fbh - (1.5 * $size);	 // Barcode height of bars	 (3mm for numerals)
 
 		if (($btype == 'EAN13' && $showtext) || $btype == 'ISSN' || $btype == 'ISBN') { // Add height for ISBN string + margin from top of bars
 			$tisbnm = 1.5 * $size; // Top margin between isbn (if shown) & bars
@@ -29974,7 +29974,7 @@ class mPDF
 				$this->SetFColor($this->ConvertColor(255));
 			}
 			$this->x = $x + $paddingL + 1; // 1mm left margin (cf. $fbwi above)
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			// max width is $fbwi
 			$loop = 0;
 			while ($loop == 0) {
@@ -29995,7 +29995,7 @@ class mPDF
 				}
 			}
 			$this->y = $y + $paddingT - ($codestr_fontsize ) - $tisbnm;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			$this->Cell($fbw, $codestr_fontsize, $codestr);
 			if ($charspacing) {
 				$this->_out('BT 0 Tc ET');
@@ -30072,9 +30072,9 @@ class mPDF
 		$y_text_outer = $y + $paddingT + $bch - ($num_height * ($outerfontsize / 3) / 2);
 
 		$this->x = $x + $paddingL - ($cw * ($outerfontsize / 3) * 0.1); // 0.1 is correction as char does not fill full width;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 		$this->y = $y_text_outer;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->Cell($cw, $num_height, $charLO);
 
 		// WORD SPACING for inner chars
@@ -30093,16 +30093,16 @@ class mPDF
 		$this->SetFontSize(3 * $fh * $size * _MPDFK); // 3mm numerals (FontSize is larger to account for space above/below characters)
 		// Inner left half characters
 		$this->x = $x + $paddingL + $llm + $outerp;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 		$this->y = $y_text;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->Cell($textw, $num_height, $charLI, 0, 0, '', 1);
 
 		// Inner right half characters
 		$this->x = $x + $paddingL + $llm + ($bcw * 0.5) + $innerp;
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 		$this->y = $y_text;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->Cell($textw, $num_height, $charRI, 0, 0, '', 1);
 
 		if ($charspacing) {
@@ -30113,9 +30113,9 @@ class mPDF
 		$this->SetFontSize(($outerfontsize / 3) * 3 * $fh * $size * _MPDFK); // 3mm numerals (FontSize is larger to account for space above/below characters)
 
 		$this->x = $x + $paddingL + $llm + $bcw + $rlm - ($cw * ($outerfontsize / 3) * 0.9); // 0.9 is correction as char does not fill full width
-        $this->debugLog("Setting x to: ". $this->x, "red");
+		$this->debugLog("Setting x to: ". $this->x, "red");
 		$this->y = $y_text_outer;
-        $this->debugLog("Setting y to: ". $this->y, "red");
+		$this->debugLog("Setting y to: ". $this->y, "red");
 		$this->Cell($cw * ($outerfontsize / 3), $num_height, $charRO, 0, 0, 'R');
 
 		if ($supplement) { // EAN-2 or -5 Supplement
@@ -30162,17 +30162,17 @@ class mPDF
 			}
 			$this->SetFontSize(3 * $fh * $size * _MPDFK); // 3mm numerals (FontSize is larger to account for space above/below characters)
 			$this->x = $x + $paddingL + $llm;
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			$this->y = $y + $paddingT;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			$this->Cell($bcw, $num_height, $supplement_code, 0, 0, 'C');
 
 			// Outer Right character (light margin)
 			$this->SetFontSize(($outerfontsize / 3) * 3 * $fh * $size * _MPDFK); // 3mm numerals (FontSize is larger to account for space above/below characters)
 			$this->x = $x + $paddingL + $llm + $bcw + $rlm - ($cw * 0.9); // 0.9 is correction as char does not fill full width
-            $this->debugLog("Setting x to: ". $this->x, "red");
+			$this->debugLog("Setting x to: ". $this->x, "red");
 			$this->y = $y + $paddingT;
-            $this->debugLog("Setting y to: ". $this->y, "red");
+			$this->debugLog("Setting y to: ". $this->y, "red");
 			$this->Cell($cw * ($outerfontsize / 3), $num_height, '>', 0, 0, 'R');
 		}
 
@@ -31469,18 +31469,18 @@ class mPDF
 	{
 		switch ($value[0]) {
 
-	        case pdf_parser::TYPE_TOKEN:
-	            $this->_out($value[1] . ' ', false);
-	        break;
+			case pdf_parser::TYPE_TOKEN:
+				$this->_out($value[1] . ' ', false);
+			break;
 
-	        case pdf_parser::TYPE_NUMERIC:
-	        case pdf_parser::TYPE_REAL:
-	            if (is_float($value[1]) && $value[1] != 0) {
-	                $this->_out(rtrim(rtrim(sprintf('%F', $value[1]), '0'), '.') . ' ', false);
-	            } else {
-	                $this->_out($value[1] . ' ', false);
-	            }
-	        break;
+			case pdf_parser::TYPE_NUMERIC:
+			case pdf_parser::TYPE_REAL:
+				if (is_float($value[1]) && $value[1] != 0) {
+					$this->_out(rtrim(rtrim(sprintf('%F', $value[1]), '0'), '.') . ' ', false);
+				} else {
+					$this->_out($value[1] . ' ', false);
+				}
+			break;
 
 			case pdf_parser::TYPE_ARRAY :
 				// An array. Output the proper
@@ -31548,9 +31548,9 @@ class mPDF
 				$this->_out("<" . $value[1] . ">");
 			break;
 
-	        case pdf_parser::TYPE_BOOLEAN :
-	            $this->_out($value[1] ? 'true' : 'false');
-	        break;
+			case pdf_parser::TYPE_BOOLEAN :
+				$this->_out($value[1] ? 'true' : 'false');
+			break;
 
 			case pdf_parser::TYPE_NULL :
 				// The null object.
@@ -31744,7 +31744,7 @@ class mPDF
 
 			if ($n % $npr == 0) {
 				if (($y + $h + $spacing + $maxh) > $this->PageBreakTrigger && $n != $pagecount) {
-                    $this->debugLog("Adding Page Here", "yellow");
+					$this->debugLog("Adding Page Here", "yellow");
 					$this->AddPage();
 					$x = $_x;
 					$y = $_y;
@@ -31766,13 +31766,13 @@ class mPDF
 		$fn = $this->current_filename;
 		if (!isset($this->parsers[$fn])) {
 			// $this->parsers[$fn] =& new fpdi_pdf_parser($fn,$this);
-	        try {
+			try {
 				$this->parsers[$fn] = new fpdi_pdf_parser($fn, $this);
-	        } catch (Exception $e) {
+			} catch (Exception $e) {
 				throw new MpdfException($this->parsers[$fn]->errormsg); // Delete this line to return false on fail
 				return false;
 			}
-	    }
+		}
 
 		$this->current_parser = $this->parsers[$fn];
 		return $this->parsers[$fn]->getPageCount();
@@ -31780,7 +31780,7 @@ class mPDF
 
 	function ImportPage($pageno = 1, $crop_x = null, $crop_y = null, $crop_w = 0, $crop_h = 0, $boxName = '/CropBox')
 	{
-		$fn     = $this->current_filename;
+		$fn	 = $this->current_filename;
 		$parser = $this->parsers[$fn];
 		$parser->setPageno($pageno);
 
@@ -31875,7 +31875,7 @@ class mPDF
 		}
 
 		if ($this->state == 0) {
-            $this->debugLog("Adding Page Here", "yellow");
+			$this->debugLog("Adding Page Here", "yellow");
 			$this->AddPage();
 		}
 
@@ -31953,359 +31953,359 @@ class mPDF
 		$this->js = $script;
 	}
 
-    /**
-     * Helper function to print debug mesages with an optional param
-     * to print a backtrack with the debug message
-     **/
-    function debugLog($message, $color = 'green', $backtrace = false)
-    {
-        $colors = array();
-        $colors['red'] = "31m";
-        $colors['green'] = "32m";
-        $colors['black'] = "30m";
-        $colors['white'] = "97m";
-        $colors['yellow'] = "33m";
+	/**
+	 * Helper function to print debug mesages with an optional param
+	 * to print a backtrack with the debug message
+	 **/
+	function debugLog($message, $color = 'green', $backtrace = false)
+	{
+		$colors = array();
+		$colors['red'] = "31m";
+		$colors['green'] = "32m";
+		$colors['black'] = "30m";
+		$colors['white'] = "97m";
+		$colors['yellow'] = "33m";
 
-        $traceColor = "\e[" . $colors[$color];
-        $defaultColor = "\e[" . $colors['white'];
+		$traceColor = "\e[" . $colors[$color];
+		$defaultColor = "\e[" . $colors['white'];
 
-        if ($this->debug) {
-            $now = date('D M j H:i:s Y');
-            $trace = debug_backtrace();
-            $traceLine = $trace[0]['line'];
-            $traceFile = $trace[0]['file'];
-            $traceClass = $trace[0]['class'];
-            fwrite($this->stderr, "[$now] - [$traceFile:$traceLine] - [$traceClass]: $traceColor $message $defaultColor\n");
-            if ($backtrace) {
-                fwrite($this->stderr, "[$now]: Backtrace:\n");
-                fwrite($this->stderr, $trace . "\n");
-            }
-            return true;
-        }
+		if ($this->debug) {
+			$now = date('D M j H:i:s Y');
+			$trace = debug_backtrace();
+			$traceLine = $trace[0]['line'];
+			$traceFile = $trace[0]['file'];
+			$traceClass = $trace[0]['class'];
+			fwrite($this->stderr, "[$now] - [$traceFile:$traceLine] - [$traceClass]: $traceColor $message $defaultColor\n");
+			if ($backtrace) {
+				fwrite($this->stderr, "[$now]: Backtrace:\n");
+				fwrite($this->stderr, $trace . "\n");
+			}
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Calculate how much space is available on the current page
-     * using the current flowing blocks start position
-     **/
-    function getPageBlockSpaceAvailable()
-    {
-       return ($this->PageBreakTrigger - $this->flowingBlockAttr['starts_y']);
-    }
+	/**
+	 * Calculate how much space is available on the current page
+	 * using the current flowing blocks start position
+	 **/
+	function getPageBlockSpaceAvailable()
+	{
+	   return ($this->PageBreakTrigger - $this->flowingBlockAttr['starts_y']);
+	}
 
-    /**
-     * Calculate how many lines are available on the current page
-     * using the current flowing blocks height requirements
-     **/
-    function getPageBlockLinesAvailable()
-    {
-        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
-        $spaceAvailable = $this->getPageBlockSpaceAvailable();
+	/**
+	 * Calculate how many lines are available on the current page
+	 * using the current flowing blocks height requirements
+	 **/
+	function getPageBlockLinesAvailable()
+	{
+		$lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+		$spaceAvailable = $this->getPageBlockSpaceAvailable();
 
-        $lineHeight = ($lineHeight) ? $lineHeight : $this->normalLineheight;
-        return floor($spaceAvailable / $lineHeight);
-    }
+		$lineHeight = ($lineHeight) ? $lineHeight : $this->normalLineheight;
+		return floor($spaceAvailable / $lineHeight);
+	}
 
 
-    function onLastColumn()
-    {
-        if ($this->NbCol > 1) {
-            if ($this->CurrCol < ($this->NbCol - 1)) {
-                return false;
-            }
-        } 
-        return true;
-    }
+	function onLastColumn()
+	{
+		if ($this->NbCol > 1) {
+			if ($this->CurrCol < ($this->NbCol - 1)) {
+				return false;
+			}
+		} 
+		return true;
+	}
 
-    /**
-     * Calculate how many lines needed for all lines in the current block,
-     * how many lines remain on the current page, and how many lines 
-     * from this block are expected to be printed on the next page
-     **/
-    function getExpectedBlockWidowCount($linesRequired = null)
-    {
-        if (!$linesRequired) {
-            $lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
-            $linesRequired = $lineCount+1;
-        }
+	/**
+	 * Calculate how many lines needed for all lines in the current block,
+	 * how many lines remain on the current page, and how many lines 
+	 * from this block are expected to be printed on the next page
+	 **/
+	function getExpectedBlockWidowCount($linesRequired = null)
+	{
+		if (!$linesRequired) {
+			$lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
+			$linesRequired = $lineCount+1;
+		}
 
-        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
-        $spaceRequired = $lineHeight * $linesRequired;
-        $spaceAvailable = $this->getPageBlockSpaceAvailable();
-        $linesAvailable = $this->getPageBlockLinesAvailable(); 
-        $expectedWidowLines = ($linesRequired >= $linesAvailable) ? $linesAvailable : 0;
-        /*
-        if (($linesRequired < $this->minWidowLines) && ($linesRequired >= $linesAvailable)) {
-            $expectedWidowLines = $linesRequired;
-        }
-        */
-        
-        $this->debugLog("  Getting Expected Block Widows");
-        $this->debugLog("    lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
-        $this->debugLog("    space required by block: $spaceRequired, space available on current page: $spaceAvailable");
-        $this->debugLog("    expectedWidowLines: $expectedWidowLines");
+		$lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+		$spaceRequired = $lineHeight * $linesRequired;
+		$spaceAvailable = $this->getPageBlockSpaceAvailable();
+		$linesAvailable = $this->getPageBlockLinesAvailable(); 
+		$expectedWidowLines = ($linesRequired >= $linesAvailable) ? $linesAvailable : 0;
+		/*
+		if (($linesRequired < $this->minWidowLines) && ($linesRequired >= $linesAvailable)) {
+			$expectedWidowLines = $linesRequired;
+		}
+		*/
+		
+		$this->debugLog("  Getting Expected Block Widows");
+		$this->debugLog("	lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
+		$this->debugLog("	space required by block: $spaceRequired, space available on current page: $spaceAvailable");
+		$this->debugLog("	expectedWidowLines: $expectedWidowLines");
 
-        return $expectedWidowLines;
-    }
+		return $expectedWidowLines;
+	}
  
-    /**
-     * Calculate how many lines needed for all lines in the current block,
-     * how many lines remain on the current page, and how many lines 
-     * from this block are expected to be printed on the next page
-     **/
-    function getExpectedBlockOrphanCount($linesRequired = null)
-    {
-        if (!$linesRequired) {
-            $lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
-            $linesRequired = $lineCount+1;
-        }
+	/**
+	 * Calculate how many lines needed for all lines in the current block,
+	 * how many lines remain on the current page, and how many lines 
+	 * from this block are expected to be printed on the next page
+	 **/
+	function getExpectedBlockOrphanCount($linesRequired = null)
+	{
+		if (!$linesRequired) {
+			$lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
+			$linesRequired = $lineCount+1;
+		}
 
-        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
-        $spaceRequired = $lineHeight * $linesRequired;
-        $spaceAvailable = $this->getPageBlockSpaceAvailable();
-        $linesAvailable = $this->getPageBlockLinesAvailable(); 
-        $linesAvailableAfterPrint = ($linesAvailable - $linesRequired);
-        $expectedOrphanLines = abs(min(($linesAvailableAfterPrint), 0));
+		$lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+		$spaceRequired = $lineHeight * $linesRequired;
+		$spaceAvailable = $this->getPageBlockSpaceAvailable();
+		$linesAvailable = $this->getPageBlockLinesAvailable(); 
+		$linesAvailableAfterPrint = ($linesAvailable - $linesRequired);
+		$expectedOrphanLines = abs(min(($linesAvailableAfterPrint), 0));
 
-        $this->debugLog("  Getting Expected Block Orphans");
-        $this->debugLog("    lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
-        $this->debugLog("    space required by block: $spaceRequired, space available on current page: $spaceAvailable");
-        $this->debugLog("    expectedOrphanLines: $expectedOrphanLines");
+		$this->debugLog("  Getting Expected Block Orphans");
+		$this->debugLog("	lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
+		$this->debugLog("	space required by block: $spaceRequired, space available on current page: $spaceAvailable");
+		$this->debugLog("	expectedOrphanLines: $expectedOrphanLines");
 
-        return $expectedOrphanLines;
-    } 
+		return $expectedOrphanLines;
+	} 
 
-    function addColBreaksForWidows($expectedWidowLines, $preProcess = false)
-    {
-        $this->debugLog(print_r($this->flowingBlockAttr, true), "yellow");
-        $this->debugLog("expectedWidowLines: $expectedWidowLines, minWidowLines: " . $this->minWidowLines);
+	function addColBreaksForWidows($expectedWidowLines, $preProcess = false)
+	{
+		$this->debugLog(print_r($this->flowingBlockAttr, true), "yellow");
+		$this->debugLog("expectedWidowLines: $expectedWidowLines, minWidowLines: " . $this->minWidowLines);
 
-        if (($expectedWidowLines) && $expectedWidowLines < $this->minWidowLines) {
-            if ($this->onLastColumn()) {
-                // add a page and reset current column back to 0
-                $this->debugLog('GONNA ADD PAGE BREAK HERE', 'yellow');
-                $this->AddPage($this->CurOrientation);
-                //Go back to the first column - NEW PAGE
-                $this->SetCol(0);
-                $this->y0 = $this->tMargin;
-                $this->ChangeColumn = -($this->NbCol - 1);
-                // DIRECTIONALITY RTL
-                if ($this->directionality == 'rtl') {
-                    $this->ChangeColumn = -($this->ChangeColumn);
-                }
-            } else {
-                $this->debugLog("ADDING COLUMN BREAK HERE, CurrCol: " . $this->CurrCol . ", OldCol: " . $this->OldCol, 'yellow');
-                //Go to the next column
-                $this->OldCol = $this->CurrCol;
-                $this->CurrCol++;
-                $this->SetCol($this->CurrCol);
-                $this->y = $this->y0;
-                $this->debugLog("Setting y to: ". $this->y, "red");
-                $this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
-                // DIRECTIONALITY RTL
-                if ($this->directionality == 'rtl') {
-                    $this->ChangeColumn = -($this->ChangeColumn);
-                }
-                $this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-                $this->debugLog("Setting x to: ". $this->x, "red");
-                $this->flowingBlockAttr['widow_col_added'] = true;
-            }
-        }
-    }
+		if (($expectedWidowLines) && $expectedWidowLines < $this->minWidowLines) {
+			if ($this->onLastColumn()) {
+				// add a page and reset current column back to 0
+				$this->debugLog('GONNA ADD PAGE BREAK HERE', 'yellow');
+				$this->AddPage($this->CurOrientation);
+				//Go back to the first column - NEW PAGE
+				$this->SetCol(0);
+				$this->y0 = $this->tMargin;
+				$this->ChangeColumn = -($this->NbCol - 1);
+				// DIRECTIONALITY RTL
+				if ($this->directionality == 'rtl') {
+					$this->ChangeColumn = -($this->ChangeColumn);
+				}
+			} else {
+				$this->debugLog("ADDING COLUMN BREAK HERE, CurrCol: " . $this->CurrCol . ", OldCol: " . $this->OldCol, 'yellow');
+				//Go to the next column
+				$this->OldCol = $this->CurrCol;
+				$this->CurrCol++;
+				$this->SetCol($this->CurrCol);
+				$this->y = $this->y0;
+				$this->debugLog("Setting y to: ". $this->y, "red");
+				$this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
+				// DIRECTIONALITY RTL
+				if ($this->directionality == 'rtl') {
+					$this->ChangeColumn = -($this->ChangeColumn);
+				}
+				$this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
+				$this->debugLog("Setting x to: ". $this->x, "red");
+				$this->flowingBlockAttr['widow_col_added'] = true;
+			}
+		}
+	}
 
-    function addPageBreaksForWidows($expectedWidowLines, $preProcess = false)
-    {
-        if ($this->InFooter) {
-            return false;
-        }
-        if (($expectedWidowLines) && ($expectedWidowLines < $this->minWidowLines)) {
+	function addPageBreaksForWidows($expectedWidowLines, $preProcess = false)
+	{
+		if ($this->InFooter) {
+			return false;
+		}
+		if (($expectedWidowLines) && ($expectedWidowLines < $this->minWidowLines)) {
 
-            // debug column vars
-            $NbCol = $this->NbCol;
-            $ColWidth = $this->ColWidth;
-            $CurrCol = $this->CurrCol;
-            $OldCol = $this->OldCol;
-            $ColActive = $this->ColActive;
-            $ChangeColumn = $this->ChangeColumn;
-            $ColDetails = $this->ColDetails;
-            $columnbuffer = $this->columnbuffer;
-            $keepColumns = $this->keepColumns;
+			// debug column vars
+			$NbCol = $this->NbCol;
+			$ColWidth = $this->ColWidth;
+			$CurrCol = $this->CurrCol;
+			$OldCol = $this->OldCol;
+			$ColActive = $this->ColActive;
+			$ChangeColumn = $this->ChangeColumn;
+			$ColDetails = $this->ColDetails;
+			$columnbuffer = $this->columnbuffer;
+			$keepColumns = $this->keepColumns;
 
-            $this->debugLog("    is_table: $is_table, table_draft: $table_draft, width: $width, contentWidth: $contentWidth", "red");
-            $this->debugLog("    NbCol: $NbCol, CurrCol: $CurrCol, OldCol: $OldCol, ColActive: $ColActive, ColWidth: $ColWidth, ChnageColumn: $ChangeColumn, keepColumns: $keepColumns", "yellow");
+			$this->debugLog("	is_table: $is_table, table_draft: $table_draft, width: $width, contentWidth: $contentWidth", "red");
+			$this->debugLog("	NbCol: $NbCol, CurrCol: $CurrCol, OldCol: $OldCol, ColActive: $ColActive, ColWidth: $ColWidth, ChnageColumn: $ChangeColumn, keepColumns: $keepColumns", "yellow");
 
-            // check if we can accept a page break now
-            $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
-            if ($this->AcceptPageBreak()) {
-                // check if we already handled this case in Estimate
-                if (
-                    (!$this->flowingBlockAttr['widow_col_added']) &&
-                    (!$this->flowingBlockAttr['orphan_col_added']) &&
-                    (!$this->flowingBlockAttr['widow_break_added']) &&
-                    (!$this->flowingBlockAttr['orphan_break_added'])
-                   ) {
-                    if (!$this->ChangeColumn) {
-                        // add the page break before printing this block
-                        $this->debugLog("Adding Page Here", "yellow");
-                        $this->AddPage($this->CurOrientation);
-                        $this->flowingBlockAttr['widow_break_added'] = true;
-                        $this->flowingBlockAttr['starts_y'] = $this->tMargin;
-                        $this->flowingBlockAttr['newX'] = $this->lMargin;
-                        $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
-                        $this->debugLog("Widow detection triggered a page break", "red");
-                    } else {
-                        if (!$this->flowingBlockAttr['widow_col_added']) {
-                            $this->debugLog("Adding Page Here in addPageBreaksForWidows", "yellow");
-                            $this->AddPage($this->CurOrientation);
-                            $this->flowingBlockAttr['newX'] = $this->lMargin;
-                            $this->flowingBlockAttr['starts_y'] = $this->tMargin;
-                        }
-                    }
-                } else {
-                    $this->debugLog("Widow detected, but already handled in Estimate", "yellow");
-                    // TODO: fix this so AcceptPageBreak does set column data
-                    // for now reset column data back to what it was before we
-                    // called AcceptPageBreak
-                    $this->CurrCol = $CurrCol;
-                    $this->OldCol = $OldCol;
-                    $this->ChangeColumn = $ChangeColumn;
-                }
-            } else {
-                // this should handle column breaks
-                $this->debugLog("Widow detected, but we AcceptPageBreak() returns false", "yellow");
-                // Adjust columns
-                // TODO: currently, We only have to set x here because AcceptPageBreak actually does the column change
-                // this should be changed, as AcceptPageBreak shouldn't be incrementing columns
-                if ($this->CurrCol != $this->OldCol) {
-                    $this->flowingBlockAttr['widow_break_added'] = true;
-                    if ($this->directionality == 'rtl') { // *OTL*
-                        $this->x -= ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
-                    } else {
-                        $this->x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
-                    }
-                    $this->OldCol = $this->CurrCol;
-                    $this->flowingBlockAttr['widow_break_added'] = true;
-                    $this->flowingBlockAttr['newX'] = $this->x;
-                }
-            }
-        }
-    }
+			// check if we can accept a page break now
+			$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+			if ($this->AcceptPageBreak()) {
+				// check if we already handled this case in Estimate
+				if (
+					(!$this->flowingBlockAttr['widow_col_added']) &&
+					(!$this->flowingBlockAttr['orphan_col_added']) &&
+					(!$this->flowingBlockAttr['widow_break_added']) &&
+					(!$this->flowingBlockAttr['orphan_break_added'])
+				   ) {
+					if (!$this->ChangeColumn) {
+						// add the page break before printing this block
+						$this->debugLog("Adding Page Here", "yellow");
+						$this->AddPage($this->CurOrientation);
+						$this->flowingBlockAttr['widow_break_added'] = true;
+						$this->flowingBlockAttr['starts_y'] = $this->tMargin;
+						$this->flowingBlockAttr['newX'] = $this->lMargin;
+						$this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+						$this->debugLog("Widow detection triggered a page break", "red");
+					} else {
+						if (!$this->flowingBlockAttr['widow_col_added']) {
+							$this->debugLog("Adding Page Here in addPageBreaksForWidows", "yellow");
+							$this->AddPage($this->CurOrientation);
+							$this->flowingBlockAttr['newX'] = $this->lMargin;
+							$this->flowingBlockAttr['starts_y'] = $this->tMargin;
+						}
+					}
+				} else {
+					$this->debugLog("Widow detected, but already handled in Estimate", "yellow");
+					// TODO: fix this so AcceptPageBreak does set column data
+					// for now reset column data back to what it was before we
+					// called AcceptPageBreak
+					$this->CurrCol = $CurrCol;
+					$this->OldCol = $OldCol;
+					$this->ChangeColumn = $ChangeColumn;
+				}
+			} else {
+				// this should handle column breaks
+				$this->debugLog("Widow detected, but we AcceptPageBreak() returns false", "yellow");
+				// Adjust columns
+				// TODO: currently, We only have to set x here because AcceptPageBreak actually does the column change
+				// this should be changed, as AcceptPageBreak shouldn't be incrementing columns
+				if ($this->CurrCol != $this->OldCol) {
+					$this->flowingBlockAttr['widow_break_added'] = true;
+					if ($this->directionality == 'rtl') { // *OTL*
+						$this->x -= ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
+					} else {
+						$this->x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
+					}
+					$this->OldCol = $this->CurrCol;
+					$this->flowingBlockAttr['widow_break_added'] = true;
+					$this->flowingBlockAttr['newX'] = $this->x;
+				}
+			}
+		}
+	}
 
-    function addColBreaksForOrphans($expectedOrphanLines, $preProcess = false)
-    {
-        if ($this->InFooter) {
-            return false;
-        }
-        if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
-            if ($this->onLastColumn()) {
-                // add a page and reset current column back to 0
-                $this->debugLog('GONNA ADD PAGE BREAK HERE', 'yellow');
-                $this->AddPage($this->CurOrientation);
-                //Go back to the first column - NEW PAGE
-                $this->SetCol(0);
-                $this->y0 = $this->tMargin;
-                $this->ChangeColumn = -($this->NbCol - 1);
-                // DIRECTIONALITY RTL
-                if ($this->directionality == 'rtl') {
-                    $this->ChangeColumn = -($this->ChangeColumn);
-                }
-            } else {
-                $this->debugLog('ADDING COLUMN BREAK HERE', 'yellow');
-                //Go to the next column
-                $this->OldCol = $this->CurrCol;
-                $this->CurrCol++;
-                $this->SetCol($this->CurrCol);
-                $this->y = $this->y0;
-                $this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
-                // DIRECTIONALITY RTL
-                if ($this->directionality == 'rtl') {
-                    $this->ChangeColumn = -($this->ChangeColumn);
-                }
-                $this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
-                $this->flowingBlockAttr['orphan_col_added'] = true;
-            }
-        }
-    }
+	function addColBreaksForOrphans($expectedOrphanLines, $preProcess = false)
+	{
+		if ($this->InFooter) {
+			return false;
+		}
+		if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
+			if ($this->onLastColumn()) {
+				// add a page and reset current column back to 0
+				$this->debugLog('GONNA ADD PAGE BREAK HERE', 'yellow');
+				$this->AddPage($this->CurOrientation);
+				//Go back to the first column - NEW PAGE
+				$this->SetCol(0);
+				$this->y0 = $this->tMargin;
+				$this->ChangeColumn = -($this->NbCol - 1);
+				// DIRECTIONALITY RTL
+				if ($this->directionality == 'rtl') {
+					$this->ChangeColumn = -($this->ChangeColumn);
+				}
+			} else {
+				$this->debugLog('ADDING COLUMN BREAK HERE', 'yellow');
+				//Go to the next column
+				$this->OldCol = $this->CurrCol;
+				$this->CurrCol++;
+				$this->SetCol($this->CurrCol);
+				$this->y = $this->y0;
+				$this->ChangeColumn = 1; // Number (and direction) of columns changed +1, +2, -2 etc.
+				// DIRECTIONALITY RTL
+				if ($this->directionality == 'rtl') {
+					$this->ChangeColumn = -($this->ChangeColumn);
+				}
+				$this->x += $this->ChangeColumn * ($this->ColWidth + $this->ColGap);
+				$this->flowingBlockAttr['orphan_col_added'] = true;
+			}
+		}
+	}
 
-    function addPageBreaksForOrphans($expectedOrphanLines, $preProcess = false)
-    {
-        if ($this->InFooter) {
-            return false;
-        }
+	function addPageBreaksForOrphans($expectedOrphanLines, $preProcess = false)
+	{
+		if ($this->InFooter) {
+			return false;
+		}
 
-        if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
+		if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
 
-            // debug column vars
-            $NbCol = $this->NbCol;
-            $ColWidth = $this->ColWidth;
-            $CurrCol = $this->CurrCol;
-            $OldCol = $this->OldCol;
-            $ColActive = $this->ColActive;
-            $ChangeColumn = $this->ChangeColumn;
-            $ColDetails = $this->ColDetails;
-            $columnbuffer = $this->columnbuffer;
-            $keepColumns = $this->keepColumns;
+			// debug column vars
+			$NbCol = $this->NbCol;
+			$ColWidth = $this->ColWidth;
+			$CurrCol = $this->CurrCol;
+			$OldCol = $this->OldCol;
+			$ColActive = $this->ColActive;
+			$ChangeColumn = $this->ChangeColumn;
+			$ColDetails = $this->ColDetails;
+			$columnbuffer = $this->columnbuffer;
+			$keepColumns = $this->keepColumns;
 
-            $this->debugLog("    is_table: $is_table, table_draft: $table_draft, width: $width, contentWidth: $contentWidth", "red");
-            $this->debugLog("    NbCol: $NbCol, CurrCol: $CurrCol, OldCol: $OldCol, ColActive: $ColActive, ColWidth: $ColWidth, ChnageColumn: $ChangeColumn, keepColumns: $keepColumns", "yellow");
+			$this->debugLog("	is_table: $is_table, table_draft: $table_draft, width: $width, contentWidth: $contentWidth", "red");
+			$this->debugLog("	NbCol: $NbCol, CurrCol: $CurrCol, OldCol: $OldCol, ColActive: $ColActive, ColWidth: $ColWidth, ChnageColumn: $ChangeColumn, keepColumns: $keepColumns", "yellow");
 
-            // check if we can accept a page break now
-            $this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
-            if ($this->AcceptPageBreak()) {
-                // check if we already handled this case in Estimate
-                if (
-                    (!$this->flowingBlockAttr['widow_col_added']) &&
-                    (!$this->flowingBlockAttr['orphan_col_added']) &&
-                    (!$this->flowingBlockAttr['widow_break_added']) &&
-                    (!$this->flowingBlockAttr['orphan_break_added'])
-                   ) {
-                    if (!$this->ChangeColumn) {
-                        // add the page break before printing this block
-                        $this->debugLog("Adding Page Here", "yellow");
-                        $this->AddPage($this->CurOrientation);
-                        $this->flowingBlockAttr['orphan_break_added'] = true;
-                        $this->flowingBlockAttr['starts_y'] = $this->tMargin;
-                        $this->flowingBlockAttr['newX'] = $this->lMargin;
-                        $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
-                        $this->debugLog("Orphan detection triggered a page break", "red");
-                    } else {
-                        if (!$this->flowingBlockAttr['orphan_col_added']) {
-                            // COLUMN CHANGE
-                            $this->debugLog("Adding Page Here in addPageBreaksForOrphans", "yellow");
-                            $this->AddPage($this->CurOrientation);
+			// check if we can accept a page break now
+			$this->debugLog("Calling AcceptPageBreak with CurrCol: " . $this->CurrCol . " ChangeColumn: " . $this->ChangeColumn, "red");
+			if ($this->AcceptPageBreak()) {
+				// check if we already handled this case in Estimate
+				if (
+					(!$this->flowingBlockAttr['widow_col_added']) &&
+					(!$this->flowingBlockAttr['orphan_col_added']) &&
+					(!$this->flowingBlockAttr['widow_break_added']) &&
+					(!$this->flowingBlockAttr['orphan_break_added'])
+				   ) {
+					if (!$this->ChangeColumn) {
+						// add the page break before printing this block
+						$this->debugLog("Adding Page Here", "yellow");
+						$this->AddPage($this->CurOrientation);
+						$this->flowingBlockAttr['orphan_break_added'] = true;
+						$this->flowingBlockAttr['starts_y'] = $this->tMargin;
+						$this->flowingBlockAttr['newX'] = $this->lMargin;
+						$this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+						$this->debugLog("Orphan detection triggered a page break", "red");
+					} else {
+						if (!$this->flowingBlockAttr['orphan_col_added']) {
+							// COLUMN CHANGE
+							$this->debugLog("Adding Page Here in addPageBreaksForOrphans", "yellow");
+							$this->AddPage($this->CurOrientation);
 
-                            $this->flowingBlockAttr['newX'] = $this->lMargin;
-                            $this->flowingBlockAttr['starts_y'] = $this->tMargin;
-                        }
-                    }
-                } else {
-                    $this->debugLog("Orphan detected, but already handled in Estimate", "yellow");
-                    // TODO: fix this so AcceptPageBreak does set column data
-                    // for now reset column data back to what it was before we
-                    // called AcceptPageBreak
-                    $this->CurrCol = $CurrCol;
-                    $this->OldCol = $OldCol;
-                    $this->ChangeColumn = $ChangeColumn;
-                }   
-            } else {
-                // this should handle column breaks
-                $this->debugLog("Orphan detected, but we AcceptPageBreak() returns false", "yellow");
-                // Adjust here for columns
-                // TODO: currently, We only have to set x here because AcceptPageBreak actually does the column change
-                // this should be changed, as AcceptPageBreak shouldn't be incrementing columns
-                if ($this->CurrCol != $this->OldCol) {
-                    if ($this->directionality == 'rtl') { // *OTL*
-                        $this->x -= ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
-                    } else {
-                        $this->x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
-                    }
-                    $this->OldCol = $this->CurrCol;
-                    $this->flowingBlockAttr['orphan_break_added'] = true;
-                    $this->flowingBlockAttr['newX'] = $this->x;
-                }
-            }
-        }
-    }
+							$this->flowingBlockAttr['newX'] = $this->lMargin;
+							$this->flowingBlockAttr['starts_y'] = $this->tMargin;
+						}
+					}
+				} else {
+					$this->debugLog("Orphan detected, but already handled in Estimate", "yellow");
+					// TODO: fix this so AcceptPageBreak does set column data
+					// for now reset column data back to what it was before we
+					// called AcceptPageBreak
+					$this->CurrCol = $CurrCol;
+					$this->OldCol = $OldCol;
+					$this->ChangeColumn = $ChangeColumn;
+				}   
+			} else {
+				// this should handle column breaks
+				$this->debugLog("Orphan detected, but we AcceptPageBreak() returns false", "yellow");
+				// Adjust here for columns
+				// TODO: currently, We only have to set x here because AcceptPageBreak actually does the column change
+				// this should be changed, as AcceptPageBreak shouldn't be incrementing columns
+				if ($this->CurrCol != $this->OldCol) {
+					if ($this->directionality == 'rtl') { // *OTL*
+						$this->x -= ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
+					} else {
+						$this->x += ($this->CurrCol - $this->OldCol) * ($this->ColWidth + $this->ColGap);
+					}
+					$this->OldCol = $this->CurrCol;
+					$this->flowingBlockAttr['orphan_break_added'] = true;
+					$this->flowingBlockAttr['newX'] = $this->x;
+				}
+			}
+		}
+	}
 }

--- a/mpdf.php
+++ b/mpdf.php
@@ -1110,8 +1110,8 @@ class mPDF
 
 		require(_MPDF_PATH . 'config.php'); // config data
         // now load custom config
-        if(file_exists(_MPDF_PATH . 'custom_config.php')) {
-            include _MPDF_PATH . 'custom_config.php';
+        if(file_exists(_MPDF_PATH . 'config.local.php')) {
+            include _MPDF_PATH . 'config.local.php';
         }
 
 		$this->_setPageSize($format, $orientation);

--- a/mpdf.php
+++ b/mpdf.php
@@ -6569,7 +6569,7 @@ class mPDF
 			$charspacing = $this->charspacing; //Character Spacing
 			$this->ResetSpacing();
 
-			//$this->AddPage($this->CurOrientation);
+			$this->AddPage($this->CurOrientation);
 
 			$this->x = $bak_x;
 			// Added to correct for OddEven Margins

--- a/mpdf.php
+++ b/mpdf.php
@@ -17559,8 +17559,8 @@ class mPDF
 		$blk['bgcolor'] = false;
 		$blk['page_break_after_avoid'] = false;
 		$blk['keep_block_together'] = false;
-        //$blk['orphans'] = 4; // this max number of orphan lines allowed before a page break will be inserted
-        //$blk['widows'] = 2; // the max number of widow lines allow before page break will be inserted
+        $blk['min_orphans'] = $this->minOrphanLines; // global defined in config.php
+        $blk['min_widows'] = $this->minWidowLines; // global defined in config.php
 		$blk['float'] = false;
 		$blk['line_height'] = '';
 		$blk['margin_collapse'] = false;

--- a/mpdf.php
+++ b/mpdf.php
@@ -829,8 +829,8 @@ class mPDF
 	//var $aliasNbPgGpHex;	// mPDF 6 deleted
 
     // Widows and Orphans
-    var $maxWidowLines;
-    var $maxOrphanLines;
+    var $minWidowLines;
+    var $mminOrphanLines;
 
 	var $ispre;
 	var $outerblocktags;

--- a/mpdf.php
+++ b/mpdf.php
@@ -1109,6 +1109,10 @@ class mPDF
 		$this->autoPageBreak = true;
 
 		require(_MPDF_PATH . 'config.php'); // config data
+        // now load custom config
+        if(file_exists(_MPDF_PATH . 'custom_config.php')) {
+            include _MPDF_PATH . 'custom_config.php';
+        }
 
 		$this->_setPageSize($format, $orientation);
 		$this->DefOrientation = $orientation;

--- a/mpdf.php
+++ b/mpdf.php
@@ -1,7 +1,7 @@
 <?php
 
 // ******************************************************************************
-// Software: mPDF, Unicode-HTML Free PDF generator                              *
+// Software: mPDFdow, Unicode-HTML Free PDF generator                              *
 // Version:  6.0        based on                                                *
 //           FPDF by Olivier PLATHEY                                            *
 //           HTML2FPDF by Renato Coelho                                         *
@@ -178,6 +178,7 @@ class mPDF
 	var $enableImports;
 
 	var $debug;
+    var $stderr;
 
 	var $showStats;
 	var $setAutoTopMargin;
@@ -827,6 +828,10 @@ class mPDF
 	//var $aliasNbPgHex;	// mPDF 6 deleted
 	//var $aliasNbPgGpHex;	// mPDF 6 deleted
 
+    // Widows and Orphans
+    var $maxWidowLines;
+    var $maxOrphanLines;
+
 	var $ispre;
 	var $outerblocktags;
 	var $innerblocktags;
@@ -845,6 +850,10 @@ class mPDF
 
 	public function __construct($mode = '', $format = 'A4', $default_font_size = 0, $default_font = '', $mgl = 15, $mgr = 15, $mgt = 16, $mgb = 16, $mgh = 9, $mgf = 9, $orientation = 'P')
 	{
+
+         /* where to send debug output */
+         $this->stderr = fopen("php://stderr", "w");
+
 		/* -- BACKGROUNDS -- */
 		if (!class_exists('grad', false)) {
 			include(_MPDF_PATH . 'classes/grad.php');
@@ -6284,6 +6293,9 @@ class mPDF
 
 	function newFlowingBlock($w, $h, $a = '', $is_table = false, $blockstate = 0, $newblock = true, $blockdir = 'ltr', $table_draft = false)
 	{
+        $this->debugLog("-------------------------");
+        $this->debugLog("Starting New Flowing Block || PAGE: " . $this->page . " || X: ". $this->x . " || Y: " . $this->y);
+
 		if (!$a) {
 			if ($blockdir == 'rtl') {
 				$a = 'R';
@@ -6291,6 +6303,11 @@ class mPDF
 				$a = 'L';
 			}
 		}
+        // Save the start position of this block - needed for orphan / widow detection
+		$this->flowingBlockAttr['starts_y'] = $this->y;
+		$this->flowingBlockAttr['widow_break_added'] = false;
+		$this->flowingBlockAttr['orphan_break_added'] = false;
+
 		$this->flowingBlockAttr['width'] = ($w * _MPDFK);
 		// line height in user units
 		$this->flowingBlockAttr['is_table'] = $is_table;
@@ -6334,6 +6351,8 @@ class mPDF
 		$cOTLdata = & $this->flowingBlockAttr['cOTLdata']; // mPDF 5.7.1
 		$newblock = $this->flowingBlockAttr['newblock'];
 		$blockdir = $this->flowingBlockAttr['blockdir'];
+
+        $this->debugLog("Finishing Flowing Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
 
 		// *********** BLOCK BACKGROUND COLOR *****************//
 		if ($this->blk[$this->blklvl]['bgcolor'] && !$is_table) {
@@ -6412,7 +6431,6 @@ class mPDF
 			/* -- END CSS-IMAGE-FLOAT -- */
 		} // *TABLES*
 
-
 		$lineBox = array();
 
 		$this->_setInlineBlockHeights($lineBox, $stackHeight, $content, $font, $is_table);
@@ -6479,6 +6497,38 @@ class mPDF
 		// Get PAGEBREAK TO TEST for height including the bottom border/padding
 		$check_h = max($this->divheight, $stackHeight);
 
+        /**
+         * determine if our orphans and widows config should page break before 
+         * printing this block content
+         **/
+        $expectedWidowLines = $this->getExpectedBlockWidowCount();
+        $expectedOrphanLines = $this->getExpectedBlockOrphanCount();
+        if (($expectedWidowLines) && ($expectedWidowLines < $this->minWidowLines)) {
+            // check if we already handled this case in Estimate
+            if ((!$this->flowingBlockAttr['widow_break_added']) && (!$this->flowingBlockAttr['orphan_break_added'])) {
+                // add the page break before printing this block
+                $this->AddPage($this->CurOrientation);
+                $this->flowingBlockAttr['widow_break_added'] = true; 
+                $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+                $this->debugLog("Widow detection triggered a page break");
+            } else {
+                $this->debugLog("Widow detection, but already handled in Estimate");
+            }
+        }
+
+        if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
+            // check if we already handled this case in Estimate
+            if ((!$this->flowingBlockAttr['widow_break_added']) && (!$this->flowingBlockAttr['orphan_break_added'])) {
+                // add the page break before printing this block
+                $this->AddPage($this->CurOrientation);
+                $this->flowingBlockAttr['orphan_break_added'] = true; 
+                $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+                $this->debugLog("Orphan detection triggered a page break");
+            } else {
+                $this->debugLog("Orphan detection, but already handled in Estimate");
+            }
+        }
+    
 		// This fixes a proven bug...
 		if ($endofblock && $newblock && $blockstate == 0 && !$content) {
 			$check_h = 0;
@@ -6510,16 +6560,16 @@ class mPDF
 			$buff = 0;
 		}
 
-
 		// PAGEBREAK
 		if (!$is_table && ($this->y + $check_h) > ($this->PageBreakTrigger + $buff) and ! $this->InFooter and $this->AcceptPageBreak()) {
+
 			$bak_x = $this->x; //Current X position
 			// WORD SPACING
 			$ws = $this->ws; //Word Spacing
 			$charspacing = $this->charspacing; //Character Spacing
 			$this->ResetSpacing();
 
-			$this->AddPage($this->CurOrientation);
+			//$this->AddPage($this->CurOrientation);
 
 			$this->x = $bak_x;
 			// Added to correct for OddEven Margins
@@ -6971,6 +7021,9 @@ class mPDF
 
 		// Reset lineheight
 		$stackHeight = $this->divheight;
+
+        $this->debugLog("Done finishing Flowing Block");
+        $this->debugLog("----------------------------\n");
 	}
 
 	function printobjectbuffer($is_table = false, $blockdir = false)
@@ -7532,7 +7585,21 @@ class mPDF
 		return $lastchar;
 	}
 
-	function WriteFlowingBlock($s, $sOTLdata)
+	function EstimateFlowingBlockWriteLines($s, $sOTLdata)
+	{
+        /**
+         * We will run the writes on a cloned version of the
+         * current document so that we can estimate how many lines
+         * are required before actually printing the lines
+         */
+        $mock = clone $this;
+        $mock->WriteFlowingBlock($s, $sOTLdata, true);
+        $lineCount = $mock->flowingBlockAttr['lineCount']; 
+
+        return $lineCount;
+    }
+
+	function WriteFlowingBlock($s, $sOTLdata, $draft = false)
 	{ // mPDF 5.7.1
 		$currentx = $this->x;
 		$is_table = $this->flowingBlockAttr['is_table'];
@@ -7554,6 +7621,12 @@ class mPDF
 
 		$newblock = $this->flowingBlockAttr['newblock'];
 		$blockdir = $this->flowingBlockAttr['blockdir'];
+
+        if ($draft) {
+            $this->debugLog("    Drafting Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
+        } else {
+            $this->debugLog("  Writing Flow Block || PAGE: " . $this->page . " || X: " . $this->x . " || Y: " . $this->y);
+        }
 
 		// *********** BLOCK BACKGROUND COLOR ***************** //
 		if ($this->blk[$this->blklvl]['bgcolor'] && !$is_table) {
@@ -17486,6 +17559,8 @@ class mPDF
 		$blk['bgcolor'] = false;
 		$blk['page_break_after_avoid'] = false;
 		$blk['keep_block_together'] = false;
+        //$blk['orphans'] = 4; // this max number of orphan lines allowed before a page break will be inserted
+        //$blk['widows'] = 2; // the max number of widow lines allow before page break will be inserted
 		$blk['float'] = false;
 		$blk['line_height'] = '';
 		$blk['margin_collapse'] = false;
@@ -18640,6 +18715,7 @@ class mPDF
 		if (!$table_draft)
 			$this->SetFont($this->default_font, '', $this->default_font_size, true, true); // force output to page
 
+
 		$this->newFlowingBlock($this->divwidth, $this->divheight, $align, $is_table, $blockstate, true, $blockdir, $table_draft);
 
 		$array_size = count($arrayaux);
@@ -18717,10 +18793,63 @@ class mPDF
 			}
 		}
 
+        /**
+         * Determine if this block has multiple writes, if so
+         * process it with a clone object and determine
+         * if a page break will be required for and expecte
+         * orphans or widows
+         */
+        if ($array_size > 0) {
+            $this->debugLog("  Writes in this Block: $array_size");
+            $linesRequired = 1;
+            for ($i = 0; $i < $array_size; $i++) {
+                $vetor = isset($arrayaux[$i]) ? $arrayaux[$i] : NULL;
+
+                //Ignore empty text and not carrying an internal link
+                if (empty($vetor[0]) && !($vetor[0] === '0') && empty($vetor[7])) {
+                    continue;
+                }
+                // get line estimates
+                $linesRequired += $this->EstimateFlowingBlockWriteLines($vetor[0], $vetor[18]);
+            }
+            $this->debugLog("  Writes in this Block: $array_size, Lines in this Block: $linesRequired");
+            /**
+             * determine if our orphans and widows config should page break before 
+             * printing this block content
+             **/
+            $expectedWidowLines = $this->getExpectedBlockWidowCount($linesRequired);
+            $expectedOrphanLines = $this->getExpectedBlockOrphanCount($linesRequired);
+            if (($expectedWidowLines) && ($expectedWidowLines < $this->minWidowLines)) {
+                if ((!$this->flowingBlockAttr['widow_break_added']) && (!$this->flowingBlockAttr['orphan_break_added'])) {
+                    // add the page break before printing this block
+                    $this->AddPage($this->CurOrientation);
+                    $this->flowingBlockAttr['widow_break_added'] = true; 
+                    $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+                    $this->debugLog("Widow detection triggered a page break");
+                } else {
+                    $this->debugLog("Widow detection, but already handled in Estimate");
+                }
+            }
+
+            if (($expectedOrphanLines) && $expectedOrphanLines < $this->minOrphanLines) {
+                if ((!$this->flowingBlockAttr['widow_break_added']) && (!$this->flowingBlockAttr['orphan_break_added'])) {
+                    // add the page break before printing this block
+                    $this->AddPage($this->CurOrientation);
+                    $this->flowingBlockAttr['orphan_break_added'] = true; 
+                    $this->debugLog("expectedWidows: $expectedWidowLines, expectedOrphans: $expectedOrphanLines");
+                    $this->debugLog("Orphan detection triggered a page break");
+                } else {
+                    $this->debugLog("Orphan detection, but already handled in Estimate");
+                }
+            }
+        }
+        
+
 		for ($i = 0; $i < $array_size; $i++) {
 			// COLS
 			$oldcolumn = $this->CurrCol;
 			$vetor = isset($arrayaux[$i]) ? $arrayaux[$i] : NULL;
+
 			if ($i == 0 && $vetor[0] != "\n" && ! $this->ispre) {
 				$vetor[0] = ltrim($vetor[0]);
 				if (!empty($vetor[18])) {
@@ -18735,8 +18864,7 @@ class mPDF
 					$this->finishFlowingBlock(true);
 				} // true = END of flowing block
 				continue;
-			}
-
+            }
 
 			//Activating buffer properties
 			if (isset($vetor[11]) && $vetor[11] != '') {   // Font Size
@@ -18841,8 +18969,7 @@ class mPDF
 
 			// SPECIAL CONTENT - IMAGES & FORM OBJECTS
 			//Print-out special content
-
-			if (substr($vetor[0], 0, 3) == "\xbb\xa4\xac") { //identifier has been identified!
+			if (substr($vetor[0], 0, 3) == "\xbb\xa4\xac") {
 				$objattr = $this->_getObjAttr($vetor[0]);
 
 				/* -- TABLES -- */
@@ -19200,6 +19327,7 @@ class mPDF
 			//Check if it is the last element. If so then finish printing the block
 			if ($i == ($array_size - 1)) {
 				$this->finishFlowingBlock(true); // true = END of flowing block
+
 				// Added to correct for OddEven Margins
 				if ($this->page != $oldpage) {
 					if (($this->page - $oldpage) % 2 == 1) {
@@ -31541,5 +31669,103 @@ class mPDF
 	{
 		$this->js = $script;
 	}
+
+    /**
+     * Helper function to print debug mesages with an optional param
+     * to print a backtrack with the debug message
+     **/
+    function debugLog($message, $backtrace = false)
+    {
+        if ($this->debug) {
+            $now = date('D M j H:i:s Y');
+            fwrite($this->stderr, "[$now]: $message\n");
+            if ($backtrace) {
+                fwrite($this->stderr, "[$now]: Backtrace:\n");
+                fwrite($this->stderr, print_r(debug_backtrace(), true) . "\n");
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Calculate how much space is available on the current page
+     * using the current flowing blocks start position
+     **/
+    function getPageBlockSpaceAvailable()
+    {
+       return ($this->PageBreakTrigger - $this->flowingBlockAttr['starts_y']);
+    }
+
+    /**
+     * Calculate how many lines are available on the current page
+     * using the current flowing blocks height requirements
+     **/
+    function getPageBlockLinesAvailable()
+    {
+        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+        $spaceAvailable = $this->getPageBlockSpaceAvailable();
+
+        $lineHeight = ($lineHeight) ? $lineHeight : $this->normalLineheight;
+        return floor($spaceAvailable / $lineHeight);
+    }
+
+
+    /**
+     * Calculate how many lines needed for all lines in the current block,
+     * how many lines remain on the current page, and how many lines 
+     * from this block are expected to be printed on the next page
+     **/
+    function getExpectedBlockWidowCount($linesRequired = null)
+    {
+        if (!$linesRequired) {
+            $lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
+            $linesRequired = $lineCount+1;
+        }
+        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+        $spaceRequired = $lineHeight * $linesRequired;
+        $spaceAvailable = $this->getPageBlockSpaceAvailable();
+        $linesAvailable = $this->getPageBlockLinesAvailable(); 
+        $expectedWidowLines = ($linesRequired >= $linesAvailable) ? $linesAvailable : 0;
+        /*
+        if (($linesRequired < $this->minWidowLines) && ($linesRequired >= $linesAvailable)) {
+            $expectedWidowLines = $linesRequired;
+        }
+        */
+
+        $this->debugLog("  Getting Expected Block Widows");
+        $this->debugLog("    lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
+        $this->debugLog("    space required by block: $spaceRequired, space available on current page: $spaceAvailable");
+        $this->debugLog("    expectedWidowLines: $expectedWidowLines");
+
+        return $expectedWidowLines;
+    }
+ 
+    /**
+     * Calculate how many lines needed for all lines in the current block,
+     * how many lines remain on the current page, and how many lines 
+     * from this block are expected to be printed on the next page
+     **/
+    function getExpectedBlockOrphanCount($linesRequired = null)
+    {
+        if (!$linesRequired) {
+            $lineCount = max($this->flowingBlockAttr['lineCount'], 0); 
+            $linesRequired = $lineCount+1;
+        }
+        $lineHeight = max($this->divheight, $this->flowingBlockAttr['height']);
+        $spaceRequired = $lineHeight * $linesRequired;
+        $spaceAvailable = $this->getPageBlockSpaceAvailable();
+        $linesAvailable = $this->getPageBlockLinesAvailable(); 
+        $linesAvailableAfterPrint = ($linesAvailable - $linesRequired);
+        $expectedOrphanLines = abs(min(($linesAvailableAfterPrint), 0));
+
+        $this->debugLog("  Getting Expected Block Orphans");
+        $this->debugLog("    lines required in this block: $linesRequired, lines available on current page: $linesAvailable");
+        $this->debugLog("    space required by block: $spaceRequired, space available on current page: $spaceAvailable");
+        $this->debugLog("    expectedOrphanLines: $expectedOrphanLines");
+        
+        return $expectedOrphanLines;
+    } 
 
 }


### PR DESCRIPTION
To config min lines require before allowing a block orphan / widow update config.php:

$this->minWidowLines = 3;
$this->minOrphanLines = 3;

a value of 0 here should result in current behavior without auto breaks.

I have only so far tested with examples/example02_CSS_styles.php, and this is a bit of a hasty patch, so any help with testing, examples, and feedback (be critical, I can take it ;-) would be very much appreciated.  I would be interested in the proper way to regression test and make sure I didn't break anything with these changes as well. 