### PR TITLE
fixed colsum float calculation for german based locales

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -23929,17 +23929,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 									$cell['textbuffer'][0][0] = preg_replace('/{colsum[0-9_]*}/', $rep, $cell['textbuffer'][0][0]);
 								}
 							} elseif (!isset($table['is_thead'][$i])) {
-								$cellContent = floatVal(
-									str_replace(
-										['.', ','],
-										['', '.'],
-										preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0])
-									)
-								);
 								if (isset($this->colsums[$j])) {
-									$this->colsums[$j] += $cellContent;
+									$this->colsums[$j] += tofloat($cell['textbuffer'][0][0]);
 								} else {
-									$this->colsums[$j] = $cellContent;
+									$this->colsums[$j] = tofloat($cell['textbuffer'][0][0]);
 								}
 							}
 						}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -23929,10 +23929,17 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 									$cell['textbuffer'][0][0] = preg_replace('/{colsum[0-9_]*}/', $rep, $cell['textbuffer'][0][0]);
 								}
 							} elseif (!isset($table['is_thead'][$i])) {
+								$cellContent = floatVal(
+									str_replace(
+										['.', ','],
+										['', '.'],
+										preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0])
+									)
+								);
 								if (isset($this->colsums[$j])) {
-									$this->colsums[$j] += floatval(preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0]));
+									$this->colsums[$j] += $cellContent;
 								} else {
-									$this->colsums[$j] = floatval(preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0]));
+									$this->colsums[$j] = $cellContent;
 								}
 							}
 						}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -23930,9 +23930,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 								}
 							} elseif (!isset($table['is_thead'][$i])) {
 								if (isset($this->colsums[$j])) {
-									$this->colsums[$j] += tofloat($cell['textbuffer'][0][0]);
+									$this->colsums[$j] += $this->toFloat($cell['textbuffer'][0][0]);
 								} else {
-									$this->colsums[$j] = tofloat($cell['textbuffer'][0][0]);
+									$this->colsums[$j] = $this->toFloat($cell['textbuffer'][0][0]);
 								}
 							}
 						}
@@ -29436,6 +29436,28 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	function SetJS($script)
 	{
 		$this->js = $script;
+    }
+
+    /**
+     * This function takes the last comma or dot (if any) to make a clean float, ignoring thousand separator, currency or any other letter
+     *
+     * @param string $num
+     * @see http://php.net/manual/de/function.floatval.php#114486
+     * @return float
+     */
+	public function toFloat($num) {
+		$dotPos = strrpos($num, '.');
+		$commaPos = strrpos($num, ',');
+		$sep = (($dotPos > $commaPos) && $dotPos) ? $dotPos : ((($commaPos > $dotPos) && $commaPos) ? $commaPos : false);
+
+		if (!$sep) {
+			return floatval(preg_replace('/[^0-9]/', '', $num));
+		}
+
+		return floatval(
+            preg_replace('/[^0-9]/', '', substr($num, 0, $sep)) . '.' .
+            preg_replace('/[^0-9]/', '', substr($num, $sep+1, strlen($num)))
+		);
 	}
 
 	public function getFontDescriptor()

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -29436,16 +29436,17 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	function SetJS($script)
 	{
 		$this->js = $script;
-    }
+	}
 
-    /**
-     * This function takes the last comma or dot (if any) to make a clean float, ignoring thousand separator, currency or any other letter
-     *
-     * @param string $num
-     * @see http://php.net/manual/de/function.floatval.php#114486
-     * @return float
-     */
-	public function toFloat($num) {
+	/**
+	 * This function takes the last comma or dot (if any) to make a clean float, ignoring thousand separator, currency or any other letter
+	 *
+	 * @param string $num
+	 * @see http://php.net/manual/de/function.floatval.php#114486
+	 * @return float
+	 */
+	public function toFloat($num)
+	{
 		$dotPos = strrpos($num, '.');
 		$commaPos = strrpos($num, ',');
 		$sep = (($dotPos > $commaPos) && $dotPos) ? $dotPos : ((($commaPos > $dotPos) && $commaPos) ? $commaPos : false);
@@ -29455,8 +29456,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		return floatval(
-            preg_replace('/[^0-9]/', '', substr($num, 0, $sep)) . '.' .
-            preg_replace('/[^0-9]/', '', substr($num, $sep+1, strlen($num)))
+			preg_replace('/[^0-9]/', '', substr($num, 0, $sep)) . '.' .
+			preg_replace('/[^0-9]/', '', substr($num, $sep+1, strlen($num)))
 		);
 	}
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -227,3 +227,27 @@ if (!function_exists('cmp')) {
 		return strcoll(strtolower($a['uf']), strtolower($b['uf']));
 	}
 }
+
+if (!function_exists('tofloat')) {
+    /**
+     * This function takes the last comma or dot (if any) to make a clean float, ignoring thousand separator, currency or any other letter
+     *
+     * @param string $num
+     * @see http://php.net/manual/de/function.floatval.php#114486
+     * @return float
+     */
+	function tofloat($num) {
+		$dotPos = strrpos($num, '.');
+		$commaPos = strrpos($num, ',');
+		$sep = (($dotPos > $commaPos) && $dotPos) ? $dotPos : ((($commaPos > $dotPos) && $commaPos) ? $commaPos : false);
+
+		if (!$sep) {
+			return floatval(preg_replace('/[^0-9]/', '', $num));
+		}
+
+		return floatval(
+            preg_replace('/[^0-9]/', '', substr($num, 0, $sep)) . '.' .
+            preg_replace('/[^0-9]/', '', substr($num, $sep+1, strlen($num)))
+		);
+	}
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -227,5 +227,3 @@ if (!function_exists('cmp')) {
 		return strcoll(strtolower($a['uf']), strtolower($b['uf']));
 	}
 }
-
-

--- a/src/functions.php
+++ b/src/functions.php
@@ -228,26 +228,4 @@ if (!function_exists('cmp')) {
 	}
 }
 
-if (!function_exists('tofloat')) {
-    /**
-     * This function takes the last comma or dot (if any) to make a clean float, ignoring thousand separator, currency or any other letter
-     *
-     * @param string $num
-     * @see http://php.net/manual/de/function.floatval.php#114486
-     * @return float
-     */
-	function tofloat($num) {
-		$dotPos = strrpos($num, '.');
-		$commaPos = strrpos($num, ',');
-		$sep = (($dotPos > $commaPos) && $dotPos) ? $dotPos : ((($commaPos > $dotPos) && $commaPos) ? $commaPos : false);
 
-		if (!$sep) {
-			return floatval(preg_replace('/[^0-9]/', '', $num));
-		}
-
-		return floatval(
-            preg_replace('/[^0-9]/', '', substr($num, 0, $sep)) . '.' .
-            preg_replace('/[^0-9]/', '', substr($num, $sep+1, strlen($num)))
-		);
-	}
-}

--- a/tests/Issues/Issue491Test.php
+++ b/tests/Issues/Issue491Test.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Mpdf;
+
+class Issue491Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function htmlProvider()
+	{
+		return [
+			[
+				'<table>
+					<tbody>
+						<tr><td>4</td></tr>
+						<tr><td>6</td></tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>#SUM#{colsum0}#SUM#</td>
+						</tr>
+					</tfoot>
+				</table>',
+				'10'
+			], [
+				'<table>
+					<tbody>
+						<tr><td>12,54</td></tr>
+						<tr><td>0,12</td></tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>#SUM#{colsum2}#SUM#</td>
+						</tr>
+					</tfoot>
+				</table>',
+				'12.66'
+			], [
+				'<table>
+					<tbody>
+						<tr><td>1.999,39€</td></tr>
+						<tr><td>3.214,01€</td></tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>#SUM#{colsum2}#SUM#</td>
+						</tr>
+					</tfoot>
+				</table>',
+				'5213.40'
+			], [
+				'<table>
+					<tbody>
+						<tr><td>1 215 951,21 €</td></tr>
+						<tr><td>US$ 2,104,092.99</td></tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>#SUM#{colsum0}#SUM#</td>
+						</tr>
+					</tfoot>
+				</table>',
+				'3320044'
+			]
+		];
+	}
+
+
+	/**
+	 * @dataProvider htmlProvider
+	 */
+	public function testColsumInt($html, $expected)
+	{
+		$this->mpdf->setCompression(false);
+		$this->mpdf->WriteHtml($html);
+		$out = $this->mpdf->Output('', 'S');
+		$iMatchCnt = preg_match('/#SUM#(.*)#SUM#/', $out, $aMatches);
+		$this->assertEquals(1, $iMatchCnt, "could not find colsum for '".$html."'");
+		$this->assertEquals($expected, $aMatches[1]);
+	}
+
+}
+


### PR DESCRIPTION
In germany we use comma as decimal point and dot as thousands separator.  `floatval()` is not locale aware (as is `scanf()`), so we must use `str_replace()` magic :wink: 