### PR TITLE
Convert Font Cache from PHP to JSON Files

### DIFF
--- a/src/Fonts/FontCache.php
+++ b/src/Fonts/FontCache.php
@@ -7,6 +7,8 @@ use Mpdf\Cache;
 class FontCache
 {
 
+	private $memoryCache = [];
+
 	private $cache;
 
 	public function __construct(Cache $cache)
@@ -24,9 +26,28 @@ class FontCache
 		return $this->cache->has($filename);
 	}
 
+	public function jsonHas($filename)
+	{
+		if (isset($this->memoryCache[$filename]) || $this->has($filename)) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public function load($filename)
 	{
 		return $this->cache->load($filename);
+	}
+
+	public function jsonLoad($filename)
+	{
+		if (isset($this->memoryCache[$filename])) {
+			return $this->memoryCache[$filename];
+		}
+
+		$this->memoryCache[$filename] = json_decode($this->load($filename), true);
+		return $this->memoryCache[$filename];
 	}
 
 	public function write($filename, $data)
@@ -41,8 +62,22 @@ class FontCache
 		fclose($handle);
 	}
 
+	public function jsonWrite($filename, $data)
+	{
+		return $this->cache->write($filename, json_encode($data));
+	}
+
 	public function remove($filename)
 	{
 		return $this->cache->remove($filename);
+	}
+
+	public function jsonRemove($filename)
+	{
+		if (isset($this->memoryCache[$filename])) {
+			unset($this->memoryCache[$filename]);
+		}
+
+		$this->remove($filename);
 	}
 }

--- a/src/Fonts/MetricsGenerator.php
+++ b/src/Fonts/MetricsGenerator.php
@@ -20,146 +20,56 @@ class MetricsGenerator
 	public function generateMetrics($ttffile, $ttfstat, $fontkey, $TTCfontID, $debugfonts, $BMPonly, $useOTL, $fontUseOTL)
 	{
 		$ttf = new TTFontFile($this->fontCache, $this->fontDescriptor);
-
 		$ttf->getMetrics($ttffile, $fontkey, $TTCfontID, $debugfonts, $BMPonly, $useOTL); // mPDF 5.7.1
-		$cw = $ttf->charWidths;
 
-		$kerninfo = $ttf->kerninfo;
-
-		$haskerninfo = false;
-		if ($kerninfo) {
-			$haskerninfo = true;
-		}
-
-		$haskernGPOS = $ttf->haskernGPOS;
-		$hassmallcapsGSUB = $ttf->hassmallcapsGSUB;
-		$name = preg_replace('/[ ()]/', '', $ttf->fullName);
-		$sip = $ttf->sipset;
-		$smp = $ttf->smpset;
-		// mPDF 6
-		$GSUBScriptLang = $ttf->GSUBScriptLang;
-		$GSUBFeatures = $ttf->GSUBFeatures;
-		$GSUBLookups = $ttf->GSUBLookups;
-		$rtlPUAstr = $ttf->rtlPUAstr;
-		$GPOSScriptLang = $ttf->GPOSScriptLang;
-		$GPOSFeatures = $ttf->GPOSFeatures;
-		$GPOSLookups = $ttf->GPOSLookups;
-		$glyphIDtoUni = $ttf->glyphIDtoUni;
-
-		$desc = [
-			'CapHeight' => round($ttf->capHeight),
-			'XHeight' => round($ttf->xHeight),
-			'FontBBox' => '[' . round($ttf->bbox[0]) . " " . round($ttf->bbox[1]) . " " . round($ttf->bbox[2]) . " " . round($ttf->bbox[3]) . ']', /* FontBBox from head table */
-			/* 		'MaxWidth' => round($ttf->advanceWidthMax),	// AdvanceWidthMax from hhea table	NB ArialUnicode MS = 31990 ! */
-			'Flags' => $ttf->flags,
-			'Ascent' => round($ttf->ascent),
-			'Descent' => round($ttf->descent),
-			'Leading' => round($ttf->lineGap),
-			'ItalicAngle' => $ttf->italicAngle,
-			'StemV' => round($ttf->stemV),
-			'MissingWidth' => round($ttf->defaultWidth)
+		$font = [
+			'name' => $this->getFontName($ttf->fullName),
+			'type' => 'TTF',
+			'desc' => [
+				'CapHeight' => round($ttf->capHeight),
+				'XHeight' => round($ttf->xHeight),
+				'FontBBox' => '[' . round($ttf->bbox[0]) . " " . round($ttf->bbox[1]) . " " . round($ttf->bbox[2]) . " " . round($ttf->bbox[3]) . ']',
+				/* FontBBox from head table */
+				/* 		'MaxWidth' => round($ttf->advanceWidthMax),	// AdvanceWidthMax from hhea table	NB ArialUnicode MS = 31990 ! */
+				'Flags' => $ttf->flags,
+				'Ascent' => round($ttf->ascent),
+				'Descent' => round($ttf->descent),
+				'Leading' => round($ttf->lineGap),
+				'ItalicAngle' => $ttf->italicAngle,
+				'StemV' => round($ttf->stemV),
+				'MissingWidth' => round($ttf->defaultWidth)
+			],
+			'unitsPerEm' => round($ttf->unitsPerEm),
+			'up' => round($ttf->underlinePosition),
+			'ut' => round($ttf->underlineThickness),
+			'strp' => round($ttf->strikeoutPosition),
+			'strs' => round($ttf->strikeoutSize),
+			'ttffile' => $ttffile,
+			'TTCfontID' => $TTCfontID,
+			'originalsize' => $ttfstat['size'] + 0, /* cast ? */
+			'sip' => ($ttf->sipset) ? true : false,
+			'smp' => ($ttf->smpset) ? true : false,
+			'BMPselected' => ($BMPonly) ? true : false,
+			'fontkey' => $fontkey,
+			'panose' => $this->getPanose($ttf),
+			'haskerninfo' => ($ttf->kerninfo) ? true : false,
+			'haskernGPOS' => ($ttf->haskernGPOS) ? true : false,
+			'hassmallcapsGSUB' => ($ttf->hassmallcapsGSUB) ? true : false,
+			'fontmetrics' => $this->fontDescriptor,
+			'useOTL' => ($fontUseOTL) ? $fontUseOTL : 0,
+			'rtlPUAstr' => $ttf->rtlPUAstr,
+			'GSUBScriptLang' => $ttf->GSUBScriptLang,
+			'GSUBFeatures' => $ttf->GSUBFeatures,
+			'GSUBLookups' => $ttf->GSUBLookups,
+			'GPOSScriptLang' => $ttf->GPOSScriptLang,
+			'GPOSFeatures' => $ttf->GPOSFeatures,
+			'GPOSLookups' => $ttf->GPOSLookups,
+			'kerninfo' => $ttf->kerninfo,
 		];
-		$panose = '';
-		if (count($ttf->panose)) {
-			$panoseArray = array_merge([$ttf->sFamilyClass, $ttf->sFamilySubClass], $ttf->panose);
-			foreach ($panoseArray as $value) {
-				$panose .= ' ' . dechex($value);
-			}
-		}
-		$unitsPerEm = round($ttf->unitsPerEm);
-		$up = round($ttf->underlinePosition);
-		$ut = round($ttf->underlineThickness);
-		$strp = round($ttf->strikeoutPosition); // mPDF 6
-		$strs = round($ttf->strikeoutSize); // mPDF 6
-		$originalsize = $ttfstat['size'] + 0;
-		$type = 'TTF';
-		//Generate metrics .php file
-		$s = '<?php' . "\n";
-		$s .= '$name=\'' . $name . "';\n";
-		$s .= '$type=\'' . $type . "';\n";
-		$s .= '$desc=' . var_export($desc, true) . ";\n";
-		$s .= '$unitsPerEm=' . $unitsPerEm . ";\n";
-		$s .= '$up=' . $up . ";\n";
-		$s .= '$ut=' . $ut . ";\n";
-		$s .= '$strp=' . $strp . ";\n"; // mPDF 6
-		$s .= '$strs=' . $strs . ";\n"; // mPDF 6
-		$s .= '$ttffile=\'' . $ttffile . "';\n";
-		$s .= '$TTCfontID=\'' . $TTCfontID . "';\n";
-		$s .= '$originalsize=' . $originalsize . ";\n";
-		if ($sip) {
-			$s .= '$sip=true;' . "\n";
-		} else {
-			$s .= '$sip=false;' . "\n";
-		}
-		if ($smp) {
-			$s .= '$smp=true;' . "\n";
-		} else {
-			$s .= '$smp=false;' . "\n";
-		}
-		if ($BMPonly) {
-			$s .= '$BMPselected=true;' . "\n";
-		} else {
-			$s .= '$BMPselected=false;' . "\n";
-		}
-		$s .= '$fontkey=\'' . $fontkey . "';\n";
-		$s .= '$panose=\'' . $panose . "';\n";
-		if ($haskerninfo) {
-			$s .= '$haskerninfo=true;' . "\n";
-		} else {
-			$s .= '$haskerninfo=false;' . "\n";
-		}
-		if ($haskernGPOS) {
-			$s .= '$haskernGPOS=true;' . "\n";
-		} else {
-			$s .= '$haskernGPOS=false;' . "\n";
-		}
-		if ($hassmallcapsGSUB) {
-			$s .= '$hassmallcapsGSUB=true;' . "\n";
-		} else {
-			$s .= '$hassmallcapsGSUB=false;' . "\n";
-		}
-		$s .= '$fontmetrics=\'' . $this->fontDescriptor . "';\n"; // mPDF 6
 
-		$s .= '// TypoAscender/TypoDescender/TypoLineGap = ' . round($ttf->typoAscender) . ', ' . round($ttf->typoDescender) . ', ' . round($ttf->typoLineGap) . "\n";
-		$s .= '// usWinAscent/usWinDescent = ' . round($ttf->usWinAscent) . ', ' . round(-$ttf->usWinDescent) . "\n";
-		$s .= '// hhea Ascent/Descent/LineGap = ' . round($ttf->hheaascent) . ', ' . round($ttf->hheadescent) . ', ' . round($ttf->hhealineGap) . "\n";
-
-		//  mPDF 5.7.1
-		if ($fontUseOTL) {
-			$s .= '$useOTL=' . $fontUseOTL . ';' . "\n";
-		} else {
-			$s .= '$useOTL=0x0000;' . "\n";
-		}
-		if ($rtlPUAstr) {
-			$s .= '$rtlPUAstr=\'' . $rtlPUAstr . "';\n";
-		} else {
-			$s .= '$rtlPUAstr=\'\';' . "\n";
-		}
-		if (count($GSUBScriptLang)) {
-			$s .= '$GSUBScriptLang=' . var_export($GSUBScriptLang, true) . ";\n";
-		}
-		if (count($GSUBFeatures)) {
-			$s .= '$GSUBFeatures=' . var_export($GSUBFeatures, true) . ";\n";
-		}
-		if (count($GSUBLookups)) {
-			$s .= '$GSUBLookups=' . var_export($GSUBLookups, true) . ";\n";
-		}
-		if (count($GPOSScriptLang)) {
-			$s .= '$GPOSScriptLang=' . var_export($GPOSScriptLang, true) . ";\n";
-		}
-		if (count($GPOSFeatures)) {
-			$s .= '$GPOSFeatures=' . var_export($GPOSFeatures, true) . ";\n";
-		}
-		if (count($GPOSLookups)) {
-			$s .= '$GPOSLookups=' . var_export($GPOSLookups, true) . ";\n";
-		}
-		if ($kerninfo) {
-			$s .= '$kerninfo=' . var_export($kerninfo, true) . ";\n";
-		}
-
-		$this->fontCache->write($fontkey . '.mtx.php', $s);
-		$this->fontCache->binaryWrite($fontkey . '.cw.dat', $cw);
-		$this->fontCache->binaryWrite($fontkey . '.gid.dat', $glyphIDtoUni);
+		$this->fontCache->jsonWrite($fontkey . '.mtx.json', $font);
+		$this->fontCache->binaryWrite($fontkey . '.cw.dat', $ttf->charWidths);
+		$this->fontCache->binaryWrite($fontkey . '.gid.dat', $ttf->glyphIDtoUni);
 
 		if ($this->fontCache->has($fontkey . '.cgm')) {
 			$this->fontCache->remove($fontkey . '.cgm');
@@ -169,8 +79,8 @@ class MetricsGenerator
 			$this->fontCache->remove($fontkey . '.z');
 		}
 
-		if ($this->fontCache->has($fontkey . '.cw127.php')) {
-			$this->fontCache->remove($fontkey . '.cw127.php');
+		if ($this->fontCache->jsonHas($fontkey . '.cw127.json')) {
+			$this->fontCache->jsonRemove($fontkey . '.cw127.json');
 		}
 
 		if ($this->fontCache->has($fontkey . '.cw')) {
@@ -178,5 +88,23 @@ class MetricsGenerator
 		}
 
 		unset($ttf);
+	}
+
+	protected function getFontName($fullName)
+	{
+		return preg_replace('/[ ()]/', '', $fullName);
+	}
+
+	protected function getPanose($ttf)
+	{
+		$panose = '';
+		if (count($ttf->panose)) {
+			$panoseArray = array_merge([$ttf->sFamilyClass, $ttf->sFamilySubClass], $ttf->panose);
+			foreach ($panoseArray as $value) {
+				$panose .= ' ' . dechex($value);
+			}
+		}
+
+		return $panose;
 	}
 }

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -3785,66 +3785,66 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			throw new \Mpdf\MpdfException(sprintf('Font "%s%s%s" is not supported', $family, $style ? ' - ' : '', $style));
 		}
 
-		$name = '';
-		$cw = '';
-		$glyphIDtoUni = '';
-		$originalsize = 0;
-		$sip = false;
-		$smp = false;
-		$useOTL = 0; // mPDF 5.7.1
-		$fontmetrics = ''; // mPDF 6
-		$haskerninfo = false;
-		$haskernGPOS = false;
-		$hassmallcapsGSUB = false;
-		$BMPselected = false;
-		$GSUBScriptLang = [];
-		$GSUBFeatures = [];
-		$GSUBLookups = [];
-		$GPOSScriptLang = [];
-		$GPOSFeatures = [];
-		$GPOSLookups = [];
+		/* Setup defaults */
+		$font = [
+			'name' => '',
+			'type' => '',
+			'desc' => '',
+			'panose' => '',
+			'unitsPerEm' => '',
+			'up' => '',
+			'ut' => '',
+			'strs' => '',
+			'strp' => '',
+			'sip' => false,
+			'smp' => false,
+			'useOTL' => 0,
+			'fontmetrics' => '',
+			'haskerninfo' => false,
+			'haskernGPOS' => false,
+			'hassmallcapsGSUB' => false,
+			'BMPselected' => false,
+			'GSUBScriptLang' => [],
+			'GSUBFeatures' => [],
+			'GSUBLookups' => [],
+			'GPOSScriptLang' => [],
+			'GPOSFeatures' => [],
+			'GPOSLookups' => [],
+			'rtlPUAstr' => '',
+		];
 
-		if ($this->fontCache->has($fontkey . '.mtx.php')) {
-			require $this->fontCache->tempFilename($fontkey . '.mtx.php');
+		$fontCacheFilename = $fontkey . '.mtx.json';
+		if ($this->fontCache->jsonHas($fontCacheFilename)) {
+			$font = $this->fontCache->jsonLoad($fontCacheFilename);
 		}
 
 		$ttffile = $this->fontFileFinder->findFontFile($this->fontdata[$family][$stylekey]);
 		$ttfstat = stat($ttffile);
 
-		if (isset($this->fontdata[$family]['TTCfontID'][$stylekey])) {
-			$TTCfontID = $this->fontdata[$family]['TTCfontID'][$stylekey];
-		} else {
-			$TTCfontID = 0;
-		}
-
+		$TTCfontID = isset($this->fontdata[$family]['TTCfontID'][$stylekey]) ? isset($this->fontdata[$family]['TTCfontID'][$stylekey]) : 0;
 		$fontUseOTL = isset($this->fontdata[$family]['useOTL']) ? $this->fontdata[$family]['useOTL'] : false;
-
-		$BMPonly = false;
-		if (in_array($family, $this->BMPonly)) {
-			$BMPonly = true;
-		}
+		$BMPonly = in_array($family, $this->BMPonly) ? true : false;
 
 		$regenerate = false;
-		if ($BMPonly && !$BMPselected) {
+		if ($BMPonly && !$font['BMPselected']) {
 			$regenerate = true;
-		} elseif (!$BMPonly && $BMPselected) {
+		} elseif (!$BMPonly && $font['BMPselected']) {
 			$regenerate = true;
 		}
 
-		// mPDF 5.7.1
-		if ($fontUseOTL && $useOTL != $fontUseOTL) {
+		if ($fontUseOTL && $font['useOTL'] != $fontUseOTL) {
 			$regenerate = true;
-			$useOTL = $fontUseOTL;
-		} elseif (!$fontUseOTL && $useOTL) {
+			$font['useOTL'] = $fontUseOTL;
+		} elseif (!$fontUseOTL && $font['useOTL']) {
 			$regenerate = true;
-			$useOTL = 0;
+			$font['useOTL'] = 0;
 		}
 
-		if ($this->fontDescriptor != $fontmetrics) {
+		if ($this->fontDescriptor != $font['fontmetrics']) {
 			$regenerate = true;
 		} // mPDF 6
 
-		if (empty($name) || $originalsize != $ttfstat['size'] || $regenerate) {
+		if (empty($font['name']) || $font['originalsize'] != $ttfstat['size'] || $regenerate) {
 			$generator = new MetricsGenerator($this->fontCache, $this->fontDescriptor);
 
 			$generator->generateMetrics(
@@ -3854,11 +3854,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$TTCfontID,
 				$this->debugfonts,
 				$BMPonly,
-				$useOTL,
+				$font['useOTL'],
 				$fontUseOTL
 			);
 
-			require $this->fontCache->tempFilename($fontkey . '.mtx.php');
+			$font = $this->fontCache->jsonLoad($fontCacheFilename);
 			$cw = $this->fontCache->load($fontkey . '.cw.dat');
 			$glyphIDtoUni = $this->fontCache->load($fontkey . '.gid.dat');
 		} else {
@@ -3889,92 +3889,60 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		$i = count($this->fonts) + $this->extraFontSubsets + 1;
-		if ($sip || $smp) {
-			$this->fonts[$fontkey] = [
-				'i' => $i,
-				'type' => $type,
-				'name' => $name,
-				'desc' => $desc,
-				'panose' => $panose,
-				'unitsPerEm' => $unitsPerEm,
-				'up' => $up,
-				'ut' => $ut,
-				'strs' => $strs,
-				'strp' => $strp,
-				'cw' => $cw,
-				'ttffile' => $ttffile,
-				'fontkey' => $fontkey,
-				'subsets' => [0 => range(0, 127)],
-				'subsetfontids' => [$i],
-				'used' => false,
-				'sip' => $sip,
-				'sipext' => $sipext,
-				'smp' => $smp,
-				'TTCfontID' => $TTCfontID,
-				'useOTL' => $fontUseOTL,
-				'useKashida' => (isset($this->fontdata[$family]['useKashida']) ? $this->fontdata[$family]['useKashida'] : false),
-				'GSUBScriptLang' => $GSUBScriptLang,
-				'GSUBFeatures' => $GSUBFeatures,
-				'GSUBLookups' => $GSUBLookups,
-				'GPOSScriptLang' => $GPOSScriptLang,
-				'GPOSFeatures' => $GPOSFeatures,
-				'GPOSLookups' => $GPOSLookups,
-				'rtlPUAstr' => $rtlPUAstr,
-				'glyphIDtoUni' => $glyphIDtoUni,
-				'haskerninfo' => $haskerninfo,
-				'haskernGPOS' => $haskernGPOS,
-				'hassmallcapsGSUB' => $hassmallcapsGSUB]; // mPDF 5.7.1	// mPDF 6
+
+		$this->fonts[$fontkey] = [
+			'i' => $i,
+			'name' => $font['name'],
+			'type' => $font['type'],
+			'desc' => $font['desc'],
+			'panose' => $font['panose'],
+			'unitsPerEm' => $font['unitsPerEm'],
+			'up' => $font['up'],
+			'ut' => $font['ut'],
+			'strs' => $font['strs'],
+			'strp' => $font['strp'],
+			'cw' => $cw,
+			'ttffile' => $ttffile,
+			'fontkey' => $fontkey,
+			'used' => false,
+			'sip' => $font['sip'],
+			'sipext' => $sipext,
+			'smp' => $font['smp'],
+			'TTCfontID' => $TTCfontID,
+			'useOTL' => $fontUseOTL,
+			'useKashida' => (isset($this->fontdata[$family]['useKashida']) ? $this->fontdata[$family]['useKashida'] : false),
+			'GSUBScriptLang' => $font['GSUBScriptLang'],
+			'GSUBFeatures' => $font['GSUBFeatures'],
+			'GSUBLookups' => $font['GSUBLookups'],
+			'GPOSScriptLang' => $font['GPOSScriptLang'],
+			'GPOSFeatures' => $font['GPOSFeatures'],
+			'GPOSLookups' => $font['GPOSLookups'],
+			'rtlPUAstr' => $font['rtlPUAstr'],
+			'glyphIDtoUni' => $glyphIDtoUni,
+			'haskerninfo' => $font['haskerninfo'],
+			'haskernGPOS' => $font['haskernGPOS'],
+			'hassmallcapsGSUB' => $font['hassmallcapsGSUB'],
+		];
+
+
+		if (!$font['sip'] && !$font['smp']) {
+			$subsetRange = range(32, 127);
+			$this->fonts[$fontkey]['subset'] = array_combine($subsetRange, $subsetRange);
 		} else {
-			$ss = [];
-			for ($s = 32; $s < 128; $s++) {
-				$ss[$s] = $s;
-			}
-			$this->fonts[$fontkey] = [
-				'i' => $i,
-				'type' => $type,
-				'name' => $name,
-				'desc' => $desc,
-				'panose' => $panose,
-				'unitsPerEm' => $unitsPerEm,
-				'up' => $up,
-				'ut' => $ut,
-				'strs' => $strs,
-				'strp' => $strp,
-				'cw' => $cw,
-				'ttffile' => $ttffile,
-				'fontkey' => $fontkey,
-				'subset' => $ss,
-				'used' => false,
-				'sip' => $sip,
-				'sipext' => $sipext,
-				'smp' => $smp,
-				'TTCfontID' => $TTCfontID,
-				'useOTL' => $fontUseOTL,
-				'useKashida' => (isset($this->fontdata[$family]['useKashida']) ? $this->fontdata[$family]['useKashida'] : false),
-				'GSUBScriptLang' => $GSUBScriptLang,
-				'GSUBFeatures' => $GSUBFeatures,
-				'GSUBLookups' => $GSUBLookups,
-				'GPOSScriptLang' => $GPOSScriptLang,
-				'GPOSFeatures' => $GPOSFeatures,
-				'GPOSLookups' => $GPOSLookups,
-				'rtlPUAstr' => $rtlPUAstr,
-				'glyphIDtoUni' => $glyphIDtoUni,
-				'haskerninfo' => $haskerninfo,
-				'haskernGPOS' => $haskernGPOS,
-				'hassmallcapsGSUB' => $hassmallcapsGSUB
-			];
+			$this->fonts[$fontkey]['subsets'] = [0 => range(0, 127)];
+			$this->fonts[$fontkey]['subsetfontids'] = [$i];
 		}
 
-		if ($haskerninfo) {
-			$this->fonts[$fontkey]['kerninfo'] = $kerninfo;
+		if ($font['haskerninfo']) {
+			$this->fonts[$fontkey]['kerninfo'] = $font['kerninfo'];
 		}
 
 		$this->FontFiles[$fontkey] = [
-			'length1' => $originalsize,
+			'length1' => $font['originalsize'],
 			'type' => 'TTF',
 			'ttffile' => $ttffile,
-			'sip' => $sip,
-			'smp' => $smp
+			'sip' => $font['sip'],
+			'smp' => $font['smp'],
 		];
 
 		unset($cw);

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -137,17 +137,19 @@ class Otl
 		//==============================
 		$this->fontkey = $this->mpdf->CurrentFont['fontkey'];
 		$this->glyphIDtoUni = $this->mpdf->CurrentFont['glyphIDtoUni'];
-		if (!isset($this->GDEFdata[$this->fontkey])) {
-			include $this->fontCache->tempFilename($this->fontkey . '.GDEFdata.php');
-			$this->GSUB_offset = $this->GDEFdata[$this->fontkey]['GSUB_offset'] = $GSUB_offset;
-			$this->GPOS_offset = $this->GDEFdata[$this->fontkey]['GPOS_offset'] = $GPOS_offset;
-			$this->GSUB_length = $this->GDEFdata[$this->fontkey]['GSUB_length'] = $GSUB_length;
-			$this->MarkAttachmentType = $this->GDEFdata[$this->fontkey]['MarkAttachmentType'] = $MarkAttachmentType;
-			$this->MarkGlyphSets = $this->GDEFdata[$this->fontkey]['MarkGlyphSets'] = $MarkGlyphSets;
-			$this->GlyphClassMarks = $this->GDEFdata[$this->fontkey]['GlyphClassMarks'] = $GlyphClassMarks;
-			$this->GlyphClassLigatures = $this->GDEFdata[$this->fontkey]['GlyphClassLigatures'] = $GlyphClassLigatures;
-			$this->GlyphClassComponents = $this->GDEFdata[$this->fontkey]['GlyphClassComponents'] = $GlyphClassComponents;
-			$this->GlyphClassBases = $this->GDEFdata[$this->fontkey]['GlyphClassBases'] = $GlyphClassBases;
+		$fontCacheFilename = $this->fontkey . '.GDEFdata.json';
+		if (!isset($this->GDEFdata[$this->fontkey]) && $this->fontCache->jsonHas($fontCacheFilename)) {
+			$font = $this->fontCache->jsonLoad($fontCacheFilename);
+
+			$this->GSUB_offset = $this->GDEFdata[$this->fontkey]['GSUB_offset'] = $font['GSUB_offset'];
+			$this->GPOS_offset = $this->GDEFdata[$this->fontkey]['GPOS_offset'] = $font['GPOS_offset'];
+			$this->GSUB_length = $this->GDEFdata[$this->fontkey]['GSUB_length'] = $font['GSUB_length'];
+			$this->MarkAttachmentType = $this->GDEFdata[$this->fontkey]['MarkAttachmentType'] = $font['MarkAttachmentType'];
+			$this->MarkGlyphSets = $this->GDEFdata[$this->fontkey]['MarkGlyphSets'] = $font['MarkGlyphSets'];
+			$this->GlyphClassMarks = $this->GDEFdata[$this->fontkey]['GlyphClassMarks'] = $font['GlyphClassMarks'];
+			$this->GlyphClassLigatures = $this->GDEFdata[$this->fontkey]['GlyphClassLigatures'] = $font['GlyphClassLigatures'];
+			$this->GlyphClassComponents = $this->GDEFdata[$this->fontkey]['GlyphClassComponents'] = $font['GlyphClassComponents'];
+			$this->GlyphClassBases = $this->GDEFdata[$this->fontkey]['GlyphClassBases'] = $font['GlyphClassBases'];
 		} else {
 			$this->GSUB_offset = $this->GDEFdata[$this->fontkey]['GSUB_offset'];
 			$this->GPOS_offset = $this->GDEFdata[$this->fontkey]['GPOS_offset'];
@@ -366,16 +368,18 @@ class Otl
 				$this->GSUBfont = $this->fontkey . '.GSUB.' . $GSUBscriptTag . '.' . $GSUBlangsys;
 
 				if (!isset($this->GSUBdata[$this->GSUBfont])) {
-					if ($this->fontCache->has($this->mpdf->CurrentFont['fontkey'] . '.GSUB.' . $GSUBscriptTag . '.' . $GSUBlangsys . '.php')) {
-						include $this->fontCache->tempFilename($this->mpdf->CurrentFont['fontkey'] . '.GSUB.' . $GSUBscriptTag . '.' . $GSUBlangsys . '.php');
-						$this->GSUBdata[$this->GSUBfont]['rtlSUB'] = $rtlSUB;
-						$this->GSUBdata[$this->GSUBfont]['finals'] = $finals;
+					$fontCacheFilename = $this->GSUBfont . '.json';
+					if ($this->fontCache->jsonHas($fontCacheFilename)) {
+						$font = $this->fontCache->jsonLoad($fontCacheFilename);
+
+						$this->GSUBdata[$this->GSUBfont]['rtlSUB'] = $font['rtlSUB'];
+						$this->GSUBdata[$this->GSUBfont]['finals'] = $font['finals'];
 						if ($this->shaper == 'I') {
-							$this->GSUBdata[$this->GSUBfont]['rphf'] = $rphf;
-							$this->GSUBdata[$this->GSUBfont]['half'] = $half;
-							$this->GSUBdata[$this->GSUBfont]['pref'] = $pref;
-							$this->GSUBdata[$this->GSUBfont]['blwf'] = $blwf;
-							$this->GSUBdata[$this->GSUBfont]['pstf'] = $pstf;
+							$this->GSUBdata[$this->GSUBfont]['rphf'] = $font['rphf'];
+							$this->GSUBdata[$this->GSUBfont]['half'] = $font['half'];
+							$this->GSUBdata[$this->GSUBfont]['pref'] = $font['pref'];
+							$this->GSUBdata[$this->GSUBfont]['blwf'] = $font['blwf'];
+							$this->GSUBdata[$this->GSUBfont]['pstf'] = $font['pstf'];
 						}
 					} else {
 						$this->GSUBdata[$this->GSUBfont] = ['rtlSUB' => [], 'rphf' => [], 'rphf' => [],
@@ -384,9 +388,9 @@ class Otl
 					}
 				}
 
-				if (!isset($this->GSUBdata[$this->fontkey])) {
-					include $this->fontCache->tempFilename($this->fontkey . '.GSUBdata.php');
-					$this->GSLuCoverage = $this->GSUBdata[$this->fontkey]['GSLuCoverage'] = $GSLuCoverage;
+				$fontCacheFilename = $this->fontkey . '.GSUBdata.json';
+				if (!isset($this->GSUBdata[$this->fontkey]) && $this->fontCache->jsonHas($fontCacheFilename)) {
+					$this->GSLuCoverage = $this->GSUBdata[$this->fontkey]['GSLuCoverage'] = $this->fontCache->jsonLoad($fontCacheFilename);
 				} else {
 					$this->GSLuCoverage = $this->GSUBdata[$this->fontkey]['GSLuCoverage'];
 				}
@@ -1022,9 +1026,9 @@ class Otl
 
 				// 6. Load GPOS data, Coverage & Lookups
 				//=================================================================
-				if (!isset($this->GPOSdata[$this->fontkey])) {
-					include $this->fontCache->tempFilename($this->mpdf->CurrentFont['fontkey'] . '.GPOSdata.php');
-					$this->LuCoverage = $this->GPOSdata[$this->fontkey]['LuCoverage'] = $LuCoverage;
+				$fontCacheFilename = $this->mpdf->CurrentFont['fontkey'] . '.GPOSdata.json';
+				if (!isset($this->GPOSdata[$this->fontkey]) && $this->fontCache->jsonHas($fontCacheFilename)) {
+					$this->LuCoverage = $this->GPOSdata[$this->fontkey]['LuCoverage'] = $this->fontCache->jsonLoad($fontCacheFilename);
 				} else {
 					$this->LuCoverage = $this->GPOSdata[$this->fontkey]['LuCoverage'];
 				}

--- a/tests/Mpdf/AddFontTest.php
+++ b/tests/Mpdf/AddFontTest.php
@@ -31,4 +31,111 @@ class AddFontTest extends \PHPUnit_Framework_TestCase
 		$this->mpdf->AddFont('font');
 	}
 
+	public function testDejavuSerifCondensed()
+	{
+		$ttf = $this->mpdf->FontFiles['dejavuserifcondensed'];
+		$this->assertEquals(334040, $ttf['length1']);
+		$this->assertSame('TTF', $ttf['type']);
+		$this->assertFalse($ttf['sip']);
+		$this->assertFalse($ttf['smp']);
+
+		$ttf = $this->mpdf->fonts['dejavuserifcondensed'];
+		$this->assertEquals(729, $ttf['desc']['CapHeight']);
+		$this->assertEquals(519, $ttf['desc']['XHeight']);
+		$this->assertSame('[-693 -347 1512 1109]', $ttf['desc']['FontBBox']);
+		$this->assertSame(' 0 0 2 6 6 6 5 6 5 2 2 4', $ttf['panose']);
+		$this->assertEquals(2048, $ttf['unitsPerEm']);
+		$this->assertEquals(-63, $ttf['up']);
+		$this->assertEquals(44, $ttf['ut']);
+		$this->assertEquals(50, $ttf['strs']);
+		$this->assertEquals(259, $ttf['strp']);
+		$this->assertFalse($ttf['used']);
+		$this->assertFalse($ttf['sip']);
+		$this->assertSame('', $ttf['sipext']);
+		$this->assertFalse($ttf['smp']);
+		$this->assertFalse($ttf['useOTL']);
+		$this->assertEquals(0, $ttf['TTCfontID']);
+		$this->assertFalse($ttf['useKashida']);
+		$this->assertCount(0, $ttf['GSUBScriptLang']);
+		$this->assertCount(0, $ttf['GSUBFeatures']);
+		$this->assertCount(0, $ttf['GSUBLookups']);
+		$this->assertCount(0, $ttf['GPOSScriptLang']);
+		$this->assertCount(0, $ttf['GPOSFeatures']);
+		$this->assertCount(0, $ttf['GPOSLookups']);
+		$this->assertSame('', $ttf['rtlPUAstr']);
+		$this->assertSame('', $ttf['glyphIDtoUni']);
+		$this->assertTrue($ttf['haskerninfo']);
+		$this->assertFalse($ttf['haskernGPOS']);
+		$this->assertFalse($ttf['hassmallcapsGSUB']);
+		$this->assertCount(96, $ttf['subset']);
+		$this->assertCount(103, $ttf['kerninfo']);
+	}
+
+	public function testFontWithoutCache()
+	{
+		$this->ttfAssertions($this->mpdf->fonts['dejavuserifcondensed']);
+	}
+
+	public function testFontCache()
+	{
+		/* Preloading the font cache */
+		$fontName = 'dejavusanscondensed';
+		$this->mpdf->AddFont($fontName);
+
+		$this->mpdf = new Mpdf();
+		$this->mpdf->AddFont($fontName);
+
+		$this->ttfAssertions($this->mpdf->fonts[$fontName]);
+	}
+
+	protected function ttfAssertions($ttf)
+	{
+		$this->assertTrue(is_numeric($ttf['i']));
+		$this->assertTrue(is_string($ttf['name']));
+		$this->assertTrue(is_string($ttf['type']));
+
+		$this->assertCount(10, $ttf['desc']);
+		$this->assertTrue(is_numeric($ttf['desc']['CapHeight']));
+		$this->assertTrue(is_numeric($ttf['desc']['XHeight']));
+		$this->assertTrue(is_string($ttf['desc']['FontBBox']));
+		$this->assertTrue(is_numeric($ttf['desc']['Flags']));
+		$this->assertTrue(is_numeric($ttf['desc']['Ascent']));
+		$this->assertTrue(is_numeric($ttf['desc']['Descent']));
+		$this->assertTrue(is_numeric($ttf['desc']['Leading']));
+		$this->assertTrue(is_numeric($ttf['desc']['ItalicAngle']));
+		$this->assertTrue(is_numeric($ttf['desc']['StemV']));
+		$this->assertTrue(is_numeric($ttf['desc']['MissingWidth']));
+
+		$this->assertTrue(is_string($ttf['panose']));
+		$this->assertTrue(is_numeric($ttf['unitsPerEm']));
+		$this->assertTrue(is_numeric($ttf['up']));
+		$this->assertTrue(is_numeric($ttf['ut']));
+		$this->assertTrue(is_numeric($ttf['strs']));
+		$this->assertTrue(is_numeric($ttf['strp']));
+		$this->assertArrayHasKey('cw', $ttf);
+		$this->assertFileExists($ttf['ttffile']);
+		$this->assertTrue(is_string($ttf['fontkey']));
+		$this->assertTrue(is_bool($ttf['used']));
+		$this->assertTrue(is_bool($ttf['sip']));
+		$this->assertTrue(is_string($ttf['sipext']));
+		$this->assertTrue(is_bool($ttf['smp']));
+
+		$this->assertTrue(is_numeric($ttf['TTCfontID']));
+		$this->assertTrue(is_numeric($ttf['useOTL']) || $ttf['useOTL'] === false);
+		$this->assertTrue(is_numeric($ttf['useKashida']) || $ttf['useKashida'] === false);
+		$this->assertTrue(is_array($ttf['GSUBScriptLang']));
+		$this->assertTrue(is_array($ttf['GSUBFeatures']));
+		$this->assertTrue(is_array($ttf['GSUBLookups']));
+		$this->assertTrue(is_array($ttf['GPOSScriptLang']));
+		$this->assertTrue(is_array($ttf['GPOSFeatures']));
+		$this->assertTrue(is_array($ttf['GPOSLookups']));
+		$this->assertTrue(is_string($ttf['rtlPUAstr']));
+		$this->assertTrue(is_string($ttf['glyphIDtoUni']));
+		$this->assertTrue(is_bool($ttf['haskerninfo']));
+		$this->assertTrue(is_bool($ttf['haskernGPOS']));
+		$this->assertTrue(is_bool($ttf['hassmallcapsGSUB']));
+		$this->assertTrue(is_array($ttf['subset']));
+		$this->assertTrue(is_array($ttf['kerninfo']));
+	}
+
 }

--- a/tests/Mpdf/Fonts/FontCacheTest.php
+++ b/tests/Mpdf/Fonts/FontCacheTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mpdf\Fonts;
+
+use Mpdf\Mpdf;
+use Mpdf\Cache;
+
+class FontCacheTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var \Mpdf\Mpdf
+	 */
+	private $mpdf;
+
+	/**
+	 * @var \Mpdf\Fonts\FontCache
+	 */
+	private $fontCache;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->mpdf = new Mpdf();
+		$this->fontCache = new FontCache(new Cache($this->mpdf->tempDir . '/ttfontdata'));
+	}
+
+	public function testJson()
+	{
+		$filename = 'jsonCallTest.json';
+		$this->fontCache->jsonWrite($filename, 'Output Text');
+		$this->assertEquals('Output Text', $this->fontCache->jsonLoad($filename));
+
+		/* Test loading from the in-memory cache now the file is loaded */
+		$this->fontCache->remove($filename);
+		$this->assertFalse($this->fontCache->has($filename));
+		$this->assertTrue($this->fontCache->jsonHas($filename));
+		$this->assertEquals('Output Text', $this->fontCache->jsonLoad($filename));
+
+		/* Test the deletion of the JSON cache */
+		$this->fontCache->write($filename, '');
+		$this->assertTrue($this->fontCache->has($filename));
+		$this->fontCache->jsonRemove($filename);
+		$this->assertFalse($this->fontCache->jsonHas($filename));
+	}
+}

--- a/tests/Mpdf/Fonts/MetricsGeneratorTest.php
+++ b/tests/Mpdf/Fonts/MetricsGeneratorTest.php
@@ -27,12 +27,15 @@ class MetricsGeneratorTest extends \PHPUnit_Framework_TestCase
 
 	public function testGenerateMetrics()
 	{
-		$this->fontCache->shouldReceive('write')->with('angerthas.mtx.php', Mockery::any())->once();
+		$this->fontCache->shouldReceive('jsonWrite')->with('angerthas.mtx.json', Mockery::any())->once();
 		$this->fontCache->shouldReceive('binaryWrite')->with('angerthas.cw.dat', Mockery::any())->once();
 		$this->fontCache->shouldReceive('binaryWrite')->with('angerthas.gid.dat', Mockery::any())->once();
 
-		$this->fontCache->shouldReceive('has')->times(4)->andReturn(true);
-		$this->fontCache->shouldReceive('remove')->times(4);
+		$this->fontCache->shouldReceive('has')->times(3)->andReturn(true);
+		$this->fontCache->shouldReceive('remove')->times(3);
+
+		$this->fontCache->shouldReceive('jsonHas')->times(1)->andReturn(true);
+		$this->fontCache->shouldReceive('jsonRemove')->times(1);
 
 		$file = __DIR__ . '/../../data/ttf/angerthas.ttf';
 		$this->generator->generateMetrics($file, stat($file), 'angerthas', 0, false, false, false, false);


### PR DESCRIPTION
This PR standardised the font cache. Instead of crudely generating PHP files with font data, it stores the information in JSON files. 

JSON cache files has a number of benefits:

1. The code to generate the files is much smaller. 
1. The data doesn't need to be escaped
1. It is easier to test and modify
1. More compatible on shared hosting with security that limit the dynamic creation of PHP files

**Backwards Compatibility**
This is fully backwards compatible. There is a one-time font cache refresh to generate the new JSON files, then it's business as usual. The font cache doesn't need flushing before hand.

I tested this PR against the Mpdf Example folder and found no visual regressions. 

**Benchmarks**
By forgoing the PHP cache, we lose OPCaching on these files, but I've kept the JSON cache performant none-the-less and there's little change in performance. 

Average (5 runs) for all [Mpdf Example Templates](https://github.com/mpdf/mpdf-examples/) using the CLI:
* PHP Cache: 147.839
* JSON Cache: 148.221

Difference: 0.26%

Average (5 runs) for [Example 61](https://github.com/mpdf/mpdf-examples/blob/development/example61_new_mPDF_v6-0_features.php) in the browser with OPCache Enabled:
* PHP Cache: 21.036661
* JSON Cache: 21.271170

Difference: 1.11%

**Bugs**
A few PHP notices were fixed during this revision. See `src/TTFontFile.php` and `utils/font_dump.php`. Note: I noticed all the other scripts in `utils` no longer work and need to be refined (or removed).
