### PR TITLE
fix Warning: A non-numeric value encountered in svg

### DIFF
--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -1369,10 +1369,10 @@ class Svg
 		else if (strtolower($critere_style['fill']) == 'currentcolor' && $element != 'line') {
 			$col = $this->colorConverter->convert($critere_style['color'], $this->mpdf->PDFAXwarnings);
 			if ($col) {
-				if ($col{0} == 5) {
+				if ($col{0} == 5 && is_numeric($col{4})) {
 					$critere_style['fill-opacity'] = ord($col{4} / 100);
 				} // RGBa
-				if ($col{0} == 6) {
+				if ($col{0} == 6 && is_numeric($col{5})) {
 					$critere_style['fill-opacity'] = ord($col{5} / 100);
 				} // CMYKa
 				$path_style .= $this->mpdf->SetFColor($col, true) . ' ';
@@ -1381,10 +1381,10 @@ class Svg
 		} else if ($critere_style['fill'] != 'none' && $element != 'line') {
 			$col = $this->colorConverter->convert($critere_style['fill'], $this->mpdf->PDFAXwarnings);
 			if ($col) {
-				if ($col{0} == 5) {
+				if ($col{0} == 5 && is_numeric($col{4})) {
 					$critere_style['fill-opacity'] = ord($col{4} / 100);
 				} // RGBa
-				if ($col{0} == 6) {
+				if ($col{0} == 6 && is_numeric($col{5})) {
 					$critere_style['fill-opacity'] = ord($col{5} / 100);
 				} // CMYKa
 				$path_style .= $this->mpdf->SetFColor($col, true) . ' ';
@@ -1410,10 +1410,10 @@ class Svg
 		else if (strtolower($critere_style['stroke']) == 'currentcolor') {
 			$col = $this->colorConverter->convert($critere_style['color'], $this->mpdf->PDFAXwarnings);
 			if ($col) {
-				if ($col{0} == 5) {
+				if ($col{0} == 5 && is_numeric($col{4})) {
 					$critere_style['stroke-opacity'] = ord($col{4} / 100);
 				} // RGBa
-				if ($col{0} == 6) {
+				if ($col{0} == 6 && is_numeric($col{5})) {
 					$critere_style['stroke-opacity'] = ord($col{5} / 100);
 				} // CMYKa
 				$path_style .= $this->mpdf->SetDColor($col, true) . ' ';
@@ -1426,10 +1426,10 @@ class Svg
 			if ($col) {
 				// mPDF 5.0.051
 				// mPDF 5.3.74
-				if ($col{0} == 5) {
+				if ($col{0} == 5 && is_numeric($col{4})) {
 					$critere_style['stroke-opacity'] = ord($col{4} / 100);
 				} // RGBa
-				if ($col{0} == 6) {
+				if ($col{0} == 6 && is_numeric($col{5})) {
 					$critere_style['stroke-opacity'] = ord($col{5} / 100);
 				} // CMYKa
 				$path_style .= $this->mpdf->SetDColor($col, true) . ' ';


### PR DESCRIPTION
added validation before the division operation

when sending an image of the higchart for pdf export the rgba conversion (192,192,192,0,0.001) of the stroke attribute in the function> colorConverter-> convert returns "." causing division error in PHP 7.2