### PR TITLE
Add support for "orientation" config key

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1600,10 +1600,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 
 			// e.g. A4-L = A4 landscape, A4-P = A4 portrait
-			if (preg_match('/([0-9a-zA-Z]*)-([P,L])/i', $format, $m)) { 
+			if (preg_match('/([0-9a-zA-Z]*)-([P,L])/i', $format, $m)) {
 				$format = $m[1];
 				$orientation = $m[2];
-			} elseif(empty($orientation)) {
+			} elseif (empty($orientation)) {
 				$orientation = 'P';
 			}
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1599,14 +1599,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$format = 'A4';
 			}
 
-			$pfo = 'P';
-			if (preg_match('/([0-9a-zA-Z]*)-L/i', $format, $m)) { // e.g. A4-L = A4 landscape
+			// e.g. A4-L = A4 landscape, A4-P = A4 portrait
+			if (preg_match('/([0-9a-zA-Z]*)-([P,L])/i', $format, $m)) { 
 				$format = $m[1];
-				$pfo = 'L';
+				$orientation = $m[2];
 			}
 
 			$format = PageFormat::getSizeFromName($format);
-			$orientation = $pfo;
 
 			$this->fwPt = $format[0];
 			$this->fhPt = $format[1];

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1603,6 +1603,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			if (preg_match('/([0-9a-zA-Z]*)-([P,L])/i', $format, $m)) { 
 				$format = $m[1];
 				$orientation = $m[2];
+			} elseif(empty($orientation)) {
+				$orientation = 'P';
 			}
 
 			$format = PageFormat::getSizeFromName($format);

--- a/tests/Mpdf/ConfigurationTest.php
+++ b/tests/Mpdf/ConfigurationTest.php
@@ -63,4 +63,77 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 		$this->assertArrayHasKey('angerthas', $mpdf->fontdata);
 	}
 
+	public function testOrientationSettings()
+    {
+        $format = 'A4';
+        $format_size = PageFormat::getSizeFromName($format);
+
+        // Set format to A4 and orientation to L
+        $mpdf = new Mpdf([
+            'format' => $format.'-L',
+        ]);
+
+        $this->assertSame('L', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to P
+        $mpdf = new Mpdf([
+            'format' => $format.'-P',
+        ]);
+
+        $this->assertSame('P', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to P
+        $mpdf = new Mpdf([
+            'format' => $format,
+        ]);
+
+        $this->assertSame('P', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to L, ignoring "orientation" key
+        $mpdf = new Mpdf([
+            'format' => $format.'-L',
+            'orientation' => 'P',
+        ]);
+
+        $this->assertSame('L', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to L, ignoring "orientation" key
+        $mpdf = new Mpdf([
+            'format' => $format.'-P',
+            'orientation' => 'L',
+        ]);
+
+        $this->assertSame('P', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to P
+        $mpdf = new Mpdf([
+            'format' => $format,
+            'orientation' => 'P',
+        ]);
+
+        $this->assertSame('P', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+
+        // Set format to A4 and orientation to L
+        $mpdf = new Mpdf([
+            'format' => $format,
+            'orientation' => 'L',
+        ]);
+
+        $this->assertSame('L', $mpdf->DefOrientation);
+        $this->assertSame($format_size[0], $mpdf->fwPt);
+        $this->assertSame($format_size[1], $mpdf->fhPt);
+	}
+
 }

--- a/tests/Mpdf/ConfigurationTest.php
+++ b/tests/Mpdf/ConfigurationTest.php
@@ -64,76 +64,76 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	public function testOrientationSettings()
-    {
-        $format = 'A4';
-        $format_size = PageFormat::getSizeFromName($format);
+	{
+		$format = 'A4';
+		$format_size = PageFormat::getSizeFromName($format);
 
-        // Set format to A4 and orientation to L
-        $mpdf = new Mpdf([
-            'format' => $format.'-L',
-        ]);
+		// Set format to A4 and orientation to L
+		$mpdf = new Mpdf([
+			'format' => $format.'-L',
+		]);
 
-        $this->assertSame('L', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('L', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to P
-        $mpdf = new Mpdf([
-            'format' => $format.'-P',
-        ]);
+		// Set format to A4 and orientation to P
+		$mpdf = new Mpdf([
+			'format' => $format.'-P',
+		]);
 
-        $this->assertSame('P', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('P', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to P
-        $mpdf = new Mpdf([
-            'format' => $format,
-        ]);
+		// Set format to A4 and orientation to P
+		$mpdf = new Mpdf([
+			'format' => $format,
+		]);
 
-        $this->assertSame('P', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('P', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to L, ignoring "orientation" key
-        $mpdf = new Mpdf([
-            'format' => $format.'-L',
-            'orientation' => 'P',
-        ]);
+		// Set format to A4 and orientation to L, ignoring "orientation" key
+		$mpdf = new Mpdf([
+			'format' => $format.'-L',
+			'orientation' => 'P',
+		]);
 
-        $this->assertSame('L', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('L', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to L, ignoring "orientation" key
-        $mpdf = new Mpdf([
-            'format' => $format.'-P',
-            'orientation' => 'L',
-        ]);
+		// Set format to A4 and orientation to L, ignoring "orientation" key
+		$mpdf = new Mpdf([
+			'format' => $format.'-P',
+			'orientation' => 'L',
+		]);
 
-        $this->assertSame('P', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('P', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to P
-        $mpdf = new Mpdf([
-            'format' => $format,
-            'orientation' => 'P',
-        ]);
+		// Set format to A4 and orientation to P
+		$mpdf = new Mpdf([
+			'format' => $format,
+			'orientation' => 'P',
+		]);
 
-        $this->assertSame('P', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('P', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 
-        // Set format to A4 and orientation to L
-        $mpdf = new Mpdf([
-            'format' => $format,
-            'orientation' => 'L',
-        ]);
+		// Set format to A4 and orientation to L
+		$mpdf = new Mpdf([
+			'format' => $format,
+			'orientation' => 'L',
+		]);
 
-        $this->assertSame('L', $mpdf->DefOrientation);
-        $this->assertSame($format_size[0], $mpdf->fwPt);
-        $this->assertSame($format_size[1], $mpdf->fhPt);
+		$this->assertSame('L', $mpdf->DefOrientation);
+		$this->assertSame($format_size[0], $mpdf->fwPt);
+		$this->assertSame($format_size[1], $mpdf->fhPt);
 	}
 
 }


### PR DESCRIPTION
Add support for the "orientation" config key (issue #598), changing the way __setPageSize_ behaves when the orientation isn't defined in the "format" key.

Results:
```php
// Behaves like before (set format to A4 and orientation to L)
$mpdf = new \Mpdf\Mpdf([
    'format' => 'A4-L',
]);

// Behaves like before (set format to A4 and orientation to P)
$mpdf = new \Mpdf\Mpdf([
    'format' => 'A4',
]);

// Added: set format to A4 and orientation to P
$mpdf = new \Mpdf\Mpdf([
    'format' => 'A4-P',
]);

// Behaves like before (set format to A4 and orientation to L, ignoring "orientation" key)
$mpdf = new \Mpdf\Mpdf([
    'format' => 'A4-L',
    'orientation' => 'P',
]);
```

Hope this helps 😄 