### PR TITLE
Adds support for text-align: start and end

### DIFF
--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -75,7 +75,9 @@ abstract class Tag
 		'baseline' => 'BS',
 		'bottom' => 'B',
 		'text-bottom' => 'TB',
-		'justify' => 'J'
+		'justify' => 'J',
+		'start' => 'S',
+		'end' => 'E',
 	];
 
 	public function __construct(

--- a/src/Tag/Td.php
+++ b/src/Tag/Td.php
@@ -234,11 +234,17 @@ class Td extends Tag
 			$c['direction'] = strtolower($properties['DIRECTION']);
 		}
 
-		if (!$c['a']) {
+		if (!$c['a'] || $c['a'] == 'S') {
 			if (isset($c['direction']) && $c['direction'] === 'rtl') {
 				$c['a'] = 'R';
 			} else {
 				$c['a'] = 'L';
+			}
+		} elseif ($c['a'] == 'E') {
+			if (isset($c['direction']) && $c['direction'] === 'rtl') {
+				$c['a'] = 'L';
+			} else {
+				$c['a'] = 'R';
 			}
 		}
 


### PR DESCRIPTION
We need to produce documents in LTR as well as RTL using the same markup, and this PR adds support for: `text-align: start` and `text-align: end`