### PR TITLE
Ensure TOC Numbering is shown even when the 'suppress' setting is enabled

### DIFF
--- a/src/TableOfContents.php
+++ b/src/TableOfContents.php
@@ -315,7 +315,15 @@ class TableOfContents
 			$tocClassClone->beginTocPaint();
 			$tocClassClone->insertTOC();
 			$this->_toc = $tocClassClone->_toc;
-			$this->mpdf->PageNumSubstitutions = $tocClassClone->mpdf->PageNumSubstitutions;
+
+			/*
+			 * Ensure the page numbers show in the TOC when the 'suppress' setting is enabled
+			 * @see https://github.com/mpdf/mpdf/issues/777
+			 */
+			$this->mpdf->PageNumSubstitutions = array_map(function ($sub) {
+				$sub['suppress'] = '';
+				return $sub;
+			}, $tocClassClone->mpdf->PageNumSubstitutions);
 		}
 
 		$notocs = 0;

--- a/tests/Mpdf/TocNumbering.php
+++ b/tests/Mpdf/TocNumbering.php
@@ -202,6 +202,46 @@ class TocNumbering extends \PHPUnit_Framework_TestCase
 			)
 		);
 	}
+	
+	public function testTocNumberSuppression()
+	{
+		$this->mpdf->setCompression(false);
+
+		$this->mpdf->AddPageByArray([
+			'suppress' => 'on'
+		]);
+		$this->mpdf->WriteHTML('<p>TitlePage</p>');
+
+		$this->mpdf->TOCpagebreakByArray([
+			'links' => true,
+			'resetpagenum' => 3,
+			'name' => 'main',
+			'suppress' => 'off'
+		]);
+		$this->mpdf->TOC_Entry('1', 1, 'main');
+		$this->mpdf->WriteHTML("<h1>chapter 1</h1>");
+
+		$this->mpdf->AddPage();
+		$this->mpdf->TOC_Entry('1.1', 2, 'main');
+		$this->mpdf->WriteHTML("<h1>chapter 1.1</h1>");
+
+		$this->mpdf->AddPage();
+		$this->mpdf->TOC_Entry('2', 1, 'main');
+		$this->mpdf->WriteHTML("<h1>chapter 2</h1>");
+
+		$this->mpdf->AddPage();
+		$this->mpdf->TOC_Entry('3', 1, 'main');
+		$this->mpdf->WriteHTML("<h1>chapter 3</h1>");
+
+		$this->mpdf->Close();
+
+		$this->assertNotFalse(
+			strpos(
+				$this->mpdf->pages[2],
+				$this->getPattern('6', 'q 0.000 0.000 0.000 rg  0 Tr BT 546.468 741.642 Td  (%s) Tj ET Q')
+			)
+		);
+	}
 
 	protected function getPattern(
 		$pageNumber,


### PR DESCRIPTION
The 'suppress' setting is [meant for suppressing the page numbering on individual pages](http://mpdf.github.io/reference/mpdf-functions/addpagebyarray.html) and shouldn't apply to the TOC when showing page numbers. This PR ensures the 'suppress' setting is disabled when rendering the TOC. 

Resolves #777