### PR TITLE
Allow custom cURL CA certificate

### DIFF
--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -506,6 +506,7 @@ class ConfigVariables
 			// cURL options
 			'curlFollowLocation' => false,
 			'curlAllowUnsafeSslRequests' => false,
+			'curlCaCertificate' => '',
 			'curlTimeout' => 5,
 		];
 	}

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -696,6 +696,17 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	var $curlFollowLocation;
 
 	/**
+	 * Set your own CA certificate store for SSL Certificate verification when using cURL
+	 *
+	 * Useful setting to use on hosts with outdated CA certificates.
+	 *
+	 * Download the latest CA certificate from https://curl.haxx.se/docs/caextract.html
+	 *
+	 * @var string The absolute path to the pem file
+	 */
+	var $curlCaCertificate;
+
+	/**
 	 * Set to true to allow unsafe SSL HTTPS requests.
 	 *
 	 * Can be useful when using CDN with HTTPS and if you don't want to configure settings with SSL certificates.

--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -46,6 +46,10 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		}
 
+		if (is_file($this->mpdf->curlCaCertificate)) {
+			curl_setopt($ch, CURLOPT_CAINFO, $this->mpdf->curlCaCertificate);
+		}
+
 		$data = curl_exec($ch);
 		curl_close($ch);
 


### PR DESCRIPTION
Set your own CA certificate store for SSL Certificate verification when using cURL. This is useful setting to use on hosts with outdated CA certificates.