### PR TITLE
Use constant instead of expression when define SCALE const

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -52,7 +52,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	const VERSION = '7.0.0';
 
-	const SCALE = 72 / 25.4;
+	const SCALE = 2.834645669; // it's 72 / 25.4;
 
 	var $useFixedNormalLineHeight; // mPDF 6
 	var $useFixedTextBaseline; // mPDF 6


### PR DESCRIPTION
Define constant as float, not numeric. This is only thing stops to use v7 with php 5.5 I encountered.