### PR TITLE
Compound classes selector support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ mPDF 8.0.x
 * Allowed image stream whitelist to be customised (#1005, thanks @jakejackson)
 * Fixed parsing of top-left-bottom-right CSS rules with !important (#1009)
 * Fixed skipping ordered list numbering with page-break-inside: avoid (#339)
+* Compound classes selector support, like `.one.two` or `div.message.special` (#538, @peterdevpl)
 
 mPDF 8.0.0
 ===========================

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -357,7 +357,9 @@ class CssManager
 							$tag = '';
 
 							if (preg_match('/^[.](.*)$/', $t, $m)) {
-								$tag = 'CLASS>>' . $m[1];
+								$classes = explode('.', $m[1]);
+								sort($classes);
+								$tag = 'CLASS>>' . join('.', $classes);
 							} elseif (preg_match('/^[#](.*)$/', $t, $m)) {
 								$tag = 'ID>>' . $m[1];
 							} elseif (preg_match('/^\[LANG=[\'\"]{0,1}([A-Z\-]{2,11})[\'\"]{0,1}\]$/', $t, $m)) {
@@ -365,7 +367,9 @@ class CssManager
 							} elseif (preg_match('/^:LANG\([\'\"]{0,1}([A-Z\-]{2,11})[\'\"]{0,1}\)$/', $t, $m)) { // mPDF 6  Special case for lang as attribute selector
 								$tag = 'LANG>>' . strtolower($m[1]);
 							} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')[.](.*)$/', $t, $m)) { // mPDF 6  Special case for lang as attribute selector
-								$tag = $m[1] . '>>CLASS>>' . $m[2];
+								$classes = explode('.', $m[2]);
+								sort($classes);
+								$tag = $m[1] . '>>CLASS>>' . join('.', $classes);
 							} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')\s*:NTH-CHILD\((.*)\)$/', $t, $m)) {
 								$tag = $m[1] . '>>SELECTORNTHCHILD>>' . $m[2];
 							} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')[#](.*)$/', $t, $m)) {
@@ -402,7 +406,9 @@ class CssManager
 							if ($t) {
 
 								if (preg_match('/^[.](.*)$/', $t, $m)) {
-									$tag = 'CLASS>>' . $m[1];
+									$classes = explode('.', $m[1]);
+									sort($classes);
+									$tag = 'CLASS>>' . join('.', $classes);
 								} elseif (preg_match('/^[#](.*)$/', $t, $m)) {
 									$tag = 'ID>>' . $m[1];
 								} elseif (preg_match('/^\[LANG=[\'\"]{0,1}([A-Z\-]{2,11})[\'\"]{0,1}\]$/', $t, $m)) {
@@ -410,7 +416,9 @@ class CssManager
 								} elseif (preg_match('/^:LANG\([\'\"]{0,1}([A-Z\-]{2,11})[\'\"]{0,1}\)$/', $t, $m)) { // mPDF 6  Special case for lang as attribute selector
 									$tag = 'LANG>>' . strtolower($m[1]);
 								} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')[.](.*)$/', $t, $m)) { // mPDF 6  Special case for lang as attribute selector
-									$tag = $m[1] . '>>CLASS>>' . $m[2];
+									$classes = explode('.', $m[2]);
+									sort($classes);
+									$tag = $m[1] . '>>CLASS>>' . join('.', $classes);
 								} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')\s*:NTH-CHILD\((.*)\)$/', $t, $m)) {
 									$tag = $m[1] . '>>SELECTORNTHCHILD>>' . $m[2];
 								} elseif (preg_match('/^(' . $this->mpdf->allowedCSStags . ')[#](.*)$/', $t, $m)) {
@@ -1484,7 +1492,9 @@ class CssManager
 
 		$classes = [];
 		if (isset($attr['CLASS'])) {
-			$classes = preg_split('/\s+/', $attr['CLASS']);
+			$classes = array_map(function ($combination) {
+				return join('.', $combination);
+			}, Arrays::allUniqueSortedCombinations(preg_split('/\s+/', $attr['CLASS'])));
 		}
 		if (!isset($attr['ID'])) {
 			$attr['ID'] = '';
@@ -2100,7 +2110,9 @@ class CssManager
 		$oldcascadeCSS = $this->mpdf->blk[$this->mpdf->blklvl]['cascadeCSS'];
 		$classes = [];
 		if (isset($attr['CLASS'])) {
-			$classes = preg_split('/\s+/', $attr['CLASS']);
+			$classes = array_map(function ($combination) {
+				return join('.', $combination);
+			}, Arrays::allUniqueSortedCombinations(preg_split('/\s+/', $attr['CLASS'])));
 		}
 		//===============================================
 		// DEFAULT for this TAG set in DefaultCSS

--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -17,4 +17,76 @@ class Arrays
 
 		return $default;
 	}
+
+	/**
+	 * Returns an array of all k-combinations from an input array of n elements, where k equals 1..n.
+	 * Elements will be sorted and unique in every combination.
+	 *
+	 * Example: array[one, two] will give:
+	 * [
+	 *     [one],
+	 *     [two],
+	 *     [one, two]
+	 * ]
+	 * @param array $array
+	 * @return array
+	 */
+	public static function allUniqueSortedCombinations($array)
+	{
+		$input = array_unique($array);
+		if (count($input) <= 1) {
+			return [$input];
+		}
+
+		sort($input);
+		$combinations = [];
+		foreach ($input as $value) {
+			$combinations[] = [$value];
+		}
+
+		$n = count($input);
+		for ($k = 2; $k <= $n; $k++) {
+			$combinations = array_merge($combinations, self::combinations($input, $k));
+		}
+
+		return $combinations;
+	}
+
+	/**
+	 * Returns an array of unique k-combinations from an input array.
+	 *
+	 * Example: array=[one, two, three] and k=2 will give:
+	 * [
+	 *     [one, two],
+	 *     [one, three]
+	 * ]
+	 * @param array $array
+	 * @param int $k
+	 * @return array
+	 */
+	public static function combinations($array, $k)
+	{
+		$n = count($array);
+		$combinations = [];
+		$indexes = range(0, $k - 1);
+		$maxIndexes = range($n - $k, $n - 1);
+		do {
+			$combination = [];
+			foreach ($indexes as $index) {
+				$combination[] = $array[$index];
+			}
+			$combinations[] = $combination;
+
+			$anotherCombination = false;
+			for ($i = $k - 1; $i >= 0; $i--) {
+				if ($indexes[$i] < $maxIndexes[$i]) {
+					$indexes[$i]++;
+					$anotherCombination = true;
+					break;
+				}
+			}
+		} while ($anotherCombination);
+
+		return $combinations;
+	}
 }

--- a/tests/Issues/Issue538Test.php
+++ b/tests/Issues/Issue538Test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\BaseMpdfTest;
+use Mpdf\Output\Destination;
+
+class Issue538Test extends BaseMpdfTest
+{
+	public function testCompoundClassSelector()
+	{
+		$this->mpdf->WriteHTML('
+<style>
+.one {
+    font-weight: bold;
+}
+
+.two {
+    font-style: italic;
+}
+
+.one.two {
+    color: red;
+}
+
+span.three.four {
+	color: green;
+}
+
+span.three.four.five {
+	font-weight: bold;
+}
+</style>
+
+<p class="one">First paragraph</p>
+<p class="two">Second paragraph</p>
+<p class="one two one">Third paragraph</p>
+
+<p><span class="three four">A wild fox</span> jumped over <span class="five four three">a lazy dog</span></p>
+');
+		$this->mpdf->SetCompression(false);
+		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
+
+		$this->assertContains("BT /F2 11.000 Tf ET\nq 0.000 g  0 Tr BT 42.520 785.363 Td  (First paragraph) Tj ET Q", $output);
+		$this->assertContains("BT /F3 11.000 Tf ET\nq 0.000 g  0 Tr BT 42.520 759.197 Td  (Second paragraph) Tj ET Q", $output);
+		$this->assertContains("BT /F4 11.000 Tf ET\nq 1.000 0.000 0.000 rg  0 Tr BT 42.520 732.635 Td  (Third paragraph) Tj ET Q", $output);
+
+		$this->assertContains("BT /F1 11.000 Tf ET\n" .
+			"/GS1 gs\n" .
+			"q 0.000 0.502 0.000 rg  0 Tr BT 42.520 705.867 Td  (A wild fox) Tj ET Q\n" .
+			"q 0.000 g  0 Tr BT 90.183 705.867 Td  ( jumped over ) Tj ET Q\n" .
+			"BT /F2 11.000 Tf ET\n" .
+			"q 0.000 0.502 0.000 rg  0 Tr BT 150.980 705.867 Td  (a lazy dog) Tj ET Q", $output);
+	}
+}


### PR DESCRIPTION
Examples: `.one.two`, `p.three.four.five`.

Other complex cases, like `#identifier.class` or `td:nth-child(even).special` are still not supported - they might need a lot of additional work.

Fixes mpdf#538