### PR TITLE
Fix incorrect TOC page numbering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
 
 		"psr/log": "^1.0",
 		"setasign/fpdi": "1.6.*",
-		"paragonie/random_compat": "^1.4|^2.0"
+		"paragonie/random_compat": "^1.4|^2.0",
+		"myclabs/deep-copy": "^1.7"
 
 	},
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -25928,6 +25928,18 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 		/* -- END ANNOTATIONS -- */
 
+		// Update TOC pages
+		if (count($this->tableOfContents->_toc)) {
+			foreach ($this->tableOfContents->_toc as $key => $t) {
+				if ($t['p'] >= $start_page && $t['p'] <= $end_page) {
+					$this->tableOfContents->_toc[$key]['p'] += ($target_page - $start_page);
+				}
+				if ($t['p'] >= $target_page && $t['p'] < $start_page) {
+					$this->tableOfContents->_toc[$key]['p'] += $n_toc;
+				}
+			}
+		}
+
 		// Update PageNumSubstitutions
 		if (count($this->PageNumSubstitutions)) {
 			$newarr = [];

--- a/src/TableOfContents.php
+++ b/src/TableOfContents.php
@@ -2,6 +2,9 @@
 
 namespace Mpdf;
 
+use Mpdf\Utils\Arrays;
+use DeepCopy\DeepCopy;
+
 class TableOfContents
 {
 
@@ -67,6 +70,11 @@ class TableOfContents
 
 	var $m_TOC;
 
+	/**
+	 * @var bool Determine if the TOC should be cloned to calculate the correct page numbers
+	 */
+	protected $tocTocPaintBegun = false;
+
 	public function __construct(Mpdf $mpdf, SizeConverter $sizeConverter)
 	{
 		$this->mpdf = $mpdf;
@@ -75,6 +83,14 @@ class TableOfContents
 		$this->_toc = [];
 		$this->TOCmark = 0;
 		$this->m_TOC = [];
+	}
+
+	/**
+	 * Mark the TOC Paint as having begun
+	 */
+	public function beginTocPaint()
+	{
+		$this->tocTocPaintBegun = true;
 	}
 
 	public function TOCpagebreak(
@@ -283,6 +299,25 @@ class TableOfContents
 
 	public function insertTOC()
 	{
+		/*
+		 * Fix the TOC page numbering problem
+		 *
+		 * To do this, the current class is deep cloned and then the TOC functionality run. The correct page
+		 * numbers are calculated when the TOC pages are moved into position in the cloned object (see Mpdf::MovePages).
+		 * It's then a matter of copying the correct page numbers to the original object and letting the TOC functionality
+		 * run as per normal.
+		 *
+		 * See https://github.com/mpdf/mpdf/issues/642
+		 */
+		if (!$this->tocTocPaintBegun) {
+			$copier = new DeepCopy(true);
+			$tocClassClone = $copier->copy($this);
+			$tocClassClone->beginTocPaint();
+			$tocClassClone->insertTOC();
+			$this->_toc = $tocClassClone->_toc;
+			$this->mpdf->PageNumSubstitutions = $tocClassClone->mpdf->PageNumSubstitutions;
+		}
+
 		$notocs = 0;
 		if ($this->TOCmark) {
 			$notocs = 1;
@@ -540,6 +575,13 @@ class TableOfContents
 		if ($extrapage) {
 			unset($this->mpdf->pages[count($this->mpdf->pages)]);
 			$this->mpdf->page--; // Reset page pointer
+		}
+
+		/* Fix the over adjustment of the TOC and Page Substitutions values */
+		if (isset($tocClassClone)) {
+			$this->_toc = $tocClassClone->_toc;
+			$this->mpdf->PageNumSubstitutions = $tocClassClone->mpdf->PageNumSubstitutions;
+			unset($tocClassClone);
 		}
 	}
 

--- a/tests/Mpdf/TocNumbering.php
+++ b/tests/Mpdf/TocNumbering.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Mpdf;
+
+class TocNumbering extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var \Mpdf\Mpdf
+	 */
+	private $mpdf;
+
+	protected function setUp()
+	{
+		$this->mpdf = new Mpdf();
+	}
+
+	public function testTocPageNumbering()
+	{
+		$this->mpdf->setCompression(false);
+		$this->mpdf->h2toc = array('H1' => 0, 'H2' => 1);
+
+		$this->mpdf->WriteHTML('
+			<style>
+				@page {
+				footer: html_myFooter;
+				}
+			</style>
+			
+			<htmlpagefooter name="myFooter">
+				Page {PAGENO} / {nbpg}
+			</htmlpagefooter>
+			
+			My intro page
+			
+			<pagebreak />
+			
+			<tocpagebreak links="on" toc-resetpagenum="0" />
+			
+			<h1>Heading 1</h1>
+			
+			<h2>Heading 2</h2>
+			
+			<h2>Heading 2</h2>
+			
+			<h2>Heading 2</h2>
+			
+			<pagebreak />
+			
+			<h1>Heading 1</h1>
+			');
+
+		$this->mpdf->Close();
+
+		$this->assertNotFalse(strpos($this->mpdf->pages[2], $this->getPattern(3)));
+	}
+
+	/**
+	 * Test the page numbering is correct when using multiple TOC fields
+	 */
+	public function testTocMultiPageNumbering()
+	{
+		$this->mpdf->setCompression(false);
+		$markup = str_repeat('
+		<h1><tocentry content="Heading 1" name="first" />Heading 1</h1>
+		<h2><tocentry content="Heading 2" name="first" level="1" />Heading 2</h2>
+		
+		<h3><tocentry content="Heading 3" name="first" level="2" />Heading 3</h3>
+		
+		<h4><tocentry content="Heading 4" name="first" level="3" />Heading 4</h4>
+		
+		<pagebreak />
+		
+		<h1><tocentry content="Alternate 1" name="second" />Alternate 1</h1>
+		<h2><tocentry content="Alternate 2" name="second" level="1" />Alternate 2</h2>
+		
+		<h3><tocentry content="Alternate 3" name="second" level="2" />Alternate 3</h3>
+		
+		<h4><tocentry content="Alternate 4" name="second" level="3" />Alternate 4</h4>
+		
+		<pagebreak />
+		
+		<h1><tocentry content="Final 1" name="third" />Final 1</h1>
+		<h2><tocentry content="Final 2" name="third" level="1" />Final 2</h2>
+		
+		<h3><tocentry content="Final 3" name="third" level="2" />Final 3</h3>
+		
+		<h4><tocentry content="Final 4" name="third" level="3" />Final 4</h4>', 5);
+
+		$this->mpdf->WriteHTML('
+		<style>
+		@page {
+			footer: html_myFooter;
+		}
+		</style>
+		
+		<htmlpagefooter name="myFooter">
+			Page {PAGENO} / {nbpg}
+		</htmlpagefooter>
+		
+		<tocpagebreak links="on" name="first" />
+		
+		This is a page after the TOC
+		
+		<pagebreak />
+		
+		This is another page 
+		
+		<pagebreak />
+		
+		<tocpagebreak links="on" name="second" />
+		
+		<h1>Test</h1>
+		Another empty page
+		
+		<tocpagebreak links="on" name="third" />' . $markup);
+
+		$this->mpdf->Close();
+
+		$this->assertNotFalse(strpos($this->mpdf->pages[1], $this->getPattern(7)));
+		$this->assertNotFalse(strpos($this->mpdf->pages[4], $this->getPattern(8)));
+		$this->assertNotFalse(strpos($this->mpdf->pages[6], $this->getPattern(9)));
+	}
+
+	public function testTocAlternateSymbols()
+	{
+		$this->mpdf->setCompression(false);
+		$markup = str_repeat('
+		<h1><tocentry content="Heading 1" name="first" />Heading 1</h1>
+		<h2><tocentry content="Heading 2" name="first" level="1" />Heading 2</h2>
+		
+		<h3><tocentry content="Heading 3" name="first" level="2" />Heading 3</h3>
+		
+		<h4><tocentry content="Heading 4" name="first" level="3" />Heading 4</h4>
+		
+		<pagebreak />
+		
+		<h1><tocentry content="Alternate 1" name="second" />Alternate 1</h1>
+		<h2><tocentry content="Alternate 2" name="second" level="1" />Alternate 2</h2>
+		
+		<h3><tocentry content="Alternate 3" name="second" level="2" />Alternate 3</h3>
+		
+		<h4><tocentry content="Alternate 4" name="second" level="3" />Alternate 4</h4>
+		
+		<pagebreak />
+		
+		<h1><tocentry content="Final 1" name="third" />Final 1</h1>
+		<h2><tocentry content="Final 2" name="third" level="1" />Final 2</h2>
+		
+		<h3><tocentry content="Final 3" name="third" level="2" />Final 3</h3>
+		
+		<h4><tocentry content="Final 4" name="third" level="3" />Final 4</h4>', 5);
+
+		$this->mpdf->WriteHTML('
+		<style>
+		@page {
+			footer: html_myFooter;
+		}
+		</style>
+		
+		<htmlpagefooter name="myFooter">
+			Page {PAGENO} / {nbpg}
+		</htmlpagefooter>
+		
+		<tocpagebreak links="on" name="first" pagenumstyle="A" />
+		
+		This is a page after the TOC
+		
+		<pagebreak />
+		
+		This is another page 
+		
+		<pagebreak />
+		
+		<tocpagebreak links="on" name="second" pagenumstyle="i" />
+		
+		<h1>Test</h1>
+		Another empty page
+		
+		<tocpagebreak links="on" name="third" pagenumstyle="I" />' . $markup);
+
+		$this->mpdf->Close();
+
+		$this->assertNotFalse(
+			strpos(
+				$this->mpdf->pages[1],
+				$this->getPattern('VII', 'q 0.000 0.000 0.000 rg  0 Tr BT 540.165 784.480 Td  (%s) Tj ET Q')
+			)
+		);
+
+		$this->assertNotFalse(
+			strpos(
+				$this->mpdf->pages[4],
+				$this->getPattern('VIII', 'q 0.000 0.000 0.000 rg  0 Tr BT 537.250 784.480 Td  (%s) Tj ET Q')
+			)
+		);
+
+		$this->assertNotFalse(
+			strpos(
+				$this->mpdf->pages[6],
+				$this->getPattern('IX', 'q 0.000 0.000 0.000 rg  0 Tr BT 543.069 784.480 Td  (%s) Tj ET Q')
+			)
+		);
+	}
+
+	protected function getPattern(
+		$pageNumber,
+		$pattern = 'q 0.000 0.000 0.000 rg  0 Tr BT 546.468 784.480 Td  (%s) Tj ET Q'
+	) {
+		$pageNumber = $this->mpdf->_escape(
+			$this->mpdf->UTF8ToUTF16BE($pageNumber, false)
+		);
+
+		return sprintf(
+			$pattern,
+			$pageNumber
+		);
+	}
+
+}


### PR DESCRIPTION
This was an interesting problem to fix. The TOC page links always pointed to the correct location, but the page numbers themselves were wrong. 

To fix this issue the current Mpdf class is deep cloned using the well-tested `myclabs/deep-copy` library (98% test coverage and 30.44M downloads). Once cloned, the TOC functionality is executed before the normal TOC processes run. The correct TOC Page Numbers and Page Substitution data is calculated when the TOC pages are moved into position in the cloned object (see `Mpdf::MovePages`) and this information is copied back into the original object so it can generate the correct TOC mark-up. At the end of this process, the TOC Page Numbers and Page Substitution data are reset as `Mpdf::MovePages` has offset this data. The cloned object is then destroyed. 

I explored other ways to fix this issue besides deep cloning the object. For example, after moving the pages into place I attempted to update the page numbers in the buffer. This lead to wonky positioning where the page was previously shown with a single digit, and was changed to double digits (and vise-versa). I also looked at removing the added TOC pages and then running the process again. Sadly `Mpdf::DeletePages` is full of bugs (it's never actually used anywhere in the project, so I can see why that's the case). 

Along with my unit tests, I verified the `example14_page_numbers_ToC_Index_Bookmarks.php` PDF generated as expected. The Index is dynamically generated in this file, but if you hardcode the generated output from those loops the page numbering still functions as expected. 

I didn't see a need for any further getter/setter functionality for `TableOfContents::tocTocPaintBegun`, as it's only enabled on the cloned object (which then gets destroyed after use). 

Resolves #642