### PR TITLE
PDF/A-3 associated files + additional xmp rdf

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -79,6 +79,25 @@ function _fgets (&$h, $force=false) {
 	return $s;
 }
 
+//
+// PDF documents use the internal date format: (D:YYYYMMDDHHmmSSOHH'mm'). The date format has these parts:
+//
+//   YYYY	The full four-digit year. (For example, 2004)
+//   MM	The month from 01 to 12.
+//   DD	The day from 01 to 31.
+//   HH	The hour from 00 to 23.
+//   mm	The minute from 00 to 59.
+//   SS	The seconds from 00 to 59.
+//   O	The relationship of local time to Universal Time (UT), as denoted by one of the characters +, -, or Z.
+//   HH	The absolute value of the offset from UT in hours specified as 00 to 23.
+//   mm	The absolute value of the offset from UT in minutes specified as 00 to 59.
+//
+function pdfFormattedDate($date){
+	$z = date('O'); // +0200
+	$offset = substr($z,0,3)."'".substr($z,3,2)."'"; // +02'00'
+	return date('YmdHis', $date) . $offset;
+}
+
 
 // For PHP4 compatability
 if(!function_exists('str_ireplace')) {

--- a/mpdf.php
+++ b/mpdf.php
@@ -822,6 +822,7 @@ class mPDF
 	var $keywords; //keywords
 	var $creator; //creator
 	var $associatedFiles; // associated files (see SetAssociatedFiles below)
+	var $additionalXmpRdf; //additional rdf added in xmp
 
 	var $aliasNbPg; //alias for total number of pages
 	var $aliasNbPgGp; //alias for total number of pages in page group
@@ -1925,6 +1926,10 @@ class mPDF
 	 */
 	function SetAssociatedFiles($files){
 		$this->associatedFiles = $files;
+	}
+
+	function SetAdditionalXmpRdf($s){
+		$this->additionalXmpRdf = $s;
 	}
 
 	function SetAnchor2Bookmark($x)
@@ -11076,6 +11081,9 @@ class mPDF
 		}
 		$m .= '   </rdf:Description>' . "\n";
 
+		if(!empty($this->additionalXmpRdf)) {
+			$m .= $this->additionalXmpRdf;
+		}
 
 		// This bit is specific to PDFX-1a
 		if ($this->PDFX) {

--- a/tests/data/xml/test.xml
+++ b/tests/data/xml/test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+	<body>Hello World</body>
+</note>

--- a/tests/mPDFTest.php
+++ b/tests/mPDFTest.php
@@ -23,4 +23,25 @@ class mPDFTest extends PHPUnit_Framework_TestCase
 		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
+	public function testPdfAssociatedFiles()
+	{
+		$this->mpdf->PDFA = true;
+		$this->mpdf->PDFAauto = true;
+		$this->mpdf->SetAssociatedFiles([[
+			'name' => 'public_filename.xml',
+			'mime' => 'text/xml',
+			'description' => 'some description',
+			'AFRelationship' => 'Alternative',
+			'path' => _MPDF_PATH . 'tests/data/xml/test.xml'
+		]]);
+
+		$this->mpdf->writeHtml('<html><body>hello world</body></html>');
+		$output = $this->mpdf->Output(NULL, 'S');
+
+		$this->assertStringStartsWith('%PDF-', $output);
+		$this->assertRegExp('/\d+ 0 obj\n<<\/F \(public_filename\.xml\)\n\/Desc \(some description\)/', $output);
+		$this->assertRegExp('/\/Type \/Filespec\n\/EF <<\n\/F \d+ 0 R\n>>\n\/AFRelationship \/Alternative/', $output);
+		$this->assertRegExp('/\d+ 0 obj\n<<\/Type \/EmbeddedFile\n\/Subtype \/text#2Fxml\n\/Length \d+\n\/Filter \/FlateDecode\n\/Params \<\<\/ModDate \(D:\d{14}[+|-|Z]\d{2}\'\d{2}\'\)/', $output);
+		$this->assertRegExp('/\/AF \d+ 0 R\n\/Names << \/EmbeddedFiles << \/Names \[\(public_filename\.xml\) \d+ 0 R\]/', $output);
+	}
 }

--- a/tests/mPDFTest.php
+++ b/tests/mPDFTest.php
@@ -44,4 +44,28 @@ class mPDFTest extends PHPUnit_Framework_TestCase
 		$this->assertRegExp('/\d+ 0 obj\n<<\/Type \/EmbeddedFile\n\/Subtype \/text#2Fxml\n\/Length \d+\n\/Filter \/FlateDecode\n\/Params \<\<\/ModDate \(D:\d{14}[+|-|Z]\d{2}\'\d{2}\'\)/', $output);
 		$this->assertRegExp('/\/AF \d+ 0 R\n\/Names << \/EmbeddedFiles << \/Names \[\(public_filename\.xml\) \d+ 0 R\]/', $output);
 	}
+
+	public function testPdfAdditionalXmpRdf()
+	{
+		$this->mpdf->PDFA = true;
+		$this->mpdf->PDFAauto = true;
+		$this->mpdf->SetAdditionalXmpRdf($this->ZugferdXmpRdf());
+
+		$this->mpdf->writeHtml('<html><body>hello world</body></html>');
+		$output = $this->mpdf->Output(NULL, 'S');
+
+		$this->assertStringStartsWith('%PDF-', $output);
+		$this->assertRegExp('/<zf:DocumentFileName>ZUGFeRD-invoice\.xml<\/zf:DocumentFileName>/', $output);
+	}
+
+	private function ZugferdXmpRdf()
+	{
+		$s  = '<rdf:Description rdf:about="" xmlns:zf="urn:ferd:pdfa:CrossIndustryDocument:invoice:1p0#">'."\n";
+		$s .= '  <zf:DocumentType>INVOICE</zf:DocumentType>'."\n";
+		$s .= '  <zf:DocumentFileName>ZUGFeRD-invoice.xml</zf:DocumentFileName>'."\n";
+		$s .= '  <zf:Version>1.0</zf:Version>'."\n";
+		$s .= '  <zf:ConformanceLevel>BASIC</zf:ConformanceLevel>'."\n";
+		$s .= '</rdf:Description>'."\n";
+		return $s;
+	}
 }


### PR DESCRIPTION
This PR allows to attach files "PDF/A-3" way (via "Associated Files" /AF key) + inject additional xmp rdf in the metadata.

These 2 features allows creation of ZUGFeRD invoices using mPDF.  ZUGFeRD requires:
- Embedding file via "/AF" key ("Associated Files") for PDF/A-3 compliance. (https://github.com/mpdf/mpdf/commit/612215780fd56d750f6969b136d43a2e5e4f7784)
- Additional XMP metadata entries (https://github.com/mpdf/mpdf/commit/f29f6a0fa5a91106c36bfa12fe5c35dbb6a89fb0)

More information: http://www.pdflib.com/knowledge-base/pdfa/zugferd-invoices/ (section "PDF Requirements for ZUGFeRD Invoices")

If you are somehow interested in this PR but have some thoughts about the implementation, don't hesitate to ask for modifications.

And.. thanks for great the lib!
