### PR TITLE
chore(WriteHTML): Make WriteHTML use const instead of magic numbers

### DIFF
--- a/src/HTMLParserMode.php
+++ b/src/HTMLParserMode.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mpdf;
+
+class HTMLParserMode
+{
+	/**
+	 * Parses a whole $html document
+	 */
+	const DEFAULT_MODE = 0;
+
+	/**
+	 * Parses the $html as styles and stylesheets only
+	 */
+	const HEADER_CSS = 1;
+
+	/**
+	 * Parses the $html as output elements only
+	 */
+	const HTML_BODY = 2;
+
+	/**
+	 * (For internal use only - parses the $html code without writing to document)
+	 *
+	 * @internal
+	 */
+	const HTML_PARSE_NO_WRITE = 3;
+
+	/**
+	 * (For internal use only - writes the $html code to a buffer)
+	 *
+	 * @internal
+	 */
+	const HTML_HEADER_BUFFER = 4;
+
+	public static function getAllModes()
+	{
+		return [
+			self::DEFAULT_MODE,
+			self::HEADER_CSS,
+			self::HTML_BODY,
+			self::HTML_PARSE_NO_WRITE,
+			self::HTML_HEADER_BUFFER,
+		];
+	}
+}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -9550,7 +9550,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->pageBackgrounds = [];
 
 				$this->writingHTMLheader = true;
-				$this->WriteHTML($html, 4); // parameter 4 saves output to $this->headerbuffer
+				$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 				$this->writingHTMLheader = false;
 				$this->Reset();
 				$this->pageoutput[$n] = [];
@@ -9633,7 +9633,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 				$this->writingHTMLfooter = true;
 				$this->InFooter = true;
-				$this->WriteHTML($html, 4); // parameter 4 saves output to $this->headerbuffer
+				$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 				$this->InFooter = false;
 				$this->Reset();
 				$this->pageoutput[$n] = [];
@@ -12247,7 +12247,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->HTMLheaderPageForms = [];
 		$savepb = $this->pageBackgrounds;
 		$this->writingHTMLheader = true;
-		$this->WriteHTML($html, 4); // parameter 4 saves output to $this->headerbuffer
+		$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 		$this->writingHTMLheader = false;
 		$h = ($this->y - $this->margin_header);
 		$this->Reset();
@@ -12944,24 +12944,26 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	/* -- HTML-CSS -- */
 
 	/**
-	 * HTML parser
+	 * Write HTML code to the document
+	 *
+	 * Also used internally to parse HTML into buffers
 	 *
 	 * @param string $html
-	 * @param int $sub 0 = default;
-	 *                 1 = headerCSS only
-	 *                 2 = HTML body (parts) only;
-	 *                 3 = HTML parses only
-	 *                 4 = writes HTML headers/Fixed pos DIVs - stores in buffer - for single page only
-	 * @param bool $init Clears and sets buffers to Top level block etc.
-	 * @param bool $close If false leaves buffers etc. in current state, so that it can continue a block etc.
+	 * @param int    $mode  Use HTMLParserMode constants. Controls what parts of the $html code is parsed.
+	 * @param bool   $init  Clears and sets buffers to Top level block etc.
+	 * @param bool   $close If false leaves buffers etc. in current state, so that it can continue a block etc.
 	 */
-	function WriteHTML($html, $sub = 0, $init = true, $close = true)
+	function WriteHTML($html, $mode = HTMLParserMode::DEFAULT_MODE, $init = true, $close = true)
 	{
 		/* Check $html is an integer, float, string, boolean or class with __toString(), otherwise throw exception */
 		if (is_scalar($html) === false) {
 			if (!is_object($html) || ! method_exists($html, '__toString')) {
 				throw new \Mpdf\MpdfException('WriteHTML() requires $html be an integer, float, string, boolean or an object with the __toString() magic method.');
 			}
+		}
+
+		if (in_array($mode, HTMLParserMode::getAllModes(), true) === false) {
+			throw new \Mpdf\MpdfException('WriteHTML() requires $mode to be one of the modes defined in HTMLParserMode');
 		}
 
 		/* Cast $html as a string */
@@ -12974,15 +12976,15 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$this->textbuffer = [];
 			$this->fixedPosBlockSave = [];
 		}
-		if ($sub == 1) {
+		if ($mode === HTMLParserMode::HEADER_CSS) {
 			$html = '<style> ' . $html . ' </style>';
 		} // stylesheet only
 
 		if ($this->allow_charset_conversion) {
-			if ($sub < 1) {
+			if ($mode === HTMLParserMode::DEFAULT_MODE) {
 				$this->ReadCharset($html);
 			}
-			if ($this->charset_in && $sub != 4) {
+			if ($this->charset_in && $mode !== HTMLParserMode::HTML_HEADER_BUFFER) {
 				$success = iconv($this->charset_in, 'UTF-8//TRANSLIT', $html);
 				if ($success) {
 					$html = $success;
@@ -13002,7 +13004,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		$zproperties = [];
-		if ($sub < 2) {
+		if ($mode === HTMLParserMode::DEFAULT_MODE || $mode === HTMLParserMode::HEADER_CSS) {
 			$this->ReadMetaTags($html);
 
 			if (preg_match('/<base[^>]*href=["\']([^"\'>]*)["\']/i', $html, $m)) {
@@ -13054,7 +13056,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		$this->blk[0]['InlineProperties'] = $this->saveInlineProperties();
 
-		if ($sub == 1) {
+		if ($mode === HTMLParserMode::HEADER_CSS) {
 			return '';
 		}
 		if (!isset($this->cssManager->CSS['BODY'])) {
@@ -13100,7 +13102,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		$parseonly = false;
 		$this->bufferoutput = false;
-		if ($sub == 3) {
+		if ($mode == HTMLParserMode::HTML_PARSE_NO_WRITE) {
 			$parseonly = true;
 			// Close any open block tags
 			$arr = [];
@@ -13113,7 +13115,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->printbuffer($this->textbuffer);
 			}
 			$this->textbuffer = [];
-		} elseif ($sub == 4) {
+		} elseif ($mode === HTMLParserMode::HTML_HEADER_BUFFER) {
 			// Close any open block tags
 			$arr = [];
 			$ai = 0;
@@ -13157,7 +13159,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$html = preg_replace('/<htmlpageheader.*?<\/htmlpageheader>/si', '', $html);
 		$html = preg_replace('/<htmlpagefooter.*?<\/htmlpagefooter>/si', '', $html);
 
-		if ($this->state == 0 && $sub != 1 && $sub != 3 && $sub != 4) {
+		if ($this->state == 0 && ($mode === HTMLParserMode::DEFAULT_MODE || $mode === HTMLParserMode::HTML_BODY)) {
 			$this->AddPage($this->CurOrientation);
 		}
 
@@ -14191,7 +14193,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->pageBackgrounds = [];
 				$this->maxPosR = 0;
 				$this->maxPosL = $this->w; // For RTL
-				$this->WriteHTML($html, 4);
+				$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 				$inner_w = $this->maxPosR - $this->lMargin;
 				if ($bbox_right_auto) {
 					$bbox_right = $cont_w - $bbox_left - $bbox_ml - $bbox_bl - $bbox_pl - $inner_w - $bbox_pr - $bbox_br - $bbox_ml;
@@ -14221,7 +14223,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->HTMLheaderPageAnnots = [];
 				$this->HTMLheaderPageForms = [];
 				$this->pageBackgrounds = [];
-				$this->WriteHTML($html, 4);
+				$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 				$inner_h = $this->y - $y;
 
 				if ($overflow != 'hidden' && $overflow != 'visible') { // constrained
@@ -14280,7 +14282,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		$this->pageBackgrounds = [];
 
-		$this->WriteHTML($html, 4); // parameter 4 saves output to $this->headerbuffer
+		$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 
 		$actual_h = $this->y - $y;
 		$use_w = $w;
@@ -14322,7 +14324,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$this->HTMLheaderPageAnnots = [];
 					$this->HTMLheaderPageForms = [];
 					$this->pageBackgrounds = [];
-					$this->WriteHTML($html, 4); // parameter 4 saves output to $this->headerbuffer
+					$this->WriteHTML($html, HTMLParserMode::HTML_HEADER_BUFFER);
 					$actual_h = $this->y - $y;
 					$ratio = $actual_h / $use_w;
 				}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -12962,8 +12962,15 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 		}
 
+		// Check the mode is valid
 		if (in_array($mode, HTMLParserMode::getAllModes(), true) === false) {
-			throw new \Mpdf\MpdfException('WriteHTML() requires $mode to be one of the modes defined in HTMLParserMode');
+			// We only throw an exception if it's in debug
+			if ($this->debug === true) {
+				throw new \Mpdf\MpdfException('WriteHTML() requires $mode to be one of the modes defined in HTMLParserMode');
+			}
+
+			// If it's not an accepted mode, set it to the default mode
+			$mode = HTMLParserMode::DEFAULT_MODE;
 		}
 
 		/* Cast $html as a string */

--- a/tests/Mpdf/WriteHtmlTest.php
+++ b/tests/Mpdf/WriteHtmlTest.php
@@ -57,4 +57,45 @@ class WriteHtmlTest extends \PHPUnit_Framework_TestCase
 		];
 	}
 
+	/**
+	 * Verify that unaccepted modes throw exceptions
+	 *
+	 * @dataProvider unacceptedModes
+	 */
+	public function testItThrowsOnUnacceptableMode($mode)
+	{
+		$this->expectException(MpdfException::class);
+		$this->expectExceptionMessageRegExp('/HTMLParserMode/');
+
+		$this->mpdf->WriteHTML('test', $mode);
+	}
+
+	public function unacceptedModes()
+	{
+		return [
+			[''],
+			[-1],
+			['0'],
+		];
+	}
+
+	/**
+	 * @dataProvider acceptableModes
+	 */
+	public function testAcceptableModesDoNotThrow($mode)
+	{
+		$this->mpdf->WriteHTML('test', $mode);
+
+		$this->addToAssertionCount(1); // This prevents any complaints that the test did not actually test anything
+	}
+
+	public function acceptableModes()
+	{
+		return array_map(
+			function ($mode) {
+				return [$mode];
+			},
+			HTMLParserMode::getAllModes()
+		);
+	}
 }

--- a/tests/Mpdf/WriteHtmlTest.php
+++ b/tests/Mpdf/WriteHtmlTest.php
@@ -58,12 +58,26 @@ class WriteHtmlTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Verify that unaccepted modes throw exceptions
+	 * Verify that unaccepted modes do not throw exceptions if debug enabled
 	 *
 	 * @dataProvider unacceptedModes
 	 */
-	public function testItThrowsOnUnacceptableMode($mode)
+	public function testItThrowsOnUnacceptableModeIfDebugDisabled($mode)
 	{
+		$this->mpdf->debug = false;
+		$this->mpdf->WriteHTML('test', $mode);
+
+		$this->addToAssertionCount(1);
+	}
+
+	/**
+	 * Verify that unaccepted modes throw exceptions if debug enabled
+	 *
+	 * @dataProvider unacceptedModes
+	 */
+	public function testItThrowsOnUnacceptableModeIfDebugEnabled($mode)
+	{
+		$this->mpdf->debug = true;
 		$this->expectException(MpdfException::class);
 		$this->expectExceptionMessageRegExp('/HTMLParserMode/');
 


### PR DESCRIPTION
Hey! Thanks for this package, it works quite well.

I was pleased to see that `Destination::FILE` constants exist but was disappointed to see the same didn't exist for the magic numbers which defined the second argument to `WriteHTML()`

I specifically referred to the [external documentation](https://mpdf.github.io/reference/mpdf-functions/writehtml.html#parameters) while doing this as well:

* rename `$sub` to `$mode`, I don't know what sub was meant to mean but I don't see why it shouldn't be called `$mode`
* replace any checks that relied on the order of the constants (ie `$sub < 1) with their true meanings to aid readability
* enforced strict equality checks `===` and enforced that the mode should be one of the permitted modes
* I named the constants the best I could think of but more than happy to change that based on having a better understanding than me about what they do :D
* wrote tests to cover the enforcement of the modes

I'm happy to update docs if accepted too