### PR TITLE
table row that contain display:none should not be drawn

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -23481,6 +23481,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Draw Table Contents and Borders
 		for ($i = 0; $i < $numrows; $i++) { // Rows
+			//TODO: aici
+			if ($table['hide'][$i]) continue;
 			if ($split && $startrow > 0) {
 				$thnr = (isset($table['is_thead']) ? count($table['is_thead']) : 0);
 				if ($i >= $thnr && $i < $startrow) {

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -21949,7 +21949,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 			}//end of columns
 			/** set row height to 0 */
-			if ($table['hide'][$i]){
+			if (isset($table['hide']) && isset($table['hide'][$i]) && $table['hide'][$i]) {
 				$heightrow = 0;
 			}
 		}//end of rows
@@ -22208,7 +22208,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	function _tableGetMaxRowHeight($table, $row)
 	{
 		/** if row is hidden, row max height should be 0 */
-		if ($table['hide'][$row]) return 0;
+		if (isset($table['hide']) && isset($table['hide'][$row]) && $table['hide'][$row]) {
+			return 0;
+		}
 		if ($row == $table['nc'] - 1) {
 			return $table['hr'][$row];
 		}
@@ -23481,8 +23483,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Draw Table Contents and Borders
 		for ($i = 0; $i < $numrows; $i++) { // Rows
-			//TODO: aici
-			if ($table['hide'][$i]) continue;
+			if (isset($table['hide']) && isset($table['hide'][$i]) && $table['hide'][$i]) {
+				continue;
+			}
 			if ($split && $startrow > 0) {
 				$thnr = (isset($table['is_thead']) ? count($table['is_thead']) : 0);
 				if ($i >= $thnr && $i < $startrow) {

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -21948,6 +21948,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					unset($c);
 				}
 			}//end of columns
+			/** set row height to 0 */
+			if ($table['hide'][$i]){
+				$heightrow = 0;
+			}
 		}//end of rows
 
 		$heightrow = &$table['hr'];
@@ -22203,6 +22207,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	function _tableGetMaxRowHeight($table, $row)
 	{
+		/** if row is hidden, row max height should be 0 */
+		if ($table['hide'][$row]) return 0;
 		if ($row == $table['nc'] - 1) {
 			return $table['hr'][$row];
 		}

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -60,6 +60,11 @@ class Tr extends Tag
 			$this->mpdf->trow_text_rotate = $attr['TEXT-ROTATE'];
 		}
 
+		/** mark row as hidden */
+		if (isset($properties['DISPLAY']) && (strtolower($properties['DISPLAY']) === 'none')) {
+			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['hide'][$this->mpdf->row] = true;
+		}
+
 		if ($this->mpdf->tablethead) {
 			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['is_thead'][$this->mpdf->row] = true;
 		}


### PR DESCRIPTION
Added a small implementation for table rows (TR) that contain "display:none;" into the style, to be ignored when the tables are "written" / drawn .

