### PR TITLE
The orientation key is overwrite

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1611,7 +1611,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 
 			$format = PageFormat::getSizeFromName($format);
-			$orientation = $pfo;
+			if (empty($orientation)) {
+				$orientation = $pfo;
+			}
 
 			$this->fwPt = $format[0];
 			$this->fhPt = $format[1];


### PR DESCRIPTION
Use the two options:
```
$mpdf = new \Mpdf\Mpdf(['format' => 'A4', 'orientation' => 'L']);
$mpdf->WriteHTML('<h1>Hello world!</h1>');
$mpdf->Output();
```

```
$mpdf = new \Mpdf\Mpdf(['format' => 'A4-L']);
$mpdf->WriteHTML('<h1>Hello world!</h1>');
$mpdf->Output();
```