### PR TITLE
Write Unit Tests for LanguageToFont Class

### DIFF
--- a/src/Language/LanguageToFont.php
+++ b/src/Language/LanguageToFont.php
@@ -269,7 +269,7 @@ class LanguageToFont implements \Mpdf\Language\LanguageToFontInterface
 			case 'bih': // Bihari (Bhojpuri, Magahi, and Maithili)
 			case 'sa':
 			case 'san': // Sanskrit
-							$unifont = 'freeserif';
+				$unifont = 'freeserif';
 				break;
 			case 'gu':
 			case 'guj': // Gujarati
@@ -316,7 +316,7 @@ class LanguageToFont implements \Mpdf\Language\LanguageToFontInterface
 			case 'sd':
 			case 'snd': // Sindhi
 				$unifont = 'lateef';
-				if ($country === 'IN') {
+				if ($country === 'in') {
 					$unifont = 'freeserif';
 				}
 				break;
@@ -401,7 +401,7 @@ class LanguageToFont implements \Mpdf\Language\LanguageToFontInterface
 				$unifont = 'sun-exta';
 				if ($adobeCJK) {
 					$unifont = 'gb';
-					if ($country === 'HK' || $country === 'TW') {
+					if ($country === 'hk' || $country === 'tw') {
 						$unifont = 'big5';
 					}
 				}
@@ -444,14 +444,14 @@ class LanguageToFont implements \Mpdf\Language\LanguageToFontInterface
 
 			/* Undetermined language - script used */
 			case 'und':
-				$unifont = self::fontByScript($script, $adobeCJK);
+				$unifont = $this->fontByScript($script, $adobeCJK);
 				break;
 		}
 
 		return [$coreSuitable, $unifont];
 	}
 
-	private static function fontByScript($script, $adobeCJK)
+	protected function fontByScript($script, $adobeCJK)
 	{
 		switch ($script) {
 			/* European */

--- a/tests/Mpdf/Language/LanguageToFontTest.php
+++ b/tests/Mpdf/Language/LanguageToFontTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mpdf\Language;
+
+class LanguageToFontTest extends \PHPUnit_Framework_TestCase
+{
+	public function testExtendedImplimentation()
+	{
+		$language = new LanguageToFontTestImplimentation();
+		$impliments = class_implements($language);
+
+		$this->assertArrayHasKey('Mpdf\Language\LanguageToFontInterface', $impliments);
+	}
+
+	/**
+	 * @param string $llcc The language string being passed in
+	 * @param boolean $adobeCJK The adobeCJK value
+	 * @param boolean $coreSuitable The coreSuitable value
+	 * @param string $returnedFont The expected font being returned
+	 *
+	 * @dataProvider providerOverrideFont
+	 */
+	public function testOverrideFont($llcc, $adobeCJK, $coreSuitable, $returnedFont)
+	{
+		$language = new LanguageToFontTestImplimentation();
+
+		$results = $language->getLanguageOptions($llcc, $adobeCJK);
+		$this->assertEquals($coreSuitable, $results[0]);
+		$this->assertEquals($returnedFont, $results[1]);
+	}
+
+	public function providerOverrideFont()
+	{
+		return [
+			['fake', false, false, 'fake-font'],
+			['und-fake', false, false, 'fake-font-script'],
+			['en', false, true, ''],
+			['und-latn', false, false, 'dejavusanscondensed'],
+			['und-latn', false, false, 'dejavusanscondensed'],
+			['zh', false, false, 'sun-exta'],
+			['zh', true, false, 'gb'],
+			['zh-HK', true, false, 'big5'],
+			['und-kali', false, false, 'freemono'],
+		];
+	}
+}

--- a/tests/Mpdf/Language/LanguageToFontTestImplimentation.php
+++ b/tests/Mpdf/Language/LanguageToFontTestImplimentation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mpdf\Language;
+
+class LanguageToFontTestImplimentation extends LanguageToFont
+{
+	public function getLanguageOptions($llcc, $adobeCJK)
+	{
+		if ($llcc === 'fake') {
+			return [false, 'fake-font'];
+		}
+
+		return parent::getLanguageOptions($llcc, $adobeCJK);
+	}
+
+	protected function fontByScript($script, $adobeCJK)
+	{
+		if ($script === 'fake') {
+			return 'fake-font-script';
+		}
+
+		return parent::fontByScript($script, $adobeCJK);
+	}
+}


### PR DESCRIPTION
During testing, it was found the `$country` parameter was being lowercased and the IF statements included weren't valid, as they included the country codes in uppercase.

The `fontByScript` method was also set to a protected function. This allows developers greater control over the fonts when extending the `LanguageToFont` class. By making this change, developers don't have to copy the entire `fontByScript` function to their new class. They can instead do:

```php
<?php
class CustomLanguageToFontImplementation extends \Mpdf\Language\LanguageToFont
{

	protected function fontByScript($script, $adobeCJK)
	{
		if ($script === 'latn') {
			return 'freeserif';
		}

		return parent::fontByScript($script, $adobeCJK);
	}

}

```

This change goes hand-in-hand with https://github.com/mpdf/mpdf.github.io/pull/81 and https://github.com/mpdf/mpdf.github.io/pull/82.