### PR TITLE
Fix #860: correctly initialize cell width for nested tables

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -19174,7 +19174,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$c['padding']['L'] /= $k;
 
 					$c['maxs'] = isset($c['maxs']) ? $c['maxs'] /= $k : 0;
-					$c['w'] = isset($c['w']) ? $c['w'] /= $k : 0;
+					$c['w'] = isset($c['w']) ? $c['w'] /= $k : null;
 
 					$c['s'] = isset($c['s']) ? $c['s'] /= $k : 0;
 					$c['h'] = isset($c['h']) ? $c['h'] /= $k : 0;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -19173,19 +19173,19 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$c['padding']['B'] /= $k;
 					$c['padding']['L'] /= $k;
 
-					$c['maxs'] = isset($c['maxs']) ? $c['maxs'] /= $k : 0;
+					$c['maxs'] = isset($c['maxs']) ? $c['maxs'] /= $k : null;
 					$c['w'] = isset($c['w']) ? $c['w'] /= $k : null;
 
 					$c['s'] = isset($c['s']) ? $c['s'] /= $k : 0;
-					$c['h'] = isset($c['h']) ? $c['h'] /= $k : 0;
+					$c['h'] = isset($c['h']) ? $c['h'] /= $k : null;
 
 					$c['miw'] = isset($c['miw']) ? $c['miw'] /= $k : 0;
 					$c['maw'] = isset($c['maw']) ? $c['maw'] /= $k : 0;
 
-					$c['absmiw'] = isset($c['absmiw']) ? $c['absmiw'] /= $k : 0;
+					$c['absmiw'] = isset($c['absmiw']) ? $c['absmiw'] /= $k : null;
 
-					$c['nestedmaw'] = isset($c['nestedmaw']) ? $c['nestedmaw'] /= $k : 0;
-					$c['nestedmiw'] = isset($c['nestedmiw']) ? $c['nestedmiw'] /= $k : 0;
+					$c['nestedmaw'] = isset($c['nestedmaw']) ? $c['nestedmaw'] /= $k : null;
+					$c['nestedmiw'] = isset($c['nestedmiw']) ? $c['nestedmiw'] /= $k : null;
 
 					if (isset($c['textbuffer'])) {
 						foreach ($c['textbuffer'] as $n => $tb) {


### PR DESCRIPTION
Fix issue introduced in https://github.com/mpdf/mpdf/commit/6cb5ddcaed56d0da49dea54d8245b01854f7faab by avoiding setting the cell width to 0 if it was undefined.

Using `null` instead of putting back the `if (isset(..)) { .. }` construct to avoid future confusion.