### PR TITLE
Bugfix: undefined variable in DirectWrite::Write

### DIFF
--- a/src/DirectWrite.php
+++ b/src/DirectWrite.php
@@ -36,7 +36,7 @@ class DirectWrite
 		$this->colorConvertor = $colorConvertor;
 	}
 
-	function Write($h, $txt, $currentx = 0, $link = '', $directionality = 'ltr', $align = '')
+	function Write($h, $txt, $currentx = 0, $link = '', $directionality = 'ltr', $align = '', $fill = 0)
 	{
 		if (!$align) {
 			if ($directionality == 'rtl') {

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -5763,13 +5763,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	/* -- DIRECTW -- */
 
-	function Write($h, $txt, $currentx = 0, $link = '', $directionality = 'ltr', $align = '')
+	function Write($h, $txt, $currentx = 0, $link = '', $directionality = 'ltr', $align = '', $fill = 0)
 	{
 		if (empty($this->directWrite)) {
 			$this->directWrite = new DirectWrite($this, $this->otl, $this->sizeConvertor, $this->colorConvertor);
 		}
 
-		$this->directWrite->Write($h, $txt, $currentx, $link, $directionality, $align);
+		$this->directWrite->Write($h, $txt, $currentx, $link, $directionality, $align, $fill);
 	}
 
 	/* -- END DIRECTW -- */


### PR DESCRIPTION
The variable `$fill` was always undefined (see [e8dcfd34])

DirectWrite::Write now has a new parameter `$fill`, analogous to other
functions.
`Mpdf::Write` (which delegates to `DirectWrite::Write`) has the same.