### PR TITLE
Update package setasign/fpdi to ^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"ext-mbstring": "*",
 
 		"psr/log": "^1.0",
-		"setasign/fpdi": "1.6.*",
+		"setasign/fpdi": "^2.1",
 		"paragonie/random_compat": "^1.4|^2.0|9.99.99",
 		"myclabs/deep-copy": "^1.7"
 


### PR DESCRIPTION
@finwe 

I'm working in a project which uses the packages "mpdf/mpdf" and "tig-nl/postnl-magento2"

I was trying to update the package "tig-nl/postnl-magento2" to the version 1.7.3 but I couldn't because this package is using the package "setasign/fpdi-fpdf": "2.1", which uses the "setasign/fpdi": "^2.1"

I'm not being able to do this update because "mpdf/mpdf" uses "setasign/fpdi": "1.6.*"

Let me know if I was clear and it makes sense to you.

I don't know if it'll be possible to update the package "setasign/fpdi" in "mpdf/mpdf" without breaking anything.

If it won't be possible I'll try to find other solution on my side.