### PR TITLE
Allow use of setasign/fpdi greater than 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"ext-mbstring": "*",
 
 		"psr/log": "^1.0",
-		"setasign/fpdi": "1.6.*",
+		"setasign/fpdi": "^1.6",
 		"paragonie/random_compat": "^1.4|^2.0|9.99.99",
 		"myclabs/deep-copy": "^1.7"
 


### PR DESCRIPTION
composer.json is set to require setasign/fpdi 1.6.*, this would allow it to use a minimum of 1.6 and allow newer. Needed for compatibility with PHP7