### PR TITLE
Allow Header/Footer to be absolute-positioned on all pages its included on

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -15394,7 +15394,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$this->bufferoutput = false;
 
 			/* -- CSS-POSITION -- */
-			if (count($this->fixedPosBlockSave) && $sub != 4) {
+			if (count($this->fixedPosBlockSave)) {
 				foreach ($this->fixedPosBlockSave as $fpbs) {
 					$old_page = $this->page;
 					$this->page = $fpbs[2];

--- a/tests/Mpdf/MpdfAbsoluteHeaderFooter.php
+++ b/tests/Mpdf/MpdfAbsoluteHeaderFooter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Mpdf;
+
+class MpdfAbsoluteHeaderFooter extends \PHPUnit_Framework_TestCase
+{
+	public function testAbsoluteHeaderFooter()
+	{
+		$mpdf = $this->getMockBuilder('Mpdf\Mpdf')
+			->setMethods(['WriteFixedPosHTML'])
+			->getMock();
+
+		/*
+		 * The header/footer is absolute-positioned individually to both pages during Output().
+		 * It is also added once each in the initial WriteHTML call (gets overridden above).
+		 * The total number of calls to WriteFixedPosHTML is 10
+		 */
+		$mpdf->expects($this->exactly(10))
+			->method('WriteFixedPosHTML');
+
+		$mpdf->WriteHTML('	
+			<style>
+				@page {
+				header: html_myHeader;
+				footer: html_myFooter;
+				}
+				
+				#header {
+					position: absolute;
+					top: 20mm;
+					left: 30mm;
+				
+					width: 50mm;
+					height: 50mm;
+				
+					background: green;
+				}
+				
+				#footer {
+					position: absolute;
+					bottom: 20mm;
+					left: 30mm;
+				
+					width: 50mm;
+					height: 50mm;
+				
+					background: red;
+				}
+			</style>
+			
+			<htmlpageheader name="myHeader">
+				<div id="header">
+					This is the header
+				</div>
+			</htmlpageheader>
+			
+			<htmlpagefooter name="myFooter">
+				<div id="footer">
+					Page {PAGENO} / {nbpg}
+				</div>
+			</htmlpagefooter>
+			
+			<pagebreak />
+			
+			<pagebreak />
+			
+			<pagebreak />');
+
+		$mpdf->Close();
+	}
+}


### PR DESCRIPTION
Before the fix, only the first page will include the Header/Footer in the correct positions. The other pages won't have a header / footer. After the fix, all pages will have the header / footer correctly positioned.

### Example

```
$mpdf = new \Mpdf\Mpdf();

$mpdf->WriteHTML('
<style>
@page {
header: html_myHeader;
footer: html_myFooter;
}

#header {
	position: absolute;
	top: 20mm;
	left: 30mm;

	width: 50mm;
	height: 50mm;

	background: green;
}

#footer {
	position: absolute;
	bottom: 20mm;
	left: 30mm;

	width: 50mm;
	height: 50mm;

	background: red;
}
</style>

<htmlpageheader name="myHeader">
<div id="header">
	This is the header
</div>
</htmlpageheader>

<htmlpagefooter name="myFooter">
<div id="footer">
	Page {PAGENO} / {nbpg}
</div>
</htmlpagefooter>

<pagebreak />

<pagebreak />

<pagebreak />
');

$mpdf->Output();
```