### PR TITLE
Ensure self-closing tags with no attributes are processed when no space between tag and slash

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -29052,7 +29052,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		// Tags which are self-closing: 1) Replaceable and 2) Non-replaced items
 		$selftabs = 'input|hr|img|br|barcode|dottab';
 		$selftabs2 = 'indexentry|indexinsert|bookmark|watermarktext|watermarkimage|column_break|columnbreak|newcolumn|newpage|page_break|pagebreak|formfeed|columns|toc|tocpagebreak|setpageheader|setpagefooter|sethtmlpageheader|sethtmlpagefooter|annotation';
+
+		// Fix self-closing tags which don't close themselves
 		$html = preg_replace('/(<(' . $selftabs . '|' . $selftabs2 . ')[^>\/]*)>/i', '\\1 />', $html);
+
+		// Fix self-closing tags that don't include a space between the tag name and the closing slash
+		$html = preg_replace('/(<(' . $selftabs . '|' . $selftabs2 . '))\/>/i', '\\1 />', $html);
 
 		$iterator = 0;
 		while ($thereispre) { // Recover <pre attributes>content</pre>

--- a/tests/Issues/Issue645Test.php
+++ b/tests/Issues/Issue645Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Issues;
+
+class Issue645Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testFixSelfClosingTag()
+	{
+		$this->mpdf->WriteHTML('
+		Page 1
+		
+		<pagebreak />
+		
+		Page 2
+		
+		<pagebreak/>
+		
+		Page 3
+		
+		<pagebreak>
+		
+		Page 4
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(4, count($this->mpdf->pages));
+	}
+
+}


### PR DESCRIPTION
This issue is most prominent with the `<pagebreak/>` tag, but does effect all other control tags when no attributes are used (i.e `<pagebreak orientation="L"/>` isn't effected, but `<tocpagebreak/>` is).

Resolves #645