### PR TITLE
Handle CSS fractions without a leading zero in font-size, like .5cm

### DIFF
--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -1051,13 +1051,6 @@ class CssManager
 			}
 		}
 
-		// Fix fractional sizes without leading zeros
-		foreach ($newprop as $k => $v) {
-			if (preg_match('/^\.[0-9]+[a-z%]*$/', $v)) {
-				$newprop[$k] = '0' . $v;
-			}
-		}
-
 		return $newprop;
 	}
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -1051,6 +1051,13 @@ class CssManager
 			}
 		}
 
+		// Fix fractional sizes without leading zeros
+		foreach ($newprop as $k => $v) {
+			if (preg_match('/^\.[0-9]+[a-z%]*$/', $v)) {
+				$newprop[$k] = '0' . $v;
+			}
+		}
+
 		return $newprop;
 	}
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -17942,7 +17942,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		// Set font size first so that e.g. MARGIN 0.83em works on font size for this element
 		if (isset($arrayaux['FONT-SIZE'])) {
 			$v = $arrayaux['FONT-SIZE'];
-			if (is_numeric($v[0])) {
+			if (is_numeric($v[0]) || ($v[0] === '.')) {
 				if ($type == 'BLOCK' && $this->blklvl > 0 && isset($this->blk[$this->blklvl - 1]['InlineProperties']) && isset($this->blk[$this->blklvl - 1]['InlineProperties']['size'])) {
 					$mmsize = $this->sizeConverter->convert($v, $this->blk[$this->blklvl - 1]['InlineProperties']['size']);
 				} elseif ($type == 'TABLECELL') {

--- a/tests/Issues/Issue761Test.php
+++ b/tests/Issues/Issue761Test.php
@@ -5,7 +5,7 @@ namespace Issues;
 class Issue761Test extends \Mpdf\BaseMpdfTest
 {
 
-	public function testSizeWithoutLeadingZero()
+	public function testFontSizeWithoutLeadingZero()
 	{
 		$this->mpdf->WriteHTML('<div style="font-size: .8cm">This text shall be big</div>');
 		$this->mpdf->Close();

--- a/tests/Issues/Issue761Test.php
+++ b/tests/Issues/Issue761Test.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Issues;
+
+class Issue761Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testSizeWithoutLeadingZero()
+	{
+		$this->mpdf->WriteHTML('<div style="font-size: .8cm">This text shall be big</div>');
+		$this->mpdf->Close();
+		$this->assertContains('/F1 22.677 Tf', $this->mpdf->pages[1]);
+	}
+
+}


### PR DESCRIPTION
Resolves #761