### PR TITLE
Fix count() must be array PHP Notice

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1165,7 +1165,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->tbrot_Annots = [];
 		$this->kwt_Annots = [];
 		$this->columnAnnots = [];
+		$this->PageLinks = [];
+		$this->OrientationChanges = [];
 		$this->pageDim = [];
+		$this->saveHTMLHeader = [];
+		$this->saveHTMLFooter = [];
+		$this->PageAnnots = [];
+		$this->PageNumSubstitutions = [];
 		$this->breakpoints = []; // used in columnbuffer
 		$this->tableLevel = 0;
 		$this->tbctr = []; // counter for nested tables at each level

--- a/tests/Issues/Issue641Test.php
+++ b/tests/Issues/Issue641Test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Issues;
+
+class Issue641Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testCountPagebreakWarning()
+	{
+
+		$html = 'Test
+
+				<tocpagebreak paging="on" links="on" />
+				
+				<h1>Heading 1</h1>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<pagebreak/>
+				
+				<h1>Heading 1</h1>';
+
+		$this->mpdf->h2toc = array('H1' => 0, 'H2' => 1);
+		$this->mpdf->setCompression(false);
+		$this->mpdf->WriteHTML($html);
+
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+}


### PR DESCRIPTION
If trying to insert a TOC, a number of PHP notices in PHP 7.2 are triggered inside `Mpdf::MovePages()` due to `count()` checks on variables that haven't been defined yet.

### Example

```
$mpdf = new \Mpdf\Mpdf();
$mpdf->h2toc = array('H1' => 0, 'H2' => 1);

$mpdf->WriteHTML('
Test
<tocpagebreak paging="on" links="on" />

<h1>Heading 1</h1>

<h2>Heading 2</h2>

<h2>Heading 2</h2>

<h2>Heading 2</h2>

<pagebreak/>

<h1>Heading 1</h1>
');

$mpdf->Output();
```