### PR TITLE
Use the img_dpi setting for all images

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -8700,8 +8700,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$info = $this->imageProcessor->getImage($this->noImageFile);
 			if ($info) {
 				$file = $this->noImageFile;
-				$w = ($info['w'] * (25.4 / $this->dpi));  // 14 x 16px
-				$h = ($info['h'] * (25.4 / $this->dpi));  // 14 x 16px
+				$w = ($info['w'] * (25.4 / $this->img_dpi));  // 14 x 16px
+				$h = ($info['h'] * (25.4 / $this->img_dpi));  // 14 x 16px
 			}
 		}
 		if (!$info) {

--- a/src/Tag/Img.php
+++ b/src/Tag/Img.php
@@ -278,8 +278,8 @@ class Img extends Tag
 				$info = $this->imageProcessor->getImage($this->mpdf->noImageFile);
 				if ($info) {
 					$srcpath = $this->mpdf->noImageFile;
-					$w = ($info['w'] * (25.4 / $this->mpdf->dpi));
-					$h = ($info['h'] * (25.4 / $this->mpdf->dpi));
+					$w = ($info['w'] * (25.4 / $this->mpdf->img_dpi));
+					$h = ($info['h'] * (25.4 / $this->mpdf->img_dpi));
 				}
 			}
 			if (!$info) {

--- a/src/Tag/Input.php
+++ b/src/Tag/Input.php
@@ -220,8 +220,8 @@ class Input extends Tag
 						$info = $this->imageProcessor->getImage($this->mpdf->noImageFile);
 						if ($info) {
 							$srcpath = $this->mpdf->noImageFile;
-							$w = ($info['w'] * (25.4 / $this->mpdf->dpi));
-							$h = ($info['h'] * (25.4 / $this->mpdf->dpi));
+							$w = ($info['w'] * (25.4 / $this->mpdf->img_dpi));
+							$h = ($info['h'] * (25.4 / $this->mpdf->img_dpi));
 						}
 					}
 					if (!$info) {

--- a/src/Tag/Meter.php
+++ b/src/Tag/Meter.php
@@ -234,8 +234,8 @@ class Meter extends InlineTag
 			$info = $this->imageProcessor->getImage($this->mpdf->noImageFile);
 			if ($info) {
 				$srcpath = $this->mpdf->noImageFile;
-				$w = ($info['w'] * (25.4 / $this->mpdf->dpi));
-				$h = ($info['h'] * (25.4 / $this->mpdf->dpi));
+				$w = ($info['w'] * (25.4 / $this->mpdf->img_dpi));
+				$h = ($info['h'] * (25.4 / $this->mpdf->img_dpi));
 			}
 		}
 		if (!$info) {


### PR DESCRIPTION
Any size conversion related to images should [use the img_dpi setting](https://mpdf.github.io/reference/mpdf-variables/img-dpi.html) instead of [dpi](https://mpdf.github.io/reference/mpdf-variables/dpi.html).