### PR TITLE
Fix for version conflicts of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
 		"psr/log": "^1.0",
 		"setasign/fpdi": "1.6.*",
-		"paragonie/random_compat": "^2.0"
+		"paragonie/random_compat": "^1.4|^2.0"
 
 	},
 


### PR DESCRIPTION
Tried to install in a Laravel 5.2 application and ran into some issues with conflicting versions of random compat.  This PR allows for both 1.x/2.x versions to co-exist.  See https://github.com/paragonie/random_compat/commit/856e858ab44b76ae67d8f8398d496a7464ac4656 