### PR TITLE
Conversion code cleanup

### DIFF
--- a/src/Conversion/DecToAlpha.php
+++ b/src/Conversion/DecToAlpha.php
@@ -10,7 +10,7 @@ class DecToAlpha
 		// returns a string from A-Z to AA-ZZ to AAA-ZZZ
 		// OBS: A = 65 ASCII TABLE VALUE
 		if (($valor < 1) || ($valor > 18278)) {
-			return "?"; //supports 'only' up to 18278
+			return '?'; //supports 'only' up to 18278
 		}
 
 		$c1 = $c2 = $c3 = '';
@@ -21,7 +21,7 @@ class DecToAlpha
 			$c3 = 65 + floor((($valor - 703) % 676) % 26);
 		} elseif ($valor > 26) { // 2 letters (up to 702)
 			$c1 = (64 + (int) (($valor - 1) / 26));
-			$c2 = (64 + (int) ($valor % 26));
+			$c2 = (64 + ($valor % 26));
 			if ($c2 == 64) {
 				$c2 += 26;
 			}

--- a/src/Conversion/DecToAlpha.php
+++ b/src/Conversion/DecToAlpha.php
@@ -13,8 +13,9 @@ class DecToAlpha
 			return '?'; //supports 'only' up to 18278
 		}
 
-		$c1 = $c2 = $c3 = '';
+		$c2 = $c3 = '';
 
+		$c1 = 64 + $valor; // 1 letter (up to 26)
 		if ($valor > 702) { // 3 letters (up to 18278)
 			$c1 = 65 + floor(($valor - 703) / 676);
 			$c2 = 65 + floor((($valor - 703) % 676) / 26);
@@ -22,20 +23,18 @@ class DecToAlpha
 		} elseif ($valor > 26) { // 2 letters (up to 702)
 			$c1 = (64 + (int) (($valor - 1) / 26));
 			$c2 = (64 + ($valor % 26));
-			if ($c2 == 64) {
+			if ($c2 === 64) {
 				$c2 += 26;
 			}
-		} else { // 1 letter (up to 26)
-			$c1 = (64 + $valor);
 		}
 
 		$alpha = chr($c1);
 
-		if ($c2 != '') {
+		if ($c2 !== '') {
 			$alpha .= chr($c2);
 		}
 
-		if ($c3 != '') {
+		if ($c3 !== '') {
 			$alpha .= chr($c3);
 		}
 

--- a/src/Conversion/DecToCjk.php
+++ b/src/Conversion/DecToCjk.php
@@ -14,7 +14,7 @@ class DecToCjk
 		$glyphs = [0x3007, 0x4E00, 0x4E8C, 0x4E09, 0x56DB, 0x4E94, 0x516D, 0x4E03, 0x516B, 0x4E5D];
 		$len = strlen($nstr);
 		for ($i = 0; $i < $len; $i++) {
-			$rnum .= UtfString::code2utf($glyphs[(int)$nstr[$i]]);
+			$rnum .= UtfString::code2utf($glyphs[(int) $nstr[$i]]);
 		}
 		return $rnum;
 	}

--- a/src/Conversion/DecToCjk.php
+++ b/src/Conversion/DecToCjk.php
@@ -12,8 +12,9 @@ class DecToCjk
 		$nstr = (string) $num;
 		$rnum = '';
 		$glyphs = [0x3007, 0x4E00, 0x4E8C, 0x4E09, 0x56DB, 0x4E94, 0x516D, 0x4E03, 0x516B, 0x4E5D];
-		for ($i = 0; $i < strlen($nstr); $i++) {
-			$rnum .= UtfString::code2utf($glyphs[intval($nstr[$i])]);
+		$len = strlen($nstr);
+		for ($i = 0; $i < $len; $i++) {
+			$rnum .= UtfString::code2utf($glyphs[(int)$nstr[$i]]);
 		}
 		return $rnum;
 	}

--- a/src/Conversion/DecToHebrew.php
+++ b/src/Conversion/DecToHebrew.php
@@ -28,7 +28,7 @@ class DecToHebrew
 
 		// return as initial numeric string
 		// If I is initially 0, and there is an additive tuple with a weight of 0, append that tuple's counter glyph to S and return S.
-		if ($i == 0) {
+		if ($i === 0) {
 			return '0';
 		}
 
@@ -57,7 +57,7 @@ class DecToHebrew
 				}
 				$i -= ($ct * $n);
 			}
-			if ($i == 0) {
+			if ($i === .0 || $i === 0) {
 				return $s;
 			}
 		}

--- a/src/Conversion/DecToHebrew.php
+++ b/src/Conversion/DecToHebrew.php
@@ -10,7 +10,7 @@ class DecToHebrew
 	public function convert($in, $reverse = false)
 	{
 		// reverse is used when called from Lists, as these do not pass through bidi-algorithm
-		$i = (int)$in; // I initially be the counter value
+		$i = (int) $in; // I initially be the counter value
 		$s = ''; // S initially be the empty string
 
 		// and glyph list initially be the list of additive tuples.

--- a/src/Conversion/DecToHebrew.php
+++ b/src/Conversion/DecToHebrew.php
@@ -10,7 +10,7 @@ class DecToHebrew
 	public function convert($in, $reverse = false)
 	{
 		// reverse is used when called from Lists, as these do not pass through bidi-algorithm
-		$i = intval($in); // I initially be the counter value
+		$i = (int)$in; // I initially be the counter value
 		$s = ''; // S initially be the empty string
 
 		// and glyph list initially be the list of additive tuples.
@@ -33,7 +33,8 @@ class DecToHebrew
 		}
 
 		// Otherwise, while I is greater than 0 and there are elements left in the glyph list:
-		for ($t = 0; $t < count($additive_nums); $t++) {
+		$additiveNumsCount = count($additive_nums);
+		for ($t = 0; $t < $additiveNumsCount; $t++) {
 			// Pop the first additive tuple from the glyph list. This is the current tuple.
 			$ct = $additive_nums[$t];
 			// Append the current tuple's counter glyph to S x floor( I / current tuple's weight ) times (this may be 0).

--- a/src/Conversion/DecToOther.php
+++ b/src/Conversion/DecToOther.php
@@ -24,8 +24,9 @@ class DecToOther
 		// From docPageNum: font is not set, so no check
 		$nstr = (string) $num;
 		$rnum = '';
+		$len = strlen($nstr);
 
-		for ($i = 0; $i < strlen($nstr); $i++) {
+		for ($i = 0; $i < $len; $i++) {
 			if (!$check || $this->mpdf->_charDefined($this->mpdf->CurrentFont['cw'], $cp + ((int) $nstr[$i]))) {
 				$rnum .= UtfString::code2utf($cp + (int) $nstr[$i]);
 			} else {

--- a/src/Conversion/DecToRoman.php
+++ b/src/Conversion/DecToRoman.php
@@ -9,12 +9,14 @@ namespace Mpdf\Conversion;
 class DecToRoman
 {
 
-	private $symbolMap = [['I', 'V'], ['X', 'L'], ['C', 'D'], ['M']];
+	private $symbolMap;
 
 	public function __construct(array $symbolMap = [])
 	{
 		if ($symbolMap !== []) {
 			$this->symbolMap = $symbolMap;
+		} else {
+			$this->symbolMap = [['I', 'V'], ['X', 'L'], ['C', 'D'], ['M']];
 		}
 	}
 

--- a/src/Conversion/DecToRoman.php
+++ b/src/Conversion/DecToRoman.php
@@ -60,7 +60,8 @@ class DecToRoman
 	{
 		$romanNumber = '';
 
-		for ($i = 0; $i < count($this->symbolMap); $i++) {
+		$symbolMapCount = count($this->symbolMap);
+		for ($i = 0; $i < $symbolMapCount; $i++) {
 			$divisor = pow(10, $i + 1);
 			$remainder = $number % $divisor;
 			$digit = $remainder / pow(10, $i);

--- a/src/Conversion/DecToRoman.php
+++ b/src/Conversion/DecToRoman.php
@@ -9,14 +9,12 @@ namespace Mpdf\Conversion;
 class DecToRoman
 {
 
-	private $symbolMap;
+	private $symbolMap = [['I', 'V'], ['X', 'L'], ['C', 'D'], ['M']];
 
 	public function __construct(array $symbolMap = [])
 	{
 		if ($symbolMap !== []) {
 			$this->symbolMap = $symbolMap;
-		} else {
-			$this->symbolMap = [['I', 'V'], ['X', 'L'], ['C', 'D'], ['M']];
 		}
 	}
 
@@ -49,7 +47,7 @@ class DecToRoman
 	public function getUpperBound()
 	{
 		$symbolGroupCount = count($this->symbolMap);
-		$valueOfOne = pow(10, $symbolGroupCount - 1);
+		$valueOfOne = 10 ** ($symbolGroupCount - 1);
 
 		$hasFiveSymbol = array_key_exists(1, $this->symbolMap[$symbolGroupCount - 1]);
 
@@ -62,9 +60,9 @@ class DecToRoman
 
 		$symbolMapCount = count($this->symbolMap);
 		for ($i = 0; $i < $symbolMapCount; $i++) {
-			$divisor = pow(10, $i + 1);
+			$divisor = 10 ** ($i + 1);
 			$remainder = $number % $divisor;
-			$digit = $remainder / pow(10, $i);
+			$digit = $remainder / (10 ** $i);
 
 			$number -= $remainder;
 			$romanNumber = $this->formatDigit($digit, $i) . $romanNumber;


### PR DESCRIPTION
- Optimisation: Use (int) instead of intval()
- Optimisation: Don't use count() or strlen() in `for` condition
- Optimisation: Use ** (>= 5.6) instead of `pow()`
- Use strict comparison (===) where needed
- Some code readability changes ($c1 initialized with default value, default property value in declaration)

Replaces #543 