### PR TITLE
Remove timezone override, to avoid conflict when mpdf is used with other libraries

### DIFF
--- a/mpdf.php
+++ b/mpdf.php
@@ -90,12 +90,6 @@ $errorlevel = error_reporting($errorlevel & ~E_NOTICE);
 
 //error_reporting(E_ALL);
 
-if (function_exists("date_default_timezone_set")) {
-	if (ini_get("date.timezone") == "") {
-		date_default_timezone_set("Europe/London");
-	}
-}
-
 if (!function_exists('mb_strlen')) {
 	throw new MpdfException('mPDF requires mb_string functions. Ensure that mb_string extension is loaded.');
 }


### PR DESCRIPTION
As said on issues:

- https://github.com/mpdf/mpdf/issues/27
- https://github.com/mpdf/mpdf/issues/270
- https://github.com/mpdf/mpdf/issues/137

The file mpdf.php forces the timezone, we have found that this causes problems when we use this with other libraries, for example on this drupal module https://www.drupal.org/project/print overrides the timezone of the site.

