### PR TITLE
Added _unescape() method

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -28834,8 +28834,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						$out .= chr(0x0A);
 						break;
 					case "\r":
-						if ($count != $n-1 && $s[$count+1] == "\n")
+						if ($count != $n-1 && $s[$count+1] == "\n") {
 							$count++;
+						}
 						break;
 					case "\n":
 						break;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -28799,6 +28799,69 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		return current(unpack("H*", $str));
 	}
 
+	/**
+	 * Un-escapes a PDF string
+	 *
+	 * @param string $s
+	 * @return string
+	 */
+	function _unescape($s)
+	{
+		$out = '';
+		for ($count = 0, $n = strlen($s); $count < $n; $count++) {
+			if ($s[$count] != '\\' || $count == $n-1) {
+				$out .= $s[$count];
+			} else {
+				switch ($s[++$count]) {
+					case ')':
+					case '(':
+					case '\\':
+						$out .= $s[$count];
+						break;
+					case 'f':
+						$out .= chr(0x0C);
+						break;
+					case 'b':
+						$out .= chr(0x08);
+						break;
+					case 't':
+						$out .= chr(0x09);
+						break;
+					case 'r':
+						$out .= chr(0x0D);
+						break;
+					case 'n':
+						$out .= chr(0x0A);
+						break;
+					case "\r":
+						if ($count != $n-1 && $s[$count+1] == "\n")
+							$count++;
+						break;
+					case "\n":
+						break;
+					default:
+						// Octal-Values
+						if (ord($s[$count]) >= ord('0') &&
+							ord($s[$count]) <= ord('9')) {
+							$oct = ''. $s[$count];
+							if (ord($s[$count+1]) >= ord('0') &&
+								ord($s[$count+1]) <= ord('9')) {
+								$oct .= $s[++$count];
+								if (ord($s[$count+1]) >= ord('0') &&
+									ord($s[$count+1]) <= ord('9')) {
+									$oct .= $s[++$count];
+								}
+							}
+							$out .= chr(octdec($oct));
+						} else {
+							$out .= $s[$count];
+						}
+				}
+			}
+		}
+		return $out;
+	}
+
 	function pdf_write_value(&$value)
 	{
 		switch ($value[0]) {
@@ -28851,6 +28914,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			case pdf_parser::TYPE_STRING:
 				if ($this->encrypted) {
+					$value[1] = $this->_unescape($value[1]);
 					$value[1] = $this->protection->rc4($this->protection->objectKey($this->_current_obj_id), $value[1]);
 					$value[1] = $this->_escape($value[1]);
 				}

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -532,7 +532,7 @@ class FpdiTest extends \PHPUnit_Framework_TestCase
 	public function testEncryptionOfStringWithOctalValue()
 	{
 		$pdf = new mPDF();
-		$pdf->SetProtection(array('copy','print'), '', 'password',128);
+		$pdf->SetProtection(array('copy','print'), '', 'password', 128);
 
 		$string = [
 			pdf_parser::TYPE_STRING,
@@ -542,6 +542,8 @@ class FpdiTest extends \PHPUnit_Framework_TestCase
 		$pdf->pdf_write_value($string);
 
 		// (xxxxx)\n
-		$this->assertEquals(8, strlen($pdf->buffer));
+		$string = substr($pdf->buffer, 1, -2);
+		// we need to unescape the string, to get a comparable value
+		$this->assertEquals(5, strlen($pdf->_unescape($string)));
 	}
 }

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -525,4 +525,23 @@ class FpdiTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals(1, $rotation[0]);
 		$this->assertEquals(0, $rotation[1]);
 	}
+
+	/**
+	 * This test ensures that a string is unescaped before it is passed to the encryption function.
+	 */
+	public function testEncryptionOfStringWithOctalValue()
+	{
+		$pdf = new mPDF();
+		$pdf->SetProtection(array('copy','print'), '', 'password',128);
+
+		$string = [
+			pdf_parser::TYPE_STRING,
+			'\040\t\n\f\040'
+		];
+
+		$pdf->pdf_write_value($string);
+
+		// (xxxxx)\n
+		$this->assertEquals(8, strlen($pdf->buffer));
+	}
 }


### PR DESCRIPTION
This method is needed to support importing of PDF documents with FPDI
which uses escaped sequences in string values if the resulting document
should be encrypted.

See https://stackoverflow.com/questions/45052154/pdf-manipulation-images-are-distorted-after-few-consecutive-operations-on-pdf for details.