### PR TITLE
(Backport) Do not render table backgrounds when considering page breaks.

### DIFF
--- a/mpdf.php
+++ b/mpdf.php
@@ -25703,21 +25703,23 @@ class mPDF
 		}
 
 		if ($this->tableBackgrounds && $level == 1) {
-			$s = $this->PrintTableBackgrounds();
-			if ($this->table_rotate && !$this->processingHeader && !$this->processingFooter) {
-				$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->tablebuffer);
-				if ($level == 1) {
-					$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->tablebuffer);
-				}
-			} elseif ($this->bufferoutput) {
-				$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->headerbuffer);
-				if ($level == 1) {
-					$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->headerbuffer);
-				}
-			} else {
-				$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->pages[$this->page]);
-				if ($level == 1) {
-					$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->pages[$this->page]);
+			if (!$this->keep_block_together) {
+				$s = $this->PrintTableBackgrounds();
+				if ($this->table_rotate && !$this->processingHeader && !$this->processingFooter) {
+					$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->tablebuffer);
+					if ($level == 1) {
+						$this->tablebuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->tablebuffer);
+					}
+				} elseif ($this->bufferoutput) {
+					$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->headerbuffer);
+					if ($level == 1) {
+						$this->headerbuffer = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->headerbuffer);
+					}
+				} else {
+					$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', '\\1' . "\n" . $s . "\n", $this->pages[$this->page]);
+					if ($level == 1) {
+						$this->pages[$this->page] = preg_replace('/(___TABLE___BACKGROUNDS' . $this->uniqstr . ')/', " ", $this->pages[$this->page]);
+					}
 				}
 			}
 			$this->tableBackgrounds = array();


### PR DESCRIPTION
This is a backport for mPDF 6. See pull request #604.