### PR TITLE
Change the Wildcard Version Range (.*) to Caret Version Range (^) in the package setasign/fpdi

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"ext-mbstring": "*",
 
 		"psr/log": "^1.0",
-		"setasign/fpdi": "1.6.*",
+		"setasign/fpdi": "^1.6",
 		"paragonie/random_compat": "^1.4|^2.0|9.99.99",
 		"myclabs/deep-copy": "^1.7"
 


### PR DESCRIPTION
The package setasign/fpdi as Wildcard Version Range (.*) on 1.6.* is blocking other packages like tig-nl/postnl-magento2, so I changed to Caret Version Range (^) ^1.6

https://github.com/tig-nl/postnl-magento2/blob/v1.7.3/composer.json