### PR TITLE
Allow the non-active form radio field color to be set with CSS

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -618,12 +618,16 @@ class Form
 			$radius = $this->mpdf->FontSize * 0.35;
 			$cx = $x + ($w / 2);
 			$cy = $y + ($h / 2);
+			$color = $this->colorConverter->convert(0, $this->mpdf->PDFAXwarnings);
+			if (isset($objattr['color']) && $objattr['color']) {
+				$color = $objattr['color'];
+			}
 			if (!empty($objattr['disabled'])) {
 				$this->mpdf->SetFColor($this->colorConverter->convert(127, $this->mpdf->PDFAXwarnings));
 				$this->mpdf->SetDColor($this->colorConverter->convert(127, $this->mpdf->PDFAXwarnings));
 			} else {
-				$this->mpdf->SetFColor($this->colorConverter->convert(0, $this->mpdf->PDFAXwarnings));
-				$this->mpdf->SetDColor($this->colorConverter->convert(0, $this->mpdf->PDFAXwarnings));
+				$this->mpdf->SetFColor($color);
+				$this->mpdf->SetDColor($color);
 			}
 			$this->mpdf->Circle($cx, $cy, $radius, 'D');
 			if (!empty($objattr['checked'])) {

--- a/tests/Issues/Issue897.php
+++ b/tests/Issues/Issue897.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Output\Destination;
+
+class Issue897Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testSetHeader()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			.radio {
+				color: green;
+			}
+		</style>
+		
+    	<input class="radio" type="radio" checked="checked"/>
+    	
+    	<pagebreak/>
+    	
+    	<input type="radio" checked="checked"/>
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertRegexp('/0.000 0.502 0.000 rg/', $this->mpdf->pages[1]);
+		$this->assertRegexp('/0.000 0.502 0.000 RG/', $this->mpdf->pages[1]);
+
+		$this->assertNotRegexp('/0.000 0.502 0.000 rg/', $this->mpdf->pages[2]);
+		$this->assertNotRegexp('/0.000 0.502 0.000 RG/', $this->mpdf->pages[2]);
+	}
+
+}


### PR DESCRIPTION
The non-active checkbox field is more difficult to control via CSS due to it making use of two colours: a white square and a black cross. Because of this, I've only focused on the radio field.