### PR TITLE
preg_replace() has a limit

### DIFF
--- a/classes/cssmgr.php
+++ b/classes/cssmgr.php
@@ -206,7 +206,9 @@ class cssmgr
 			preg_match_all('/url\(([^\'\"].*?[^\'\"])\)/', $CSSstr, $m);
 			for ($i = 0; $i < count($m[1]); $i++) {
 				$tmp = str_replace(array('(', ')', ';'), array('%28', '%29', $tempmarker), $m[1][$i]);
-				$CSSstr = preg_replace('/' . preg_quote($m[0][$i], '/') . '/', 'url(\'' . $tmp . '\')', $CSSstr);
+				if ( strlen( $tmp ) < 1024 ) {
+					$CSSstr = preg_replace('/' . preg_quote($m[0][$i], '/') . '/', 'url(\'' . $tmp . '\')', $CSSstr);
+				}
 			}
 		}
 


### PR DESCRIPTION
This would prevent the error `preg_replace(): Compilation failed: regular expression is too large at offset...` and allow for all CSS to be loaded.