### PR TITLE
Fix 0.1mm whitespace when using footer with zero margins

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -9517,7 +9517,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 				// if bottom-margin==0, corrects to avoid division by zero
 				if ($this->y == $this->h) {
-					$top_y = $this->y = ($this->h - 0.1);
+					$top_y = $this->y = ($this->h + 0.01);
 				}
 
 				$html = str_replace('{PAGENO}', $pnstr, $html);

--- a/tests/Issues/Issue640Test.php
+++ b/tests/Issues/Issue640Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Issues;
+
+class Issue640Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testBottomMargin()
+	{
+		$this->mpdf->WriteHTML('	
+		<style>
+			@page {
+				footer: html_myFooter1;
+				margin-footer: 0;
+			}
+			
+			#bottom {
+			height: 25mm;
+			background:red;
+			}
+		</style>
+		
+		<htmlpagefooter name="myFooter1">
+			<div id="bottom">test</div>
+		</htmlpagefooter>');
+
+		$this->mpdf->Close();
+
+		$this->assertRegexp('/1.0000 0.0000 0.0000 1.0000 0.0000 -725.6979 cm/', $this->mpdf->pages[1]);
+	}
+
+}


### PR DESCRIPTION
### Example

```
$mpdf = new \Mpdf\Mpdf();
$mpdf->WriteHTML('
<style>
@page {
	footer: html_myFooter1;
	margin-footer: 0;
}

#bottom {
height: 25mm;
background:red;
}
</style>

<htmlpagefooter name="myFooter1">
	<div id="bottom">test</div>
</htmlpagefooter>
');
```

Before the PR, the footer would be set to 0.1mm from the bottom of the page to prevent a division by zero. However, this would leave a noticeable small white line. This PR will push the footer down below the page edge by 0.01 instead.