### PR TITLE
Ensure TOC page number isn't automatically reset

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -25642,9 +25642,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	function TOCpagebreak($tocfont = '', $tocfontsize = '', $tocindent = '', $TOCusePaging = true, $TOCuseLinking = '', $toc_orientation = '', $toc_mgl = '', $toc_mgr = '', $toc_mgt = '', $toc_mgb = '', $toc_mgh = '', $toc_mgf = '', $toc_ohname = '', $toc_ehname = '', $toc_ofname = '', $toc_efname = '', $toc_ohvalue = 0, $toc_ehvalue = 0, $toc_ofvalue = 0, $toc_efvalue = 0, $toc_preHTML = '', $toc_postHTML = '', $toc_bookmarkText = '', $resetpagenum = '', $pagenumstyle = '', $suppress = '', $orientation = '', $mgl = '', $mgr = '', $mgt = '', $mgb = '', $mgh = '', $mgf = '', $ohname = '', $ehname = '', $ofname = '', $efname = '', $ohvalue = 0, $ehvalue = 0, $ofvalue = 0, $efvalue = 0, $toc_id = 0, $pagesel = '', $toc_pagesel = '', $sheetsize = '', $toc_sheetsize = '', $tocoutdent = '')
 	{
-		if (!$resetpagenum) {
-			$resetpagenum = 1;
-		} // mPDF 6
 		// Start a new page
 		if ($this->state == 0) {
 			$this->AddPage();

--- a/src/TableOfContents.php
+++ b/src/TableOfContents.php
@@ -843,9 +843,6 @@ class TableOfContents
 				if (!$suppress) {
 					$suppress = 'off';
 				}
-				if (!$resetpagenum) {
-					$resetpagenum = 1;
-				}
 				$this->mpdf->PageNumSubstitutions[] = ['from' => 1, 'reset' => $resetpagenum, 'type' => $pagenumstyle, 'suppress' => $suppress];
 			}
 			return [true, $toc_id];

--- a/src/Tag/TocPageBreak.php
+++ b/src/Tag/TocPageBreak.php
@@ -11,9 +11,6 @@ class TocPageBreak extends FormFeed
 		if ($isbreak) {
 			return;
 		}
-		if (!isset($attr['RESETPAGENUM']) || $attr['RESETPAGENUM'] < 1) {
-			$attr['RESETPAGENUM'] = 1;
-		} // mPDF 6
 		parent::open($attr, $ahtml, $ihtml);
 	}
 }

--- a/tests/Issues/Issue643Test.php
+++ b/tests/Issues/Issue643Test.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Issues;
+
+class Issue643Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testTocPageBreak()
+	{
+
+		$html = '
+				<style>
+					@page {
+					footer: html_myFooter;
+					}
+				</style>
+					
+				<htmlpagefooter name="myFooter">
+				Page {PAGENO} / {nbpg}
+				</htmlpagefooter>
+				
+				<tocpagebreak links="on" />
+				
+				<h1>Heading 1</h1>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<pagebreak />
+				
+				<h1>Heading 1</h1>';
+
+		$this->mpdf->h2toc = array('H1' => 0, 'H2' => 1);
+		$this->mpdf->setCompression(false);
+		$this->mpdf->WriteHTML($html);
+		$this->mpdf->Close();
+
+		$this->assertSame(1, $this->mpdf->docPageNum(1));
+		$this->assertSame(2, $this->mpdf->docPageNum(2));
+		$this->assertSame(3, $this->mpdf->docPageNum(3));
+	}
+
+	public function testTocPageBreakReset()
+	{
+
+		$html = '
+				<style>
+					@page {
+					footer: html_myFooter;
+					}
+				</style>
+					
+				<htmlpagefooter name="myFooter">
+				Page {PAGENO} / {nbpg}
+				</htmlpagefooter>
+				
+				<tocpagebreak links="on" resetpagenum="1" />
+				
+				<h1>Heading 1</h1>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<h2>Heading 2</h2>
+				
+				<pagebreak />
+				
+				<h1>Heading 1</h1>';
+
+		$this->mpdf->h2toc = array('H1' => 0, 'H2' => 1);
+		$this->mpdf->setCompression(false);
+		$this->mpdf->WriteHTML($html);
+		$this->mpdf->Close();
+
+		$this->assertSame(1, $this->mpdf->docPageNum(1));
+		$this->assertSame(1, $this->mpdf->docPageNum(2));
+		$this->assertSame(2, $this->mpdf->docPageNum(3));
+	}
+
+}


### PR DESCRIPTION
As per the documentation for the [HTML control tag](http://mpdf.github.io/reference/html-control-tags/tocpagebreak.html) and [method call](http://mpdf.github.io/reference/mpdf-functions/tocpagebreak.html) `tocpagebreak`, the `resetpagenum` value when blank, omitted, or `0`will leave the proceeding page number sequence unchanged. However, since Mpdf 6 this hasn't been the case.

This PR will ensure the `resetpagenum` value isn't automatically set to `1` when omitted, blank or `0`.

Resolves #643