### PR TITLE
Fix throwing PHP Warning. If mpdf import pdf tpl.

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -25268,7 +25268,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						$this->current_parser = $tpl['parser'];
 
 						foreach ($tpl['resources'][1] as $k => $v) {
-							if ($k == '/Shading') {
+							if ($k == '/Shading' && is_array($v[1])) {
 								foreach ($v[1] as $k2 => $v2) {
 									$this->_out($k2 . " ", false);
 									$this->pdf_write_value($v2);


### PR DESCRIPTION
PHP Warning:  Invalid argument supplied for foreach() in mpdf/src/Mpdf.php on line 25272.
Because `$v[1]` is not an array.