### PR TITLE
chore(WriteHTML): Make WriteHTML mode checking strict [bc break]

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -12964,13 +12964,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Check the mode is valid
 		if (in_array($mode, HTMLParserMode::getAllModes(), true) === false) {
-			// We only throw an exception if it's in debug
-			if ($this->debug === true) {
-				throw new \Mpdf\MpdfException('WriteHTML() requires $mode to be one of the modes defined in HTMLParserMode');
-			}
-
-			// If it's not an accepted mode, set it to the default mode
-			$mode = HTMLParserMode::DEFAULT_MODE;
+			throw new \Mpdf\MpdfException('WriteHTML() requires $mode to be one of the modes defined in HTMLParserMode');
 		}
 
 		/* Cast $html as a string */

--- a/tests/Mpdf/WriteHtmlTest.php
+++ b/tests/Mpdf/WriteHtmlTest.php
@@ -58,7 +58,7 @@ class WriteHtmlTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Verify that unaccepted modes throw exceptions if debug enabled
+	 * Verify that unaccepted modes throw exceptions
 	 *
 	 * @dataProvider unacceptedModes
 	 */

--- a/tests/Mpdf/WriteHtmlTest.php
+++ b/tests/Mpdf/WriteHtmlTest.php
@@ -58,26 +58,12 @@ class WriteHtmlTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Verify that unaccepted modes do not throw exceptions if debug enabled
-	 *
-	 * @dataProvider unacceptedModes
-	 */
-	public function testItThrowsOnUnacceptableModeIfDebugDisabled($mode)
-	{
-		$this->mpdf->debug = false;
-		$this->mpdf->WriteHTML('test', $mode);
-
-		$this->addToAssertionCount(1);
-	}
-
-	/**
 	 * Verify that unaccepted modes throw exceptions if debug enabled
 	 *
 	 * @dataProvider unacceptedModes
 	 */
-	public function testItThrowsOnUnacceptableModeIfDebugEnabled($mode)
+	public function testItThrowsOnUnacceptableMode($mode)
 	{
-		$this->mpdf->debug = true;
 		$this->expectException(MpdfException::class);
 		$this->expectExceptionMessageRegExp('/HTMLParserMode/');
 


### PR DESCRIPTION
Per #911 - this pull request makes the mode checking more strict by always throwing exceptions, even when debug is disabled.

As discussed, this is potentially a bc issue for some people so this should target a BC break release, not sure if there's a more appropriate branch I can set as the base for this to be merged into.