### PR TITLE
protect against Divide By Zero error

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -21408,8 +21408,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						}
 					} elseif ($numcols) { // If all columns
 						$ttl = array_sum($table['l']);
-						for ($i = 0; $i < $numcols; $i++) {
-							$widthcols[$i]['miw'] += $surplus * $table['l'][$i] / $ttl;
+						if ( ! empty( $ttl ) ) {
+							for ( $i = 0; $i < $numcols; $i ++ ) {
+								$widthcols[ $i ]['miw'] += $surplus * $table['l'][ $i ] / $ttl;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Avoid possibility of dividing by zero

With these:
```
$mpdf = new mPDF(
	'UTF-8', //
	'LETTER', // default is A4
	'12' // I think default is 9
);
```

I kept hitting Divide By Zero error only at this line.