### PR TITLE
fix not existing array key ’s’ in _fixTableBorders

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -21334,7 +21334,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 								} else {
 									$celladj = false;
 								}
-								if ($celladj && $celladj['border_details']['L']['s'] == 1) {
+								if ($celladj && isset($celladj['border_details']['L']['s']) && $celladj['border_details']['L']['s'] == 1) {
 									$csadj = $celladj['border_details']['L']['w'];
 									$csthis = $cbord['border_details']['R']['w'];
 									// Hidden


### PR DESCRIPTION
When complex html code  contains table with mixed css and html attributes, occured error "Undefined index: s", which not exists, but rendering still working when skip this.