### PR TITLE
Log cURL error when it occurs

### DIFF
--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -47,6 +47,11 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 		}
 
 		$data = curl_exec($ch);
+
+		if (curl_error($ch)) {
+			$this->logger->error(sprintf('cURL error: "%s"', curl_error($ch)), ['context' => LogContext::REMOTE_CONTENT]);
+		}
+
 		curl_close($ch);
 
 		return $data;


### PR DESCRIPTION
This makes it easier to debug problems with external resources