### PR TITLE
PHP 7.1 empty string index operator bug

### DIFF
--- a/classes/cssmgr.php
+++ b/classes/cssmgr.php
@@ -1293,6 +1293,7 @@ class cssmgr
 	{
 		$p = array();
 		$zp = array();
+		if (empty($attr)) $attr = array();
 
 		$classes = array();
 		if (isset($attr['CLASS'])) {


### PR DESCRIPTION
empty string index operator is not supported in strings anymore in php71, so fixing it.
Please merge this to 6.1 branch, even if it's not main branch anymore. Other packages are relying on that branch as a dependencies, and it's broken on php 7.1