### PR TITLE
Import UtfString in \Mpdf\Tag\BlockTag

### DIFF
--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -4,6 +4,7 @@ namespace Mpdf\Tag;
 
 use Mpdf\Conversion\DecToAlpha;
 use Mpdf\Conversion\DecToRoman;
+use Mpdf\Utils\UtfString;
 
 abstract class BlockTag extends Tag
 {


### PR DESCRIPTION
Missed this one while refactoring.