### PR TITLE
Remove unused array_insert()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,23 +27,6 @@ function array_splice_reverse(&$arr, $offset, $length) {
 }
 
 
-function array_insert(&$array, $value, $offset) {
-	if (is_array($array)) {
-		$array  = array_values($array);
-		$offset = intval($offset);
-		if ($offset < 0 || $offset >= count($array)) { array_push($array, $value); }
-		else if ($offset == 0) { array_unshift($array, $value); }
-		else {
-			$temp  = array_slice($array, 0, $offset);
-			array_push($temp, $value);
-			$array = array_slice($array, $offset);
-			$array = array_merge($temp, $array);
-		}
-	}
-	else { $array = array($value); }
-	return count($array);
-}
-
 // mPDF 5.7.4 URLs
 function urldecode_parts($url) {
 	$file=$url;


### PR DESCRIPTION
Removing array_insert(), as it is unused in this library. Additionally, it is not name spaced and is not prefixed (and is therefore causing conflicts with another package).