### PR TITLE
feat: Allow ID to be used as internal anchor

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -15311,7 +15311,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 							// Changed to allow style="background: url('bg.jpg')"
 							if (preg_match('/^([^=]*)=["]?([^"]*)["]?$/', $v, $a3) || preg_match('/^([^=]*)=[\']?([^\']*)[\']?$/', $v, $a3)) {
 								if (strtoupper($a3[1]) == 'ID' || strtoupper($a3[1]) == 'CLASS') { // 4.2.013 Omits STYLE
-									$attr[strtoupper($a3[1])] = trim(strtoupper($a3[2]));
+									$attr[strtoupper($a3[1])] = trim(strtoupper($a3[2])); // the ID value (right) shouldn't be uppercased
 								} // includes header-style-right etc. used for <pageheader>
 								elseif (preg_match('/^(HEADER|FOOTER)-STYLE/i', $a3[1])) {
 									$attr[strtoupper($a3[1])] = trim(strtoupper($a3[2]));

--- a/src/Tag/A.php
+++ b/src/Tag/A.php
@@ -2,17 +2,24 @@
 
 namespace Mpdf\Tag;
 
+use Mpdf\Utils\Arrays;
+
 class A extends Tag
 {
 
 	public function open($attr, &$ahtml, &$ihtml)
 	{
-		if (isset($attr['NAME']) && $attr['NAME'] != '') {
+		$anchor = Arrays::get($attr, 'NAME', '');
+		if (!$anchor) {
+			$anchor = Arrays::get($attr, 'ID', '');
+		}
+
+		if ($anchor !== '') {
 			$e = '';
 			/* -- BOOKMARKS -- */
 			if ($this->mpdf->anchor2Bookmark) {
 				$objattr = [];
-				$objattr['CONTENT'] = htmlspecialchars_decode($attr['NAME'], ENT_QUOTES);
+				$objattr['CONTENT'] = htmlspecialchars_decode($anchor, ENT_QUOTES);
 				$objattr['type'] = 'bookmark';
 				if (!empty($attr['LEVEL'])) {
 					$objattr['bklevel'] = $attr['LEVEL'];
@@ -23,10 +30,10 @@ class A extends Tag
 			}
 			/* -- END BOOKMARKS -- */
 			if ($this->mpdf->tableLevel) { // *TABLES*
-				$this->mpdf->_saveCellTextBuffer($e, '', $attr['NAME']); // *TABLES*
+				$this->mpdf->_saveCellTextBuffer($e, '', $anchor); // *TABLES*
 			} // *TABLES*
 			else { // *TABLES*
-				$this->mpdf->_saveTextBuffer($e, '', $attr['NAME']); //an internal link (adds a space for recognition)
+				$this->mpdf->_saveTextBuffer($e, '', $anchor); //an internal link (adds a space for recognition)
 			} // *TABLES*
 		}
 		if (isset($attr['HREF'])) {


### PR DESCRIPTION
I had a look at #653 and added support for `id` as anchor in the `A` tag.

One thing is not working though: The value used in `id` gets automatically uppercased in `Mpdf.php` for a CSS thingy. (see added comment)

So this is **not** working:
```html
<a href="#foo">Go to foo</a>
<pagebreak />
<a id="foo">Here I am</a>
```

While this is working as expected:
```html
<a href="#FOO">Go to foo</a>
<pagebreak />
<a id="FOO">Here I am</a>
```

@finwe do you happen to know what problem was that line trying to solve?