### PR TITLE
PHP7: fix SVG handling Fatal error: 'break' not in the 'loop' or 'switch' context

### DIFF
--- a/classes/svg.php
+++ b/classes/svg.php
@@ -2997,7 +2997,6 @@ class SVG
 				}
 				else if (strtolower($name) == 'stop') {
 					if (!$last_gradid)
-						break;
 					$color = '#000000';
 					if (isset($attribs['style']) AND preg_match('/stop-color:\s*([^;]*)/i', $attribs['style'], $m)) {
 						$color = trim($m[1]);


### PR DESCRIPTION
This small deletion fixes an error seen when rendering SVG as part of a PDF when using PHP 7.1.0-dev (cli) (built: Dec  7 2015 12:44:25)