### PR TITLE
Appended missing Class for static method in Tag.php

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -2634,9 +2634,9 @@ class Tag
 					}
 					$this->mpdf->OTLdata = [];
 					if ($this->mpdf->tableLevel) {
-						$this->mpdf->_saveCellTextBuffer(code2utf($bdf) . $bdf2);
+						$this->mpdf->_saveCellTextBuffer(UtfString::code2utf($bdf) . $bdf2);
 					} else {
-						$this->mpdf->_saveTextBuffer(code2utf($bdf) . $bdf2);
+						$this->mpdf->_saveTextBuffer(UtfString::code2utf($bdf) . $bdf2);
 					}
 					$this->mpdf->biDirectional = true;
 					$currblk['bidicode'] = $popd;


### PR DESCRIPTION
Fix two places where code2utf was called without it's Class appended. This was causing some renders to break.