### PR TITLE
Improve error message if headers already sent

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -9289,8 +9289,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			case Destination::INLINE:
 
-				if (headers_sent()) {
-					throw new \Mpdf\MpdfException('Data has already been sent to output, unable to output PDF file');
+				if (headers_sent($filename, $line)) {
+					throw new \Mpdf\MpdfException(
+						sprintf('Data has already been sent to output (%s at line %s), unable to output PDF file', $filename, $line)
+					);
 				}
 
 				if ($this->debug && !$this->allow_output_buffering && ob_get_contents()) {


### PR DESCRIPTION
This PR adds the filename and the line where the header output started
![image](https://user-images.githubusercontent.com/3432361/35513515-9f3afe44-0503-11e8-8f2b-fb6524a5a122.png)
