### PR TITLE
Ensure $mpdf->GetFullPath uses the absolute path, when able.

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -13110,7 +13110,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			$path = $path . "/" . $filepath; // Make it an absolute path
 
-		} elseif (strpos($path, ":/") === false || strpos($path, ":/") > 10) { // It is a local link
+		} elseif ((strpos($path, ":/") === false || strpos($path, ":/") > 10) && !is_file($path)) { // It is a local link
 
 			if (substr($path, 0, 1) == "/") {
 

--- a/tests/Mpdf/GetFullPathTest.php
+++ b/tests/Mpdf/GetFullPathTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mpdf;
+
+class GetFullPathTest extends \PHPUnit_Framework_TestCase
+{
+
+	public function testGetFullPath()
+	{
+		$originalImagePath = $path = __DIR__ . '/../data/img/demo.svg';
+		$originalImagePath = str_replace("\\", '/', $originalImagePath); //Fix path if on Windows
+
+		$mpdf = new Mpdf();
+		$mpdf->basepath = 'http://test.com';
+
+		/* Test absolute path is returned */
+		$mpdf->GetFullPath($path);
+		$this->assertEquals($originalImagePath, $path);
+
+		/* Test URL is returned using $mpdf->basepath */
+		$localImage = $path = 'path/for/empty/image.jpg';
+		$mpdf->GetFullPath($path);
+		$this->assertEquals($mpdf->basepath . $localImage, $path);
+
+		/* Test URL is returned using $mpdf->basepath */
+		$localImage2 = $path = '/path/for/empty/image.jpg';
+		$mpdf->GetFullPath($path);
+		$this->assertEquals($mpdf->basepath . $localImage2, $path);
+	}
+}


### PR DESCRIPTION
This patch resolves an edge-case bug when the `Mpdf::basepathIsLocal` setting hasn't been correctly determined and is set to `false` and assets are trying to load using the absolute path.

Prior to this patch, when `basepathIsLocal` is determined to be `false` (whether that be incorrectly determined due to server configuration, user error, or some other reason) and you are using the absolute path to the asset, it would be convert to a URI in `Mpdf::GetFullPath` and then a HTTP request is triggered in `ImageProcessor::getImage`. This patch helps prevent that HTTP request.

```
$mpdf = new \Mpdf\Mpdf();
$mpdf->basepathIsLocal = false; //manually set for purposes of replication

$mpdf->WriteHTML('<img src="'. __DIR__ . '/assets/Desert.jpg">');
$mpdf->Output();
```

Before the patch, the above image SRC will be converted to `http://test.com/assets/Desert.jpg` and will trigger a HTTP request in `ImageProcessor::getImage()`. After the patch the absolute path will be correctly used and the image will be retrieved from disk without a HTTP request.