### PR TITLE
Add Travis testing of hhvm-3.3 and hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,22 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - hhvm-3.3
+  - hhvm-3.6
   - nightly
 
 matrix:
+  include:
+    - language: php
+      sudo: required
+      dist: trusty
+      group: edge
+      php: hhvm-nightly
   allow_failures:
-    - php: hhvm
+    - php: hhvm-3.3
+    - php: hhvm-3.6
     - php: nightly
+    - php: hhvm-nightly
 
 install:
   - composer self-update


### PR DESCRIPTION
Replace unclear 'hhvm' with 'hhvm-3.6',
and add 'hhvm-3.3' and 'hhvm-nightly' jobs,
also as allowed failures.