### PR TITLE
Fixed headings containing umlaut (ÄÖÜ) not showing up via h2toc

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -5678,7 +5678,7 @@ class Tag
 						$objattr = [];
 						$objattr['type'] = 'toc';
 						$objattr['toclevel'] = $this->mpdf->h2toc[$tag];
-						$objattr['CONTENT'] = htmlspecialchars($content);
+						$objattr['CONTENT'] = htmlspecialchars(utf8_encode($content));
 						$e = "\xbb\xa4\xactype=toc,objattr=" . serialize($objattr) . "\xbb\xa4\xac";
 						array_unshift($this->mpdf->textbuffer, [$e]);
 					}


### PR DESCRIPTION
I don't know if this is a hack, but I could not find a better place to fix it. 
```
$html = 
'<h2>Chickens</h2>
About chickens...
<h2>Hähnchen</h2>
Über Hähnchen...'
```

Both sections show up fine in the body of the PDF, but only "Chickens" shows up in the TOC. "Hähnchen" generates an empty line only showing the dots and the page number.

Example TOC before:
```
Chickens......1
......1
```
Example TOC after:
```
Chickens......1
Hähnchen......1
```