### PR TITLE
Avoid a Notice in BlockTag

### DIFF
--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -173,7 +173,8 @@ abstract class BlockTag extends Tag
 				$decToAlpha = new DecToAlpha();
 				$decToRoman = new DecToRoman();
 
-				switch (isset($this->mpdf->listtype[$this->mpdf->listlvl]) ? $this->mpdf->listtype[$this->mpdf->listlvl] : "") {
+				$listType = isset($this->mpdf->listtype[$this->mpdf->listlvl]) ? $this->mpdf->listtype[$this->mpdf->listlvl] : '';
+				switch ($listType) {
 					case 'upper-alpha':
 					case 'upper-latin':
 					case 'A':

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -173,7 +173,7 @@ abstract class BlockTag extends Tag
 				$decToAlpha = new DecToAlpha();
 				$decToRoman = new DecToRoman();
 
-				switch ($this->mpdf->listtype[$this->mpdf->listlvl]) {
+				switch (isset($this->mpdf->listtype[$this->mpdf->listlvl]) ? $this->mpdf->listtype[$this->mpdf->listlvl] : "") {
 					case 'upper-alpha':
 					case 'upper-latin':
 					case 'A':


### PR DESCRIPTION
Currently getting Notice: Undefined offset: 1 in /mpdf/mpdf/src/Tag/BlockTag.php on line 174 in v 7.0.3 when I have a plain unstyled list inside a table. Doesn't always happen but in my tests it looks like it happens if I've got two items in the list. $this->mpdf->listtype comes in empty, thus causing the notice.