### PR TITLE
Fix for notices on line 1477 in Image/Svg.php

### DIFF
--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -1465,7 +1465,7 @@ class Svg
 			}
 			if (isset($critere_style['stroke-dasharray'])) {
 				$off = 0;
-				$d = preg_split('/[ ,]/', $critere_style['stroke-dasharray']);
+				$d = preg_split('/(,\s?|\s)/', $critere_style['stroke-dasharray']);
 				if (count($d) == 1 && $d[0] == 0) {
 					$path_style .= '[] 0 d ';
 				} else {


### PR DESCRIPTION
Split attribute values by comma, comma + whitespace or whitespace,  instead comma and whitespace in same time