### PR TITLE
Fix incorrect left padding issue on tag following float

### DIFF
--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -545,8 +545,8 @@ abstract class BlockTag extends Tag
 			list($l_exists, $r_exists, $l_max, $r_max, $l_width, $r_width) = $this->mpdf->GetFloatDivInfo($this->mpdf->blklvl - 1);
 			$maxw = $container_w - $l_width - $r_width;
 
-			$pdl = is_int($pdl) ? $pdl : 0;
-			$pdr = is_int($pdr) ? $pdr : 0;
+			$pdl = is_numeric($pdl) ? $pdl : 0;
+			$pdr = is_numeric($pdr) ? $pdr : 0;
 
 			$doubleCharWidth = (2 * $this->mpdf->GetCharWidth('W', false));
 			if (($setwidth + $currblk['margin_left'] + $currblk['margin_right'] + $bdl + $pdl + $bdr + $pdr) > $maxw

--- a/tests/Issues/Issue730Test.php
+++ b/tests/Issues/Issue730Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Issues;
+
+class Issue730Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testIncorrectLeftPaddingAfterFloat()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			.label {
+				float: left;
+				width: 25%;
+			}
+			
+			.value {
+				margin-left: 35%;
+				background: #EEE;
+				padding: 2mm;
+			}
+		</style>
+		
+		<div class="label">Label</div>
+		<div class="value">Value</div>
+		');
+
+		$this->assertRegExp('/q 0.000 g  0 Tr BT 226.773 780.129 Td/', $this->mpdf->pages[1]);
+	}
+
+}


### PR DESCRIPTION
The return value of `$currblk['padding_left']` can be an integer or a float. Since `is_int` only checks for integers the values that were floats were getting set to 0. Changing it to `is_numeric` covers both integers and floats and brings it inline with the type checking done on lines 739 and 740 of the same file.

Resolves #730