### PR TITLE
fixed colsum float calculation for german based locales (backport)

### DIFF
--- a/mpdf.php
+++ b/mpdf.php
@@ -25286,10 +25286,17 @@ class mPDF
 									$cell['textbuffer'][0][0] = preg_replace('/{colsum[0-9_]*}/', $rep, $cell['textbuffer'][0][0]);
 								}
 							} elseif (!isset($table['is_thead'][$i])) {
+								$cellContent = floatVal(
+									str_replace(
+										['.', ','],
+										['', '.'],
+										preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0])
+									)
+								);
 								if (isset($this->colsums[$j])) {
-									$this->colsums[$j] += floatval(preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0]));
+									$this->colsums[$j] += $cellContent;
 								} else {
-									$this->colsums[$j] = floatval(preg_replace('/^[^0-9\.\,]*/', '', $cell['textbuffer'][0][0]));
+									$this->colsums[$j] = $cellContent;
 								}
 							}
 						}


### PR DESCRIPTION
In germany we use comma as decimal point and dot as thousands separator.  `floatval()` is not locale aware (as is `scanf()`), so we must use `str_replace()` magic :wink: 

This is a backport from #491 to the current stable version 6.1.4