### PR TITLE
Do not render table backgrounds when considering page breaks.

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22941,21 +22941,23 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		if ($this->tableBackgrounds && $level == 1) {
-			$s = $this->PrintTableBackgrounds();
-			if ($this->table_rotate && !$this->processingHeader && !$this->processingFooter) {
-				$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->tablebuffer);
-				if ($level == 1) {
-					$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->tablebuffer);
-				}
-			} elseif ($this->bufferoutput) {
-				$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->headerbuffer);
-				if ($level == 1) {
-					$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->headerbuffer);
-				}
-			} else {
-				$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->pages[$this->page]);
-				if ($level == 1) {
-					$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->pages[$this->page]);
+			if (!$this->keep_block_together) {
+				$s = $this->PrintTableBackgrounds();
+				if ($this->table_rotate && !$this->processingHeader && !$this->processingFooter) {
+					$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->tablebuffer);
+					if ($level == 1) {
+						$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->tablebuffer);
+					}
+				} elseif ($this->bufferoutput) {
+					$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->headerbuffer);
+					if ($level == 1) {
+						$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->headerbuffer);
+					}
+				} else {
+					$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->pages[$this->page]);
+					if ($level == 1) {
+						$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->pages[$this->page]);
+					}
 				}
 			}
 			$this->tableBackgrounds = [];

--- a/tests/Issues/Issue570Test.php
+++ b/tests/Issues/Issue570Test.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Mpdf;
+
+class Issue570Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testPageBreakInsideAvoidBackgrounds()
+	{
+		$before = str_repeat('<p>Before</p>', 20);
+		$after = str_repeat('<p>After</p>', 10);
+
+		$html = "
+			$before
+
+			<table>
+				<tr>
+					<td>Normal table cell</td>
+				</tr>
+			</table>
+
+			<div style=\"page-break-inside:avoid\">
+				<table>
+					<tr>
+						<td bgcolor=\"red\">Red table cell</td>
+					</tr>
+				</table>
+
+				$after
+			</div>";
+
+		$this->mpdf->setCompression(false);
+		$this->mpdf->WriteHTML($html);
+
+		$out = $this->mpdf->output('', 'S');
+
+		$num_red_boxes = substr_count($out, 'q 1.000 0.000 0.000 rg');
+
+		$this->assertEquals(1, $num_red_boxes);
+	}
+
+}


### PR DESCRIPTION
Fixes #570.

Wrapping the background printing code in a $this->keep_block_together check solves my issue.

This is my first patch to mPDF. I highly recommend reviewing my change before merging, as I'm not familiar with the mPDF codebase and I'm not confident that I haven't broken anything. I haven't broken any unit tests at least.