### PR TITLE
Only apply auto height if a header/footer has been enabled

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -11792,6 +11792,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	// mPDF 6
 	function _setAutoHeaderHeight(&$htmlh)
 	{
+		/* When the setAutoTopMargin option is set to pad/stretch, only apply auto header height when a header exists */
+		if ($this->HTMLHeader === '' && $this->HTMLHeaderE === '') {
+			return;
+		}
+
 		if ($this->setAutoTopMargin == 'pad') {
 			if (isset($htmlh['h']) && $htmlh['h']) {
 				$h = $htmlh['h'];
@@ -11814,6 +11819,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	// mPDF 6
 	function _setAutoFooterHeight(&$htmlf)
 	{
+		/* When the setAutoTopMargin option is set to pad/stretch, only apply auto footer height when a footer exists */
+		if ($this->HTMLFooter === '' && $this->HTMLFooterE === '') {
+			return;
+		}
+
 		if ($this->setAutoBottomMargin == 'pad') {
 			if (isset($htmlf['h']) && $htmlf['h']) {
 				$h = $htmlf['h'];

--- a/tests/Issues/Issue732Test.php
+++ b/tests/Issues/Issue732Test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Issues;
+
+class Issue732Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->mpdf->setAutoTopMargin = 'stretch';
+		$this->mpdf->setAutoBottomMargin = 'stretch';
+	}
+
+	public function testAutoHeaderFooterOnPagesThatHaveThem()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin: 0;             
+			}
+			
+			@page :first {
+				header: html_Header;
+				footer: html_Footer;
+			}
+		</style>
+		
+		<htmlpageheader name="Header">
+			Header
+		</htmlpageheader>
+		
+		<htmlpagefooter name="Footer">
+			Footer
+		</htmlpagefooter>
+		
+		First page content		
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(9.0, $this->mpdf->tMargin);
+		$this->assertSame(9.0, $this->mpdf->bMargin);
+	}
+
+	public function testAutoHeaderFooterOnPagesThatDontThem()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin: 0;             
+			}
+		</style>
+		
+		First page content		
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(0.0, $this->mpdf->tMargin);
+		$this->assertSame(0.0, $this->mpdf->bMargin);
+	}
+
+}


### PR DESCRIPTION
This prevents excess margins on the top and bottom of pages that do not have any Header / Footer set.

See notes on #732 for reasoning behind why this is a bug and not a feature. 