### PR TITLE
Add AssociatedFiled from file content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+mPDF 7.0.3
+===========================
+
+### 24/11/2017
+
+* Allow passing file content or file path to `SetAssociatedFiles` (#558)
+
+
 mPDF 7.0.2
 ===========================
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1794,6 +1794,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	 *
 	 * param $files is an array of hash containing:
 	 *   path: file path on FS
+	 *   content: file content
 	 *   name: file name (not necessarily the same as the file on FS)
 	 *   mime (optional): file mime type (will show up as /Subtype in the PDF)
 	 *   description (optional): file description
@@ -1802,6 +1803,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	 * e.g. to associate 1 file:
 	 *     [[
 	 *         'path' => 'tmp/1234.xml',
+	 *         'content' => 'file content',
 	 *         'name' => 'public_name.xml',
 	 *         'mime' => 'text/xml',
 	 *         'description' => 'foo',
@@ -11126,8 +11128,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$this->_out('>>');
 			$this->_out('endobj');
 
-			// stream
-			$fileContent = @file_get_contents($file['path']);
+			$fileContent = null;
+			if (isset($file['path'])) {
+				$fileContent = @file_get_contents($file['path']);
+			} elseif (isset($file['content'])) {
+				$fileContent = $file['content'];
+			}
 
 			if (!$fileContent) {
 				throw new \Mpdf\MpdfException(sprintf('Cannot access associated file - %s', $file['path']));
@@ -11141,7 +11147,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 			$this->_out('/Length '.strlen($filestream));
 			$this->_out('/Filter /FlateDecode');
-			$this->_out('/Params <</ModDate ' . $this->_textstring('D:' . PdfDate::format(filemtime($file['path']))) . ' >>');
+			if (isset($file['path'])) {
+				$this->_out('/Params <</ModDate '.$this->_textstring('D:'.PdfDate::format(filemtime($file['path']))).' >>');
+			} else {
+				$this->_out('/Params <</ModDate '.$this->_textstring('D:'.PdfDate::format(time())).' >>');
+			}
 
 			$this->_out('>>');
 			$this->_putstream($filestream);

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -38,7 +38,7 @@ class MpdfTest extends \PHPUnit_Framework_TestCase
 		$this->mpdf->AdjustHTML(str_repeat('a', ini_get('pcre.backtrack_limit') + 1));
 	}
 
-	public function testPdfAssociatedFiles()
+	public function testPdfAssociatedFilesPath()
 	{
 		$this->mpdf->PDFA = true;
 		$this->mpdf->PDFAauto = true;
@@ -59,6 +59,28 @@ class MpdfTest extends \PHPUnit_Framework_TestCase
 		$this->assertRegExp('/\d+ 0 obj\n<<\/Type \/EmbeddedFile\n\/Subtype \/text#2Fxml\n\/Length \d+\n\/Filter \/FlateDecode\n\/Params \<\<\/ModDate \(D:\d{14}[+|-|Z]\d{2}\'\d{2}\'\)/', $output);
 		$this->assertRegExp('/\/AF \d+ 0 R\n\/Names << \/EmbeddedFiles << \/Names \[\(public_filename\.xml\) \d+ 0 R\]/', $output);
 	}
+
+	 public function testPdfAssociatedFilesContent()
+	 {
+	 	 $this->mpdf->PDFA = true;
+	 	 $this->mpdf->PDFAauto = true;
+	 	 $this->mpdf->SetAssociatedFiles([[
+	 	 	 'name' => 'public_filename.xml',
+	 	 	 'mime' => 'text/xml',
+	 	 	 'description' => 'some description',
+	 	 	 'AFRelationship' => 'Alternative',
+	 	 	 'content' => '<?xml version="1.0" encoding="UTF-8"?><note><body>Hello World</body></note>'
+	 	 ]]);
+
+	 	 $this->mpdf->writeHtml('<html><body>hello world</body></html>');
+	 	 $output = $this->mpdf->Output(NULL, 'S');
+
+	 	 $this->assertStringStartsWith('%PDF-', $output);
+	 	 $this->assertRegExp('/\d+ 0 obj\n<<\/F \(public_filename\.xml\)\n\/Desc \(some description\)/', $output);
+	 	 $this->assertRegExp('/\/Type \/Filespec\n\/EF <<\n\/F \d+ 0 R\n>>\n\/AFRelationship \/Alternative/', $output);
+	 	 $this->assertRegExp('/\d+ 0 obj\n<<\/Type \/EmbeddedFile\n\/Subtype \/text#2Fxml\n\/Length \d+\n\/Filter \/FlateDecode\n\/Params \<\<\/ModDate \(D:\d{14}[+|-|Z]\d{2}\'\d{2}\'\)/', $output);
+	 	 $this->assertRegExp('/\/AF \d+ 0 R\n\/Names << \/EmbeddedFiles << \/Names \[\(public_filename\.xml\) \d+ 0 R\]/', $output);
+	 }
 
 	public function testPdfAdditionalXmpRdf()
 	{


### PR DESCRIPTION
Hi,

This is a small improvement that allows to pass associated-files as content instead of file path. We are generating XML files in PHP and it's a lot easier to pass XML source instead of saving it to a temporary file just to read back the file in `_putAssociatedFiles`.

Example
====

```php
    $this->mpdf->SetAssociatedFiles([[
        'name' => 'public_filename.xml',
        'mime' => 'text/xml',
        'description' => 'some description',
        'AFRelationship' => 'Alternative',
        'content' => '<?xml version="1.0" encoding="UTF-8"?><note><body>Hello World</body></note>'
    ]]);
```