### PR TITLE
Commented line that generated undesirable yellow boxes for links in PDF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 
-	"name": "mpdf/mpdf",
+	"name": "kikusempai/mpdf",
 	"type": "library",
 
 	"description": "A PHP class to generate PDF files from HTML with Unicode/UTF-8 and CJK support",

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -9721,7 +9721,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						$rect = sprintf('%.3F %.3F %.3F %.3F', $pl[0], $pl[1], $pl[0] + $pl[2], $pl[1] - $pl[3]);
 
 						$annot .= '<</Type /Annot /Subtype /Link /Rect [' . $rect . ']';
-						$annot .= ' /Contents ' . $this->_UTF16BEtextstring($pl[4]);
+						// $annot .= ' /Contents ' . $this->_UTF16BEtextstring($pl[4]);
 						$annot .= ' /NM ' . $this->_textstring(sprintf('%04u-%04u', $n, $key));
 						$annot .= ' /M ' . $this->_textstring('D:' . date('YmdHis'));
 


### PR DESCRIPTION
Hello. There's an issue that was mentioned in this repository:
https://github.com/mpdf/mpdf/issues/283
But the line that creates yellow boxes is still present. Please consider accepting changes with this line commented for the sake of beautiful documents without yellow boxes.