### PR TITLE
Add config constant so we can define custom font data

### DIFF
--- a/mpdf.php
+++ b/mpdf.php
@@ -1154,6 +1154,12 @@ class mPDF
 
 		// Font data
 		require(_MPDF_PATH . 'config_fonts.php');
+
+		// check for a custom config file that can add/overwrite the default config
+		if (defined('_MPDF_SYSTEM_TTFONTS_CONFIG') && file_exists(_MPDF_SYSTEM_TTFONTS_CONFIG)) {
+			require(_MPDF_SYSTEM_TTFONTS_CONFIG);
+		}
+
 		// Available fonts
 		$this->available_unifonts = array();
 		foreach ($this->fontdata AS $f => $fs) {


### PR DESCRIPTION
Allow custom `fontdata` to be defined outside of the `config_fonts.php` file.