### PR TITLE
Fix handling permissions on temporary directories

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -13,18 +13,44 @@ class Cache
 
 	public function __construct($basePath, $cleanupInterval = 3600)
 	{
-		if (!is_writable($basePath)
-				&& is_writable(dirname($basePath))
-				&& !file_exists($basePath)) {
-			mkdir($basePath, 0777, true);
-		}
-
-		if (!is_writable($basePath)) {
+		if (!$this->createBasePath($basePath)) {
 			throw new \Mpdf\MpdfException(sprintf('Temporary files directory "%s" is not writable', $basePath));
 		}
 
 		$this->basePath = $basePath;
 		$this->cleanupInterval = $cleanupInterval;
+	}
+
+	protected function createBasePath($basePath)
+	{
+		if (!file_exists($basePath)) {
+			if (!$this->createBasePath(dirname($basePath))) {
+				return false;
+			}
+
+			if (!$this->createDirectory($basePath)) {
+				return false;
+			}
+		}
+
+		if (!is_writable($basePath) || !is_dir($basePath)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected function createDirectory($basePath)
+	{
+		if (!mkdir($basePath)) {
+			return false;
+		}
+
+		if (!chmod($basePath, 0777)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public function tempFilename($filename)

--- a/tests/Mpdf/CacheTest.php
+++ b/tests/Mpdf/CacheTest.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace Mpdf;
+
+class CacheTest extends \PHPUnit_Framework_TestCase
+{
+	protected $basePath;
+	protected $oldTmpMode;
+
+	public function __construct($name = null, array $data = [], $dataName = '')
+	{
+		parent::__construct($name, $data, $dataName);
+
+		$this->basePath = __DIR__ . "/../../";
+	}
+
+	protected function path($relativeToRoot)
+	{
+		return $this->basePath . $relativeToRoot;
+	}
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$dir = $this->path("tmp");
+		$this->oldTmpMode = fileperms($dir);
+		chmod($dir, 0777);
+	}
+
+	protected function tearDown()
+	{
+		chmod($this->path("tmp"), $this->oldTmpMode);
+
+		parent::tearDown();
+	}
+
+	public function testCacheCreatesNonexistentDirectory()
+	{
+		$dir = $this->path("tmp/test1");
+
+		try {
+			new Cache($dir);
+
+			$this->assertDirectoryExists($dir);
+
+			$this->assertTrue(file_exists($dir));
+		} finally {
+			@rmdir($dir);
+		}
+	}
+
+	public function testCreatedDirectoryIsWorldWritable()
+	{
+		$dir = $this->path("tmp/test2");
+
+		try {
+			new Cache($dir);
+
+			$this->assertEquals(0777, fileperms($dir) & 0777);
+		} finally {
+			@rmdir($dir);
+		}
+	}
+
+	public function testCacheCreatesDirectoriesRecursively()
+	{
+		$dir = $this->path("tmp/test3/subdir/subdir2");
+
+		try {
+			new Cache($dir);
+
+			$this->assertDirectoryExists($dir);
+		} finally {
+			@rmdir($dir);
+			@rmdir($this->path("tmp/test3/subdir"));
+			@rmdir($this->path("tmp/test3"));
+		}
+	}
+
+	public function testRecursivelyCreatedDirectoriesAreWorldWritable()
+	{
+		$dir = $this->path("tmp/test4/subdir/subdir2");
+
+		try {
+			new Cache($dir);
+
+			foreach (array(
+						 "tmp/test4/subdir/subdir2",
+						 "tmp/test4/subdir",
+						 "tmp/test4",
+					 ) as $subdir) {
+				$this->assertEquals(0777, fileperms($this->path($subdir)) & 0777);
+			}
+		} finally {
+			@rmdir($dir);
+			@rmdir($this->path("tmp/test4/subdir"));
+			@rmdir($this->path("tmp/test4"));
+		}
+	}
+}


### PR DESCRIPTION
Follow-up for #534. Due to directory permissions issue, it is currently impossible to generate a PDF using one font, then generate another one using a different font and running under a different user (i.e. create a PDF with "font1" from the command line, then another PDF with "font2" from a web server), because the latter cannot write to `tmp/ttfontdata` directory, whenever `umask() !== 0` ― which is usually the case.

**Issue:**

`Mpdf\Cache` uses `mkdir()` to create missing temporary directories.

`mkdir()` takes umask into account (see [PHP documentation](http://php.net/mkdir#refsect1-function.mkdir-parameters)). It's not unusual to have `0002` or `0022` umask by default, so the directories end up not being world-writeable (i.e. having file mode `0775` or `0755` instead of `0777`).

This means that if a CLI worker creates the temp dirs first, a web server (running under a different, unrelated user) may not be able to generate PDF, and vice versa.

Whereas it is possible to create the main temporary directory and assign the correct permissions to it in advance, it is not true for `ttfontdata` subdirectory, which is created by MPDF itself ― so the ability to manually correct file permissions is limited.

**Fix:**

Use `chmod()`, which doesn't use umask, to assign permissions.

Since `chmod()` does not support recursive assignments, it was necessary to implement recursive directory creation manually. In the PR, `Mpdf\Cache::createBasePath()` function recursively calls itself to check the parent directory before attempting to create the target.

**Steps to reproduce:**

1. Initialize a project:
  
  ```
  composer init
  composer require mpdf/mpdf
  ```

2. Put the following code into a PHP script, and put **any two** TTF files in the same directory:

```php
<?php

require "vendor/autoload.php";

error_reporting(E_ALL);
ini_set('display_errors', 'On');

$fonts = glob('*.ttf');
sort($fonts);

$fontIndex = php_sapi_name() === "cli" ? 0 : 1;

$mpdf = new Mpdf\Mpdf([
     'fontDir' => __DIR__,
     'fontdata' => [
        'font-' . $fontIndex => [
                'R' => $fonts[$fontIndex],
        ],
     ],
]);

$mpdf->WriteHtml('<h1 style="font-family: font-' . $fontIndex . ';">Hello World!</h1>');
$mpdf->Output();
```

3. Run the script from the command line (i.e. `php index.php`).

4. Run the same script using a web server. Observe the generated exception.

**Other notes:**

I didn't find any existing tests pertaining to the `Cache` class, so I created a stub and put my tests there. The stub may be later expanded to completely cover the class. However, this is outside of the scope of the PR at the moment. Comments are welcome.