### PR TITLE
Fix for issue #556 - background-size: cover CSS size computation

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2387,7 +2387,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 								// and supporting both tall or wide images in relation to the area
 								$aspectImage = ($ih!=0)?($iw / $ih):1;
 								$aspectViewport = ($pb['bpa']['h']!=0)?($pb['bpa']['w'] / $pb['bpa']['h']):1;
-								if( $aspectImage <= $aspectViewport ) {
+								if ($aspectImage <= $aspectViewport) {
 									$ih = $ih * $pb['bpa']['w'] / $iw;
 									$iw = $pb['bpa']['w'];
 									if ($ih < $pb['bpa']['h']) {
@@ -2397,7 +2397,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 								} else {
 									$iw = $iw * $pb['bpa']['h'] / $ih;
 									$ih = $pb['bpa']['h'];
-									if ( $iw < $pb['bpa']['w'] ) {
+									if ($iw < $pb['bpa']['w']) {
 										$ih = $ih * $iw / $pb['bpa']['w'];
 										$iw = $pb['bpa']['w'];
 									}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2384,11 +2384,23 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 							} elseif ($size['w'] == 'cover') {
 								// Scale the image, while preserving its intrinsic aspect ratio (if any), to the smallest
 								// size such that both its width and its height can completely cover the background positioning area.
-								$ih = $ih * $pb['bpa']['w'] / $iw;
-								$iw = $pb['bpa']['w'];
-								if ($ih < $pb['bpa']['h']) {
-									$iw = $iw * $ih / $pb['bpa']['h'];
+								// and supporting both tall or wide images in relation to the area
+								$aspectImage = ($ih!=0)?($iw / $ih):1;
+								$aspectViewport = ($pb['bpa']['h']!=0)?($pb['bpa']['w'] / $pb['bpa']['h']):1;
+								if( $aspectImage <= $aspectViewport ) {
+									$ih = $ih * $pb['bpa']['w'] / $iw;
+									$iw = $pb['bpa']['w'];
+									if ($ih < $pb['bpa']['h']) {
+										$iw = $iw * $ih / $pb['bpa']['h'];
+										$ih = $pb['bpa']['h'];
+									}
+								} else {
+									$iw = $iw * $pb['bpa']['h'] / $ih;
 									$ih = $pb['bpa']['h'];
+									if ( $iw < $pb['bpa']['w'] ) {
+										$ih = $ih * $iw / $pb['bpa']['w'];
+										$iw = $pb['bpa']['w'];
+									}
 								}
 							} else {
 								if (NumericString::containsPercentChar($size['w'])) {

--- a/tests/Issues/Issue556Test.php
+++ b/tests/Issues/Issue556Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Mpdf;
+
+class Issue556Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testBackgroundCoverWide()
+	{
+		$html = '<div style="position:absolute;width:5in;height:5in;top:0;left:0;background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAUAQMAAAAgFiiUAAAABlBMVEXMzMyWlpYU2uzLAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAADElEQVQImWNgGL4AAADcAAGk2YNWAAAAAElFTkSuQmCC) center center no-repeat; background-size: cover"></div>';
+		$this->mpdf->WriteHTML($html);
+		$this->mpdf->Output('', 'S');
+	}
+
+	public function testBackgroundCoverTall()
+	{
+		$html = '<div style="position:absolute;width:5in;height:5in;top:0;left:0;background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAABQAQMAAAAjjsc0AAAABlBMVEXMzMyWlpYU2uzLAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAADUlEQVQYlWNgGAWUAAABQAABuwBcGQAAAABJRU5ErkJggg==) center center no-repeat; background-size: cover"></div>';
+		$this->mpdf->WriteHTML($html);
+		$this->mpdf->Output('', 'S');
+	}
+
+}


### PR DESCRIPTION
Computation of the image size for the background-size: cover mode always assumed a fixed aspect ratio between image and viewport (e.g. never a landscape image in a portrait viewport).  This code now looks at both image and viewport aspect ratio to compute image size.