### PR TITLE
Performance improvements

### DIFF
--- a/data/out.php
+++ b/data/out.php
@@ -4,7 +4,7 @@ $path = '../tmp/';
 
 $tempfilename = $_REQUEST['filename'].'.pdf';
 
-if (strstr($tempfilename,'/') || strstr($tempfilename,'\\')) {
+if (false !== strpos($tempfilename, '/') || false !== strpos($tempfilename, '\\')) {
 	throw new MpdfException('Output filename can not not contain \ or /');
 }
 

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -141,8 +141,14 @@ class Barcode
 
 	private function sanitizeCode($code)
 	{
-		$code = str_replace(chr(194) . chr(160), ' ', $code); // mPDF 5.3.95  (for utf-8 encoded)
-		$code = str_replace(chr(160), ' ', $code); // mPDF 5.3.95	(for win-1252)
+		$code = str_replace(
+		    array(
+		        chr(194) . chr(160), // mPDF 5.3.95  (for utf-8 encoded)
+                chr(160) // mPDF 5.3.95	(for win-1252)
+            ),
+            ' ',
+            $code
+        );
 
 		return $code;
 	}

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -142,13 +142,13 @@ class Barcode
 	private function sanitizeCode($code)
 	{
 		$code = str_replace(
-		    array(
-		        chr(194) . chr(160), // mPDF 5.3.95  (for utf-8 encoded)
-                chr(160) // mPDF 5.3.95	(for win-1252)
-            ),
-            ' ',
-            $code
-        );
+			array(
+				chr(194) . chr(160), // mPDF 5.3.95  (for utf-8 encoded)
+				chr(160) // mPDF 5.3.95	(for win-1252)
+			),
+			' ',
+			$code
+		);
 
 		return $code;
 	}

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -141,16 +141,10 @@ class Barcode
 
 	private function sanitizeCode($code)
 	{
-		$code = str_replace(
-			array(
-				chr(194) . chr(160), // mPDF 5.3.95  (for utf-8 encoded)
-				chr(160) // mPDF 5.3.95	(for win-1252)
-			),
-			' ',
-			$code
-		);
-
-		return $code;
+		return str_replace([
+			chr(194) . chr(160), // mPDF 5.3.95  (for utf-8 encoded)
+			chr(160) // mPDF 5.3.95	(for win-1252)
+		], ' ', $code);
 	}
 
 }

--- a/src/Barcode/Imb.php
+++ b/src/Barcode/Imb.php
@@ -325,9 +325,9 @@ class Imb extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Barcode
 
 		while ($number > 0) {
 			if ($number == 0) {
-				array_push($hex, '0');
+				$hex[] = '0';
 			} else {
-				array_push($hex, strtoupper(dechex(bcmod($number, '16'))));
+				$hex[] = strtoupper(dechex(bcmod($number, '16')));
 				$number = bcdiv($number, '16', 0);
 			}
 		}

--- a/src/Barcode/Postnet.php
+++ b/src/Barcode/Postnet.php
@@ -65,8 +65,7 @@ class Postnet extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Bar
 		$bararray = ['code' => $code, 'maxw' => 0, 'maxh' => 5, 'bcode' => []];
 
 		$k = 0;
-		$code = str_replace('-', '', $code);
-		$code = str_replace(' ', '', $code);
+        $code = str_replace(array('-', ' '), '', $code);
 		$len = strlen($code);
 
 		// calculate checksum

--- a/src/Barcode/Postnet.php
+++ b/src/Barcode/Postnet.php
@@ -65,13 +65,13 @@ class Postnet extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Bar
 		$bararray = ['code' => $code, 'maxw' => 0, 'maxh' => 5, 'bcode' => []];
 
 		$k = 0;
-		$code = str_replace(array('-', ' '), '', $code);
+		$code = str_replace(['-', ' '], '', $code);
 		$len = strlen($code);
 
 		// calculate checksum
 		$sum = 0;
 		for ($i = 0; $i < $len; ++$i) {
-			$sum += (int)$code[$i];
+			$sum += (int) $code[$i];
 		}
 
 		$chkd = ($sum % 10);

--- a/src/Barcode/Postnet.php
+++ b/src/Barcode/Postnet.php
@@ -65,13 +65,13 @@ class Postnet extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Bar
 		$bararray = ['code' => $code, 'maxw' => 0, 'maxh' => 5, 'bcode' => []];
 
 		$k = 0;
-        $code = str_replace(array('-', ' '), '', $code);
+		$code = str_replace(array('-', ' '), '', $code);
 		$len = strlen($code);
 
 		// calculate checksum
 		$sum = 0;
 		for ($i = 0; $i < $len; ++$i) {
-			$sum += (int) $code[$i];
+			$sum += (int)$code[$i];
 		}
 
 		$chkd = ($sum % 10);

--- a/src/Form.php
+++ b/src/Form.php
@@ -382,7 +382,8 @@ class Form
 			} // mPDF 5.3.37
 			$data = ['VAL' => [], 'OPT' => [], 'SEL' => [],];
 			if (isset($objattr['items'])) {
-				for ($i = 0, $iMax = count($objattr['items']); $i < $iMax; $i++) {
+				$iMax = count($objattr['items']);
+				for ($i = 0; $i < $iMax; $i++) {
 					$item = $objattr['items'][$i];
 					$data['VAL'][] = (isset($item['exportValue']) ? $item['exportValue'] : '');
 					$data['OPT'][] = (isset($item['content']) ? $item['content'] : '');
@@ -813,7 +814,8 @@ class Form
 
 	function SetFormTextJS($name, $js)
 	{
-		for ($i = 0, $iMax = count($js); $i < $iMax; $i++) {
+		$iMax = count($js);
+		for ($i = 0; $i < $iMax; $i++) {
 			$j = str_replace("\t", ' ', trim($js[$i][1]));
 			$format = $js[$i][0];
 			if ($name) {
@@ -949,12 +951,14 @@ class Form
 			throw new \Mpdf\MpdfException('Field [' . $name . '] must have a name attribute, which can only contain letters, numbers, colon(:), undersore(_) or hyphen(-)');
 		}
 		if ($this->mpdf->onlyCoreFonts) {
-			for ($i = 0, $iMax = count($array['VAL']); $i < $iMax; $i++) {
+			$iMax = count($array['VAL']);
+			for ($i = 0; $i < $iMax; $i++) {
 				$array['VAL'][$i] = $this->Win1252ToPDFDocEncoding($array['VAL'][$i]);
 				$array['OPT'][$i] = $this->Win1252ToPDFDocEncoding($array['OPT'][$i]);
 			}
 		} else {
-			for ($i = 0, $iMax = count($array['VAL']); $i < $iMax; $i++) {
+			$iMax = count($array['VAL']);
+			for ($i = 0; $i < $iMax; $i++) {
 				if (isset($this->mpdf->CurrentFont['subset'])) {
 					$this->mpdf->UTF8StringToArray($array['VAL'][$i]); // Add characters to font subset
 					$this->mpdf->UTF8StringToArray($array['OPT'][$i]); // Add characters to font subset

--- a/src/Form.php
+++ b/src/Form.php
@@ -382,7 +382,7 @@ class Form
 			} // mPDF 5.3.37
 			$data = ['VAL' => [], 'OPT' => [], 'SEL' => [],];
 			if (isset($objattr['items'])) {
-				for ($i = 0; $i < count($objattr['items']); $i++) {
+				for ($i = 0, $iMax = count($objattr['items']); $i < $iMax; $i++) {
 					$item = $objattr['items'][$i];
 					$data['VAL'][] = (isset($item['exportValue']) ? $item['exportValue'] : '');
 					$data['OPT'][] = (isset($item['content']) ? $item['content'] : '');
@@ -813,7 +813,7 @@ class Form
 
 	function SetFormTextJS($name, $js)
 	{
-		for ($i = 0; $i < count($js); $i++) {
+		for ($i = 0, $iMax = count($js); $i < $iMax; $i++) {
 			$j = str_replace("\t", ' ', trim($js[$i][1]));
 			$format = $js[$i][0];
 			if ($name) {
@@ -949,12 +949,12 @@ class Form
 			throw new \Mpdf\MpdfException('Field [' . $name . '] must have a name attribute, which can only contain letters, numbers, colon(:), undersore(_) or hyphen(-)');
 		}
 		if ($this->mpdf->onlyCoreFonts) {
-			for ($i = 0; $i < count($array['VAL']); $i++) {
+			for ($i = 0, $iMax = count($array['VAL']); $i < $iMax; $i++) {
 				$array['VAL'][$i] = $this->Win1252ToPDFDocEncoding($array['VAL'][$i]);
 				$array['OPT'][$i] = $this->Win1252ToPDFDocEncoding($array['OPT'][$i]);
 			}
 		} else {
-			for ($i = 0; $i < count($array['VAL']); $i++) {
+			for ($i = 0, $iMax = count($array['VAL']); $i < $iMax; $i++) {
 				if (isset($this->mpdf->CurrentFont['subset'])) {
 					$this->mpdf->UTF8StringToArray($array['VAL'][$i]); // Add characters to font subset
 					$this->mpdf->UTF8StringToArray($array['OPT'][$i]); // Add characters to font subset

--- a/src/Gradient.php
+++ b/src/Gradient.php
@@ -51,9 +51,11 @@ class Gradient
 		$bpcd = 65535; //16 BitsPerCoordinate
 		$trans = false;
 		$this->mpdf->gradients[$n]['stream'] = '';
-		for ($i = 0, $iMax = count($patch_array); $i < $iMax; $i++) {
+		$iMax = count($patch_array);
+		for ($i = 0; $i < $iMax; $i++) {
 			$this->mpdf->gradients[$n]['stream'].=chr($patch_array[$i]['f']); //start with the edge flag as 8 bit
-			for ($j = 0, $jMax = count($patch_array[$i]['points']); $j < $jMax; $j++) {
+			$jMax = count($patch_array[$i]['points']);
+			for ($j = 0; $j < $jMax; $j++) {
 				//each point as 16 bit
 				if (($j % 2) == 1) { // Y coordinate (adjusted as input is From top left)
 					$patch_array[$i]['points'][$j] = (($patch_array[$i]['points'][$j] - $y_min) / ($y_max - $y_min)) * $bpcd;
@@ -70,7 +72,8 @@ class Gradient
 				$this->mpdf->gradients[$n]['stream'].=chr(floor($patch_array[$i]['points'][$j] / 256));
 				$this->mpdf->gradients[$n]['stream'].=chr(floor($patch_array[$i]['points'][$j] % 256));
 			}
-			for ($j = 0, $jMax = count($patch_array[$i]['colors']); $j < $jMax; $j++) {
+			$jMax = count($patch_array[$i]['colors']);
+			for ($j = 0; $j < $jMax; $j++) {
 				//each color component as 8 bit
 				if ($colspace === 'RGB') {
 					$this->mpdf->gradients[$n]['stream'].= $patch_array[$i]['colors'][$j][1];
@@ -98,14 +101,17 @@ class Gradient
 		// TRANSPARENCY
 		if ($trans) {
 			$this->mpdf->gradients[$n]['stream_trans'] = '';
-			for ($i = 0, $iMax = count($patch_array); $i < $iMax; $i++) {
+			$iMax = count($patch_array);
+			for ($i = 0; $i < $iMax; $i++) {
 				$this->mpdf->gradients[$n]['stream_trans'].=chr($patch_array[$i]['f']);
-				for ($j = 0, $jMax = count($patch_array[$i]['points']); $j < $jMax; $j++) {
+				$jMax = count($patch_array[$i]['points']);
+				for ($j = 0; $j < $jMax; $j++) {
 					//each point as 16 bit
 					$this->mpdf->gradients[$n]['stream_trans'].=chr(floor($patch_array[$i]['points'][$j] / 256));
 					$this->mpdf->gradients[$n]['stream_trans'].=chr(floor($patch_array[$i]['points'][$j] % 256));
 				}
-				for ($j = 0, $jMax = count($patch_array[$i]['colors']); $j < $jMax; $j++) {
+				$jMax = count($patch_array[$i]['colors']);
+				for ($j = 0; $j < $jMax; $j++) {
 					//each color component as 8 bit // OPACITY
 					if ($colspace === 'RGB') {
 						$this->mpdf->gradients[$n]['stream_trans'].=chr((int) (ord($patch_array[$i]['colors'][$j][4]) * 2.55));
@@ -491,7 +497,8 @@ class Gradient
 			$axis_length = $coords[4] * $usew;
 		} // Absolute lengths are meaningless for an ellipse - Firefox uses Width as reference
 
-		for ($i = 0, $iMax = count($stops); $i < $iMax; $i++) {
+		$iMax = count($stops);
+		for ($i = 0; $i < $iMax; $i++) {
 			if (isset($stops[$i]['offset']) && preg_match('/([0-9.]+(px|em|ex|pc|pt|cm|mm|in))/i', $stops[$i]['offset'], $m)) {
 				$tmp = $this->sizeConverter->convert($m[1], $this->mpdf->w, $this->mpdf->FontSize, false);
 				$stops[$i]['offset'] = $tmp / $axis_length;
@@ -514,7 +521,8 @@ class Gradient
 			$stops[count($stops) - 1]['offset'] = 1;
 		}
 
-		for ($i = 0, $iMax = count($stops); $i < $iMax; $i++) {
+		$iMax = count($stops);
+		for ($i = 0; $i < $iMax; $i++) {
 			// mPDF 5.3.74
 			if ($colorspace === 'CMYK') {
 				$this->mpdf->gradients[$n]['stops'][$i]['col'] = sprintf('%.3F %.3F %.3F %.3F', ord($stops[$i]['col']{1}) / 100, ord($stops[$i]['col']{2}) / 100, ord($stops[$i]['col']{3}) / 100, ord($stops[$i]['col']{4}) / 100);
@@ -537,7 +545,8 @@ class Gradient
 					if (isset($stops[$i - 1]['offset']) && isset($stops[$i + 1]['offset'])) {
 						$stops[$i]['offset'] = ($stops[$i - 1]['offset'] + $stops[$i + 1]['offset']) / 2;
 					} else {
-						for ($j = ($i + 1), $jMax = count($stops); $j < $jMax; $j++) {
+						$jMax = count($stops);
+						for ($j = ($i + 1); $j < $jMax; $j++) {
 							if (isset($stops[$j]['offset'])) {
 								break;
 							}
@@ -612,7 +621,8 @@ class Gradient
 			$v = preg_replace('/(\([^\)]*?)[ ]/', '\\1', $v);
 		}
 		$bgr = preg_split('/\s*,\s*/', $v);
-		for ($i = 0, $iMax = count($bgr); $i < $iMax; $i++) {
+		$iMax = count($bgr);
+		for ($i = 0; $i < $iMax; $i++) {
 			$bgr[$i] = preg_replace('/@/', ',', $bgr[$i]);
 		}
 		// Is first part $bgr[0] a valid point/angle?
@@ -704,7 +714,8 @@ class Gradient
 		}
 		$g['coords'] = [$startx, $starty, $endx, $endy, $angle, $repeat];
 		$g['stops'] = [];
-		for ($i = $startStops, $iMax = count($bgr); $i < $iMax; $i++) {
+		$iMax = count($bgr);
+		for ($i = $startStops; $i < $iMax; $i++) {
 			// parse stops
 			$el = preg_split('/\s+/', trim($bgr[$i]));
 			// mPDF 5.3.74
@@ -739,7 +750,8 @@ class Gradient
 			$v = preg_replace('/(\([^\)]*?)[ ]/', '\\1', $v);
 		}
 		$bgr = preg_split('/\s*,\s*/', $v);
-		for ($i = 0, $iMax = count($bgr); $i < $iMax; $i++) {
+		$iMax = count($bgr);
+		for ($i = 0; $i < $iMax; $i++) {
 			$bgr[$i] = preg_replace('/@/', ',', $bgr[$i]);
 		}
 
@@ -848,7 +860,8 @@ class Gradient
 		$g['coords'] = [$startx, $starty, $endx, $endy, $radius, $angle, $shape, $size, $repeat];
 
 		$g['stops'] = [];
-		for ($i = $startStops, $iMax = count($bgr); $i < $iMax; $i++) {
+		$iMax = count($bgr);
+		for ($i = $startStops; $i < $iMax; $i++) {
 			// parse stops
 			$el = preg_split('/\s+/', trim($bgr[$i]));
 			// mPDF 5.3.74

--- a/src/Gradient.php
+++ b/src/Gradient.php
@@ -51,9 +51,9 @@ class Gradient
 		$bpcd = 65535; //16 BitsPerCoordinate
 		$trans = false;
 		$this->mpdf->gradients[$n]['stream'] = '';
-		for ($i = 0; $i < count($patch_array); $i++) {
+		for ($i = 0, $iMax = count($patch_array); $i < $iMax; $i++) {
 			$this->mpdf->gradients[$n]['stream'].=chr($patch_array[$i]['f']); //start with the edge flag as 8 bit
-			for ($j = 0; $j < count($patch_array[$i]['points']); $j++) {
+			for ($j = 0, $jMax = count($patch_array[$i]['points']); $j < $jMax; $j++) {
 				//each point as 16 bit
 				if (($j % 2) == 1) { // Y coordinate (adjusted as input is From top left)
 					$patch_array[$i]['points'][$j] = (($patch_array[$i]['points'][$j] - $y_min) / ($y_max - $y_min)) * $bpcd;
@@ -70,7 +70,7 @@ class Gradient
 				$this->mpdf->gradients[$n]['stream'].=chr(floor($patch_array[$i]['points'][$j] / 256));
 				$this->mpdf->gradients[$n]['stream'].=chr(floor($patch_array[$i]['points'][$j] % 256));
 			}
-			for ($j = 0; $j < count($patch_array[$i]['colors']); $j++) {
+			for ($j = 0, $jMax = count($patch_array[$i]['colors']); $j < $jMax; $j++) {
 				//each color component as 8 bit
 				if ($colspace === 'RGB') {
 					$this->mpdf->gradients[$n]['stream'].= $patch_array[$i]['colors'][$j][1];
@@ -98,14 +98,14 @@ class Gradient
 		// TRANSPARENCY
 		if ($trans) {
 			$this->mpdf->gradients[$n]['stream_trans'] = '';
-			for ($i = 0; $i < count($patch_array); $i++) {
+			for ($i = 0, $iMax = count($patch_array); $i < $iMax; $i++) {
 				$this->mpdf->gradients[$n]['stream_trans'].=chr($patch_array[$i]['f']);
-				for ($j = 0; $j < count($patch_array[$i]['points']); $j++) {
+				for ($j = 0, $jMax = count($patch_array[$i]['points']); $j < $jMax; $j++) {
 					//each point as 16 bit
 					$this->mpdf->gradients[$n]['stream_trans'].=chr(floor($patch_array[$i]['points'][$j] / 256));
 					$this->mpdf->gradients[$n]['stream_trans'].=chr(floor($patch_array[$i]['points'][$j] % 256));
 				}
-				for ($j = 0; $j < count($patch_array[$i]['colors']); $j++) {
+				for ($j = 0, $jMax = count($patch_array[$i]['colors']); $j < $jMax; $j++) {
 					//each color component as 8 bit // OPACITY
 					if ($colspace === 'RGB') {
 						$this->mpdf->gradients[$n]['stream_trans'].=chr((int) (ord($patch_array[$i]['colors'][$j][4]) * 2.55));
@@ -491,7 +491,7 @@ class Gradient
 			$axis_length = $coords[4] * $usew;
 		} // Absolute lengths are meaningless for an ellipse - Firefox uses Width as reference
 
-		for ($i = 0; $i < count($stops); $i++) {
+		for ($i = 0, $iMax = count($stops); $i < $iMax; $i++) {
 			if (isset($stops[$i]['offset']) && preg_match('/([0-9.]+(px|em|ex|pc|pt|cm|mm|in))/i', $stops[$i]['offset'], $m)) {
 				$tmp = $this->sizeConverter->convert($m[1], $this->mpdf->w, $this->mpdf->FontSize, false);
 				$stops[$i]['offset'] = $tmp / $axis_length;
@@ -514,7 +514,7 @@ class Gradient
 			$stops[count($stops) - 1]['offset'] = 1;
 		}
 
-		for ($i = 0; $i < count($stops); $i++) {
+		for ($i = 0, $iMax = count($stops); $i < $iMax; $i++) {
 			// mPDF 5.3.74
 			if ($colorspace === 'CMYK') {
 				$this->mpdf->gradients[$n]['stops'][$i]['col'] = sprintf('%.3F %.3F %.3F %.3F', ord($stops[$i]['col']{1}) / 100, ord($stops[$i]['col']{2}) / 100, ord($stops[$i]['col']{3}) / 100, ord($stops[$i]['col']{4}) / 100);
@@ -537,7 +537,7 @@ class Gradient
 					if (isset($stops[$i - 1]['offset']) && isset($stops[$i + 1]['offset'])) {
 						$stops[$i]['offset'] = ($stops[$i - 1]['offset'] + $stops[$i + 1]['offset']) / 2;
 					} else {
-						for ($j = ($i + 1); $j < count($stops); $j++) {
+						for ($j = ($i + 1), $jMax = count($stops); $j < $jMax; $j++) {
 							if (isset($stops[$j]['offset'])) {
 								break;
 							}
@@ -612,7 +612,7 @@ class Gradient
 			$v = preg_replace('/(\([^\)]*?)[ ]/', '\\1', $v);
 		}
 		$bgr = preg_split('/\s*,\s*/', $v);
-		for ($i = 0; $i < count($bgr); $i++) {
+		for ($i = 0, $iMax = count($bgr); $i < $iMax; $i++) {
 			$bgr[$i] = preg_replace('/@/', ',', $bgr[$i]);
 		}
 		// Is first part $bgr[0] a valid point/angle?
@@ -704,7 +704,7 @@ class Gradient
 		}
 		$g['coords'] = [$startx, $starty, $endx, $endy, $angle, $repeat];
 		$g['stops'] = [];
-		for ($i = $startStops; $i < count($bgr); $i++) {
+		for ($i = $startStops, $iMax = count($bgr); $i < $iMax; $i++) {
 			// parse stops
 			$el = preg_split('/\s+/', trim($bgr[$i]));
 			// mPDF 5.3.74
@@ -739,7 +739,7 @@ class Gradient
 			$v = preg_replace('/(\([^\)]*?)[ ]/', '\\1', $v);
 		}
 		$bgr = preg_split('/\s*,\s*/', $v);
-		for ($i = 0; $i < count($bgr); $i++) {
+		for ($i = 0, $iMax = count($bgr); $i < $iMax; $i++) {
 			$bgr[$i] = preg_replace('/@/', ',', $bgr[$i]);
 		}
 
@@ -848,7 +848,7 @@ class Gradient
 		$g['coords'] = [$startx, $starty, $endx, $endy, $radius, $angle, $shape, $size, $repeat];
 
 		$g['stops'] = [];
-		for ($i = $startStops; $i < count($bgr); $i++) {
+		for ($i = $startStops, $iMax = count($bgr); $i < $iMax; $i++) {
 			// parse stops
 			$el = preg_split('/\s+/', trim($bgr[$i]));
 			// mPDF 5.3.74

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -538,13 +538,15 @@ class Svg
 		}
 
 
-		for ($i = 0; $i < (count($gradient_info['color'])); $i++) {
+		$iMax = count($gradient_info['color']);
+		for ($i = 0; $i < $iMax; $i++) {
 			if (false !== strpos($gradient_info['color'][$i]['offset'], '%')) {
-				$gradient_info['color'][$i]['offset'] = ((float) $gradient_info['color'][$i]['offset']) / 100;
+				$gradient_info['color'][$i]['offset'] = ((float)$gradient_info['color'][$i]['offset']) / 100;
 			}
-			if (isset($gradient_info['color'][($i + 1)]['offset']) && false !== strpos($gradient_info['color'][($i + 1)]['offset'],
-                    '%')) {
-				$gradient_info['color'][($i + 1)]['offset'] = ((float) $gradient_info['color'][($i + 1)]['offset']) / 100;
+			if (isset($gradient_info['color'][($i + 1)]['offset']) &&
+				false !== strpos($gradient_info['color'][($i + 1)]['offset'], '%')
+			) {
+				$gradient_info['color'][($i + 1)]['offset'] = ((float)$gradient_info['color'][($i + 1)]['offset']) / 100;
 			}
 			if ($gradient_info['color'][$i]['offset'] < 0) {
 				$gradient_info['color'][$i]['offset'] = 0;

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -536,10 +536,10 @@ class Svg
 
 
 		for ($i = 0; $i < (count($gradient_info['color'])); $i++) {
-			if (false !== stripos($gradient_info['color'][$i]['offset'], '%')) {
+			if (false !== strpos($gradient_info['color'][$i]['offset'], '%')) {
 				$gradient_info['color'][$i]['offset'] = ((float) $gradient_info['color'][$i]['offset']) / 100;
 			}
-			if (isset($gradient_info['color'][($i + 1)]['offset']) && false !== stripos($gradient_info['color'][($i + 1)]['offset'],
+			if (isset($gradient_info['color'][($i + 1)]['offset']) && false !== strpos($gradient_info['color'][($i + 1)]['offset'],
                     '%')) {
 				$gradient_info['color'][($i + 1)]['offset'] = ((float) $gradient_info['color'][($i + 1)]['offset']) / 100;
 			}
@@ -607,16 +607,16 @@ class Svg
 				$y2 = 0;
 			} // mPDF 6
 
-			if (false !== stripos($x1, '%')) {
+			if (false !== strpos($x1, '%')) {
 				$x1 = ($x1 + 0) / 100;
 			}
-			if (false !== stripos($x2, '%')) {
+			if (false !== strpos($x2, '%')) {
 				$x2 = ($x2 + 0) / 100;
 			}
-			if (false !== stripos($y1, '%')) {
+			if (false !== strpos($y1, '%')) {
 				$y1 = ($y1 + 0) / 100;
 			}
-			if (false !== stripos($y2, '%')) {
+			if (false !== strpos($y2, '%')) {
 				$y2 = ($y2 + 0) / 100;
 			}
 
@@ -862,22 +862,22 @@ class Svg
 				$y1 = $y0;
 			}
 
-			if (false !== stripos($x1, '%')) {
+			if (false !== strpos($x1, '%')) {
 				$x1 = ($x1 + 0) / 100;
 			}
-			if (false !== stripos($x0, '%')) {
+			if (false !== strpos($x0, '%')) {
 				$x0 = ($x0 + 0) / 100;
 			}
-			if (false !== stripos($y1, '%')) {
+			if (false !== strpos($y1, '%')) {
 				$y1 = ($y1 + 0) / 100;
 			}
-			if (false !== stripos($y0, '%')) {
+			if (false !== strpos($y0, '%')) {
 				$y0 = ($y0 + 0) / 100;
 			}
-			if (false !== stripos($rx, '%')) {
+			if (false !== strpos($rx, '%')) {
 				$rx = ($rx + 0) / 100;
 			}
-			if (false !== stripos($ry, '%')) {
+			if (false !== strpos($ry, '%')) {
 				$ry = ($ry + 0) / 100;
 			}
 

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -2804,7 +2804,7 @@ class Svg
 		}
 
 		// add current style to text style array (will remove it later after writing text to svg_string)
-		array_push($this->txt_style, $current_style);
+		$this->txt_style[] = $current_style;
 	}
 
 	//
@@ -3308,7 +3308,7 @@ class Svg
 				'offset' => (isset($attribs['offset']) ? $attribs['offset'] : ''),
 				'opacity' => $stop_opacity
 			];
-			array_push($this->svg_gradient[$last_gradid]['color'], $tmp_color);
+			$this->svg_gradient[$last_gradid]['color'][] = $tmp_color;
 			return;
 		}
 		if ($this->inDefs) {
@@ -3468,7 +3468,7 @@ class Svg
 				$arguments = [];
 				for ($i = 0; $i < count($tmp); $i++) {
 					if ($tmp[$i][0] != '') {
-						array_push($arguments, $tmp[$i][0]);
+						$arguments[] = $tmp[$i][0];
 					}
 				}
 				$path_cmd = $this->svgPolyline($arguments);
@@ -3483,7 +3483,7 @@ class Svg
 				$arguments = [];
 				for ($i = 0; $i < count($tmp[0]); $i++) {
 					if ($tmp[0][$i] != '') {
-						array_push($arguments, $tmp[0][$i]);
+						$arguments[] = $tmp[0][$i];
 					}
 				}
 				$path_cmd = $this->svgPolygon($arguments);
@@ -3517,7 +3517,7 @@ class Svg
 						$this->svgWriteString(' q ' . $array_style['transformations']);
 					}
 				}
-				array_push($this->svg_style, $array_style);
+				$this->svg_style[] = $array_style;
 
 				$this->svgDefineTxtStyle($attribs);
 
@@ -3569,7 +3569,7 @@ class Svg
 				if (!empty($array_style['transformations'])) {
 					$this->textoutput .= ' q ' . $array_style['transformations']; // mPDF 5.7.4
 				}
-				array_push($this->svg_style, $array_style);
+				$this->svg_style[] = $array_style;
 
 				$this->txt_data = [];
 				$x = isset($attribs['x']) ? $this->ConvertSVGSizePixels($attribs['x'], 'x') : 0;  // mPDF 5.7.4
@@ -3695,7 +3695,7 @@ class Svg
 				if (!empty($array_style['transformations'])) {
 					$this->textoutput .= ' q ' . $array_style['transformations'];
 				}
-				array_push($this->svg_style, $array_style);
+				$this->svg_style[] = $array_style;
 
 				break;
 		}

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -395,7 +395,7 @@ class Svg
 			$pts = preg_split('/[ ,]+/', trim($attribs['points']));
 			$maxr = $maxb = 0;
 			$minl = $mint = 999999;
-			for ($i = 0; $i < count($pts); $i++) {
+			for ($i = 0, $iMax = count($pts); $i < $iMax; $i++) {
 				if ($i % 2 == 0) { // x values
 					$minl = min($minl, $pts[$i]);
 					$maxr = max($maxr, $pts[$i]);
@@ -423,7 +423,7 @@ class Svg
 						list($tmp, $cmd, $arg) = $c;
 						if ($cmd == 'M' || $cmd == 'L' || $cmd == 'C' || $cmd == 'S' || $cmd == 'Q' || $cmd == 'T') {
 							$pts = preg_split('/[ ,]+/', trim($arg));
-							for ($i = 0; $i < count($pts); $i++) {
+							for ($i = 0, $iMax = count($pts); $i < $iMax; $i++) {
 								if ($i % 2 == 0) { // x values
 									$minl = min($minl, $pts[$i]);
 									$maxr = max($maxr, $pts[$i]);
@@ -467,7 +467,7 @@ class Svg
 		if (isset($gradient_info['transform'])) {
 			preg_match_all('/(matrix|translate|scale|rotate|skewX|skewY)\((.*?)\)/is', $gradient_info['transform'], $m);
 			if (count($m[0])) {
-				for ($i = 0; $i < count($m[0]); $i++) {
+				for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 					$c = strtolower($m[1][$i]);
 					$v = trim($m[2][$i]);
 					$vv = preg_split('/[ ,]+/', $v);
@@ -1141,7 +1141,7 @@ class Svg
 		if (isset($critere_style['transform'])) {
 			preg_match_all('/(matrix|translate|scale|rotate|skewX|skewY)\((.*?)\)/is', $critere_style['transform'], $m);
 			if (count($m[0])) {
-				for ($i = 0; $i < count($m[0]); $i++) {
+				for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 					$c = strtolower($m[1][$i]);
 					$v = trim($m[2][$i]);
 					$vv = preg_split('/[ ,]+/', $v);
@@ -1474,7 +1474,7 @@ class Svg
 						$d = array_merge($d, $d);
 					} // 5, 3, 1 => 5,3,1,5,3,1  OR 3 => 3,3
 					$arr = '';
-					for ($i = 0; $i < count($d); $i+=2) {
+					for ($i = 0, $iMax = count($d); $i < $iMax; $i+=2) {
 						$arr .= sprintf('%.3F %.3F ', $d[$i] * $this->kp, $d[$i + 1] * $this->kp);
 					}
 					if (isset($critere_style['stroke-dashoffset'])) {
@@ -2206,7 +2206,7 @@ class Svg
 			$ybase = - $this->ConvertSVGSizePixels($arguments[1], 'y');
 		}
 		$path_cmd = sprintf('%.3F %.3F m ', $xbase * $this->kp, $ybase * $this->kp);
-		for ($i = 2; $i < count($arguments); $i += 2) {
+		for ($i = 2, $iMax = count($arguments); $i < $iMax; $i += 2) {
 			if ($ispolyline) {
 				$tmp_x = $arguments[$i];
 				$tmp_y = - $arguments[($i + 1)];
@@ -2228,7 +2228,7 @@ class Svg
 		$xbase = $arguments[0];
 		$ybase = - $arguments[1];
 		$path_cmd = sprintf('%.3F %.3F m ', $xbase * $this->kp, $ybase * $this->kp);
-		for ($i = 2; $i < count($arguments); $i += 2) {
+		for ($i = 2, $iMax = count($arguments); $i < $iMax; $i += 2) {
 			$tmp_x = $arguments[$i];
 			$tmp_y = - $arguments[($i + 1)];
 
@@ -2850,7 +2850,7 @@ class Svg
 			// Get User-defined entities
 			preg_match_all('/<!ENTITY\s+([a-z]+)\s+\"(.*?)\">/si', $data, $ent);
 			// Replace entities
-			for ($i = 0; $i < count($ent[0]); $i++) {
+			for ($i = 0, $iMax = count($ent[0]); $i < $iMax; $i++) {
 				$data = preg_replace('/&' . preg_quote($ent[1][$i], '/') . ';/is', $ent[2][$i], $data);
 			}
 		}
@@ -2865,7 +2865,7 @@ class Svg
 			}
 
 			// Delete links from data - keeping in $links
-			for ($i = 0; $i < count($links[0]); $i++) {
+			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
 				$links[5][$i] = 'tmpLink' . random_int(100000, 9999999);
 				$data = preg_replace('/' . preg_quote($links[0][$i], '/') . '/is', '<MYLINKS' . $links[5][$i] . '>', $data);
 			}
@@ -2876,12 +2876,12 @@ class Svg
 			$stops = [];
 
 			// keeping in $targets
-			for ($i = 0; $i < count($m[0]); $i++) {
+			for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 				$stops[$m[3][$i]] = $m[5][$i];
 			}
 
 			// Add back links this time as targets (gradients)
-			for ($i = 0; $i < count($links[0]); $i++) {
+			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
 				$def = $links[1][$i] . ' ' . $links[4][$i] . '>' . $stops[$links[3][$i]] . '</' . $links[2][$i] . '>';
 				$data = preg_replace('/<MYLINKS' . $links[5][$i] . '>/is', $def, $data);
 			}
@@ -2889,7 +2889,7 @@ class Svg
 			// mPDF 5.7.4
 			// <TREF>
 			preg_match_all('/<tref ([^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)\/>/si', $data, $links);
-			for ($i = 0; $i < count($links[0]); $i++) {
+			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
 				// Get the item to use from defs
 				$insert = '';
 				if (preg_match('/<text [^>]*id\s*=\s*["\']' . $links[2][$i] . '["\'][^>]*>(.*?)<\/text>/si', $data, $m)) {
@@ -2903,7 +2903,7 @@ class Svg
 			// mPDF 5.7.2
 			// <USE>
 			preg_match_all('/<use( [^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)\/>/si', $data, $links);
-			for ($i = 0; $i < count($links[0]); $i++) {
+			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
 				// Get the item to use from defs
 				$insert = '';
 				if (preg_match('/<([a-zA-Z]*) [^>]*id\s*=\s*["\']' . $links[2][$i] . '["\'][^>]*\/>/si', $data, $m)) {
@@ -2958,7 +2958,7 @@ class Svg
 			}
 
 			preg_match_all('/<use( [^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)>\s*<\/use>/si', $data, $links);
-			for ($i = 0; $i < count($links[0]); $i++) {
+			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
 
 				// Get the item to use from defs
 				$insert = '';
@@ -3120,7 +3120,7 @@ class Svg
 				for ($sch = 0; $sch <= $subchunk; $sch++) {
 					if (isset($chardata[$sch])) {
 						$s = '';
-						for ($j = 0; $j < count($chardata[$sch]); $j++) {
+						for ($j = 0, $jMax = count($chardata[$sch]); $j < $jMax; $j++) {
 							$s .= UtfString::code2utf($chardata[$sch][$j]['uni']);
 						}
 						// ZZZ99 Undo lesser_entity_decode as above - but only for <>&
@@ -3466,7 +3466,7 @@ class Svg
 				$path = $attribs['points'];
 				preg_match_all('/[0-9\-\.]*/', $path, $tmp, PREG_SET_ORDER);
 				$arguments = [];
-				for ($i = 0; $i < count($tmp); $i++) {
+				for ($i = 0, $iMax = count($tmp); $i < $iMax; $i++) {
 					if ($tmp[$i][0] != '') {
 						$arguments[] = $tmp[$i][0];
 					}
@@ -3481,7 +3481,7 @@ class Svg
 				$path = $attribs['points'];
 				preg_match_all('/([\-]*[0-9\.]+)/', $path, $tmp);
 				$arguments = [];
-				for ($i = 0; $i < count($tmp[0]); $i++) {
+				for ($i = 0, $iMax = count($tmp[0]); $i < $iMax; $i++) {
 					if ($tmp[0][$i] != '') {
 						$arguments[] = $tmp[0][$i];
 					}

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -395,7 +395,8 @@ class Svg
 			$pts = preg_split('/[ ,]+/', trim($attribs['points']));
 			$maxr = $maxb = 0;
 			$minl = $mint = 999999;
-			for ($i = 0, $iMax = count($pts); $i < $iMax; $i++) {
+			$iMax = count($pts);
+			for ($i = 0; $i < $iMax; $i++) {
 				if ($i % 2 == 0) { // x values
 					$minl = min($minl, $pts[$i]);
 					$maxr = max($maxr, $pts[$i]);
@@ -423,7 +424,8 @@ class Svg
 						list($tmp, $cmd, $arg) = $c;
 						if ($cmd == 'M' || $cmd == 'L' || $cmd == 'C' || $cmd == 'S' || $cmd == 'Q' || $cmd == 'T') {
 							$pts = preg_split('/[ ,]+/', trim($arg));
-							for ($i = 0, $iMax = count($pts); $i < $iMax; $i++) {
+							$iMax = count($pts);
+							for ($i = 0; $i < $iMax; $i++) {
 								if ($i % 2 == 0) { // x values
 									$minl = min($minl, $pts[$i]);
 									$maxr = max($maxr, $pts[$i]);
@@ -467,7 +469,8 @@ class Svg
 		if (isset($gradient_info['transform'])) {
 			preg_match_all('/(matrix|translate|scale|rotate|skewX|skewY)\((.*?)\)/is', $gradient_info['transform'], $m);
 			if (count($m[0])) {
-				for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+				$iMax = count($m[0]);
+				for ($i = 0; $i < $iMax; $i++) {
 					$c = strtolower($m[1][$i]);
 					$v = trim($m[2][$i]);
 					$vv = preg_split('/[ ,]+/', $v);
@@ -1141,7 +1144,8 @@ class Svg
 		if (isset($critere_style['transform'])) {
 			preg_match_all('/(matrix|translate|scale|rotate|skewX|skewY)\((.*?)\)/is', $critere_style['transform'], $m);
 			if (count($m[0])) {
-				for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+				$iMax = count($m[0]);
+				for ($i = 0; $i < $iMax; $i++) {
 					$c = strtolower($m[1][$i]);
 					$v = trim($m[2][$i]);
 					$vv = preg_split('/[ ,]+/', $v);
@@ -1474,7 +1478,8 @@ class Svg
 						$d = array_merge($d, $d);
 					} // 5, 3, 1 => 5,3,1,5,3,1  OR 3 => 3,3
 					$arr = '';
-					for ($i = 0, $iMax = count($d); $i < $iMax; $i+=2) {
+					$iMax = count($d);
+					for ($i = 0; $i < $iMax; $i+=2) {
 						$arr .= sprintf('%.3F %.3F ', $d[$i] * $this->kp, $d[$i + 1] * $this->kp);
 					}
 					if (isset($critere_style['stroke-dashoffset'])) {
@@ -2206,7 +2211,8 @@ class Svg
 			$ybase = - $this->ConvertSVGSizePixels($arguments[1], 'y');
 		}
 		$path_cmd = sprintf('%.3F %.3F m ', $xbase * $this->kp, $ybase * $this->kp);
-		for ($i = 2, $iMax = count($arguments); $i < $iMax; $i += 2) {
+		$iMax = count($arguments);
+		for ($i = 2; $i < $iMax; $i += 2) {
 			if ($ispolyline) {
 				$tmp_x = $arguments[$i];
 				$tmp_y = - $arguments[($i + 1)];
@@ -2228,7 +2234,8 @@ class Svg
 		$xbase = $arguments[0];
 		$ybase = - $arguments[1];
 		$path_cmd = sprintf('%.3F %.3F m ', $xbase * $this->kp, $ybase * $this->kp);
-		for ($i = 2, $iMax = count($arguments); $i < $iMax; $i += 2) {
+		$iMax = count($arguments);
+		for ($i = 2; $i < $iMax; $i += 2) {
 			$tmp_x = $arguments[$i];
 			$tmp_y = - $arguments[($i + 1)];
 
@@ -2850,7 +2857,8 @@ class Svg
 			// Get User-defined entities
 			preg_match_all('/<!ENTITY\s+([a-z]+)\s+\"(.*?)\">/si', $data, $ent);
 			// Replace entities
-			for ($i = 0, $iMax = count($ent[0]); $i < $iMax; $i++) {
+			$iMax = count($ent[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				$data = preg_replace('/&' . preg_quote($ent[1][$i], '/') . ';/is', $ent[2][$i], $data);
 			}
 		}
@@ -2865,7 +2873,8 @@ class Svg
 			}
 
 			// Delete links from data - keeping in $links
-			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
+			$iMax = count($links[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				$links[5][$i] = 'tmpLink' . random_int(100000, 9999999);
 				$data = preg_replace('/' . preg_quote($links[0][$i], '/') . '/is', '<MYLINKS' . $links[5][$i] . '>', $data);
 			}
@@ -2876,12 +2885,14 @@ class Svg
 			$stops = [];
 
 			// keeping in $targets
-			for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+			$iMax = count($m[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				$stops[$m[3][$i]] = $m[5][$i];
 			}
 
 			// Add back links this time as targets (gradients)
-			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
+			$iMax = count($links[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				$def = $links[1][$i] . ' ' . $links[4][$i] . '>' . $stops[$links[3][$i]] . '</' . $links[2][$i] . '>';
 				$data = preg_replace('/<MYLINKS' . $links[5][$i] . '>/is', $def, $data);
 			}
@@ -2889,7 +2900,8 @@ class Svg
 			// mPDF 5.7.4
 			// <TREF>
 			preg_match_all('/<tref ([^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)\/>/si', $data, $links);
-			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
+			$iMax = count($links[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				// Get the item to use from defs
 				$insert = '';
 				if (preg_match('/<text [^>]*id\s*=\s*["\']' . $links[2][$i] . '["\'][^>]*>(.*?)<\/text>/si', $data, $m)) {
@@ -2903,7 +2915,8 @@ class Svg
 			// mPDF 5.7.2
 			// <USE>
 			preg_match_all('/<use( [^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)\/>/si', $data, $links);
-			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
+			$iMax = count($links[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 				// Get the item to use from defs
 				$insert = '';
 				if (preg_match('/<([a-zA-Z]*) [^>]*id\s*=\s*["\']' . $links[2][$i] . '["\'][^>]*\/>/si', $data, $m)) {
@@ -2958,7 +2971,8 @@ class Svg
 			}
 
 			preg_match_all('/<use( [^>]*)xlink:href\s*=\s*["\']#([^>]*?)["\']([^>]*)>\s*<\/use>/si', $data, $links);
-			for ($i = 0, $iMax = count($links[0]); $i < $iMax; $i++) {
+			$iMax = count($links[0]);
+			for ($i = 0; $i < $iMax; $i++) {
 
 				// Get the item to use from defs
 				$insert = '';
@@ -3120,12 +3134,12 @@ class Svg
 				for ($sch = 0; $sch <= $subchunk; $sch++) {
 					if (isset($chardata[$sch])) {
 						$s = '';
-						for ($j = 0, $jMax = count($chardata[$sch]); $j < $jMax; $j++) {
+						$jMax = count($chardata[$sch]);
+						for ($j = 0; $j < $jMax; $j++) {
 							$s .= UtfString::code2utf($chardata[$sch][$j]['uni']);
 						}
 						// ZZZ99 Undo lesser_entity_decode as above - but only for <>&
-						$s = str_replace("&", "&amp;", $s);
-                        $s = str_replace(array("<", ">"), array("&lt;", "&gt;"), $s);
+						$s = str_replace(["&", "<", ">"], ["&amp;", "&lt;", "&gt;"], $s);
 
 						if (substr($a[$i - 1], 0, 5) != '<text' && substr($a[$i - 1], 0, 5) != '<tspa') {
 							continue;
@@ -3466,7 +3480,8 @@ class Svg
 				$path = $attribs['points'];
 				preg_match_all('/[0-9\-\.]*/', $path, $tmp, PREG_SET_ORDER);
 				$arguments = [];
-				for ($i = 0, $iMax = count($tmp); $i < $iMax; $i++) {
+				$iMax = count($tmp);
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($tmp[$i][0] != '') {
 						$arguments[] = $tmp[$i][0];
 					}
@@ -3481,7 +3496,8 @@ class Svg
 				$path = $attribs['points'];
 				preg_match_all('/([\-]*[0-9\.]+)/', $path, $tmp);
 				$arguments = [];
-				for ($i = 0, $iMax = count($tmp[0]); $i < $iMax; $i++) {
+				$iMax = count($tmp[0]);
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($tmp[0][$i] != '') {
 						$arguments[] = $tmp[0][$i];
 					}

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -536,10 +536,11 @@ class Svg
 
 
 		for ($i = 0; $i < (count($gradient_info['color'])); $i++) {
-			if (stristr($gradient_info['color'][$i]['offset'], '%') !== false) {
+			if (false !== stripos($gradient_info['color'][$i]['offset'], '%')) {
 				$gradient_info['color'][$i]['offset'] = ((float) $gradient_info['color'][$i]['offset']) / 100;
 			}
-			if (isset($gradient_info['color'][($i + 1)]['offset']) && stristr($gradient_info['color'][($i + 1)]['offset'], '%') !== false) {
+			if (isset($gradient_info['color'][($i + 1)]['offset']) && false !== stripos($gradient_info['color'][($i + 1)]['offset'],
+                    '%')) {
 				$gradient_info['color'][($i + 1)]['offset'] = ((float) $gradient_info['color'][($i + 1)]['offset']) / 100;
 			}
 			if ($gradient_info['color'][$i]['offset'] < 0) {
@@ -606,16 +607,16 @@ class Svg
 				$y2 = 0;
 			} // mPDF 6
 
-			if (stristr($x1, '%') !== false) {
+			if (false !== stripos($x1, '%')) {
 				$x1 = ($x1 + 0) / 100;
 			}
-			if (stristr($x2, '%') !== false) {
+			if (false !== stripos($x2, '%')) {
 				$x2 = ($x2 + 0) / 100;
 			}
-			if (stristr($y1, '%') !== false) {
+			if (false !== stripos($y1, '%')) {
 				$y1 = ($y1 + 0) / 100;
 			}
-			if (stristr($y2, '%') !== false) {
+			if (false !== stripos($y2, '%')) {
 				$y2 = ($y2 + 0) / 100;
 			}
 
@@ -861,22 +862,22 @@ class Svg
 				$y1 = $y0;
 			}
 
-			if (stristr($x1, '%') !== false) {
+			if (false !== stripos($x1, '%')) {
 				$x1 = ($x1 + 0) / 100;
 			}
-			if (stristr($x0, '%') !== false) {
+			if (false !== stripos($x0, '%')) {
 				$x0 = ($x0 + 0) / 100;
 			}
-			if (stristr($y1, '%') !== false) {
+			if (false !== stripos($y1, '%')) {
 				$y1 = ($y1 + 0) / 100;
 			}
-			if (stristr($y0, '%') !== false) {
+			if (false !== stripos($y0, '%')) {
 				$y0 = ($y0 + 0) / 100;
 			}
-			if (stristr($rx, '%') !== false) {
+			if (false !== stripos($rx, '%')) {
 				$rx = ($rx + 0) / 100;
 			}
-			if (stristr($ry, '%') !== false) {
+			if (false !== stripos($ry, '%')) {
 				$ry = ($ry + 0) / 100;
 			}
 

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -3125,8 +3125,7 @@ class Svg
 						}
 						// ZZZ99 Undo lesser_entity_decode as above - but only for <>&
 						$s = str_replace("&", "&amp;", $s);
-						$s = str_replace("<", "&lt;", $s);
-						$s = str_replace(">", "&gt;", $s);
+                        $s = str_replace(array("<", ">"), array("&lt;", "&gt;"), $s);
 
 						if (substr($a[$i - 1], 0, 5) != '<text' && substr($a[$i - 1], 0, 5) != '<tspa') {
 							continue;

--- a/src/Image/Wmf.php
+++ b/src/Image/Wmf.php
@@ -154,7 +154,8 @@ class Wmf
 							}
 							if (!empty($dashArray)) {
 								$s = '[';
-								for ($i = 0, $iMax = count($dashArray); $i < $iMax; $i++) {
+								$iMax = count($dashArray);
+								for ($i = 0; $i < $iMax; $i++) {
 									$s .= $dashArray[$i] * $k;
 									if ($i != count($dashArray) - 1) {
 										$s .= ' ';

--- a/src/Image/Wmf.php
+++ b/src/Image/Wmf.php
@@ -154,7 +154,7 @@ class Wmf
 							}
 							if (!empty($dashArray)) {
 								$s = '[';
-								for ($i = 0; $i < count($dashArray); $i++) {
+								for ($i = 0, $iMax = count($dashArray); $i < $iMax; $i++) {
 									$s .= $dashArray[$i] * $k;
 									if ($i != count($dashArray) - 1) {
 										$s .= ' ';

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2043,12 +2043,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$h = $ch;
 				}
 			} else {
-				if (false !== stripos($size['w'], '%')) {
+				if (false !== strpos($size['w'], '%')) {
 					$size['w'] = (float) $size['w'];
 					$size['w'] /= 100;
 					$size['w'] = ($cw * $size['w']);
 				}
-				if (false !== stripos($size['h'], '%')) {
+				if (false !== strpos($size['h'], '%')) {
 					$size['h'] = (float) $size['h'];
 					$size['h'] /= 100;
 					$size['h'] = ($ch * $size['h']);
@@ -2120,10 +2120,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				} else {
 					$bsw = $sz[0];
 				}
-				if (false === stripos($bsw, '%') && false === stripos($bsw, 'auto')) {
+				if (false === strpos($bsw, '%') && false === stripos($bsw, 'auto')) {
 					$bsw = $this->sizeConverter->convert($bsw, $maxwidth, $this->FontSize);
 				}
-				if (false === stripos($bsh, '%') && false === stripos($bsh, 'auto')) {
+				if (false === strpos($bsh, '%') && false === stripos($bsh, 'auto')) {
 					$bsh = $this->sizeConverter->convert($bsh, $maxwidth, $this->FontSize);
 				}
 			}
@@ -2168,10 +2168,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$ppos = preg_split('/\s+/', $properties['BACKGROUND-POSITION']);
 					$x_pos = $ppos[0];
 					$y_pos = $ppos[1];
-					if (false === stripos($x_pos, '%')) {
+					if (false === strpos($x_pos, '%')) {
 						$x_pos = $this->sizeConverter->convert($x_pos, $maxwidth, $this->FontSize);
 					}
-					if (false === stripos($y_pos, '%')) {
+					if (false === strpos($y_pos, '%')) {
 						$y_pos = $this->sizeConverter->convert($y_pos, $maxwidth, $this->FontSize);
 					}
 				}
@@ -2458,7 +2458,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						}
 
 						$x_pos = $pb['x_pos'];
-						if (false !== stripos($x_pos, '%')) {
+						if (false !== strpos($x_pos, '%')) {
 							$x_pos = (float) $x_pos;
 							$x_pos /= 100;
 							$x_pos = ($pb['bpa']['w'] * $x_pos) - ($iw * $x_pos);
@@ -2466,7 +2466,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 						$y_pos = $pb['y_pos'];
 
-						if (false !== stripos($y_pos, '%')) {
+						if (false !== strpos($y_pos, '%')) {
 							$y_pos = (float) $y_pos;
 							$y_pos /= 100;
 							$y_pos = ($pb['bpa']['h'] * $y_pos) - ($ih * $y_pos);
@@ -17415,14 +17415,14 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					if (isset($this->blk[$blvl]['background-image']['size']['w']) && $this->blk[$blvl]['background-image']['size']['w']) {
 						$size = $this->blk[$blvl]['background-image']['size'];
 						if ($size['w'] != 'contain' && $size['w'] != 'cover') {
-							if (false !== stripos($size['w'], '%')) {
+							if (false !== strpos($size['w'], '%')) {
 								$size['w'] = (float) $size['w'];
 								$size['w'] /= 100;
 								$w *= $size['w'];
 							} elseif ($size['w'] != 'auto') {
 								$w = $size['w'];
 							}
-							if (false !== stripos($size['h'], '%')) {
+							if (false !== strpos($size['h'], '%')) {
 								$size['h'] = (float) $size['h'];
 								$size['h'] /= 100;
 								$h *= $size['h'];
@@ -25799,7 +25799,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			$code .= $arrcode['checkdigit'];
 
-			if (false !== stripos($codestr, '-')) {
+			if (false !== strpos($codestr, '-')) {
 				$codestr .= '-' . $arrcode['checkdigit'];
 			} else {
 				$codestr .= $arrcode['checkdigit'];

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -7289,8 +7289,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						throw new \Mpdf\MpdfException('Class Mpdf\QrCode\QrCode does not exists. Install the package from Packagist with "composer require mpdf/qrcode"');
 					}
 
-					$barcodeContent = str_replace('\r\n', "\r\n", $objattr['code']);
-					$barcodeContent = str_replace('\n', "\n", $barcodeContent);
+                    $barcodeContent = str_replace(array('\r\n', '\n'), array("\r\n", "\n"), $objattr['code']);
 
 					$qrcode = new QrCode\QrCode($barcodeContent, $objattr['errorlevel']);
 					if ($objattr['disableborder']) {
@@ -9538,8 +9537,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->x = $this->lMargin;
 				$this->y = $this->margin_header;
 				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace($this->aliasNbPgGp, $pntstr, $html); // {nbpg}
-				$html = str_replace($this->aliasNbPg, $nb, $html); // {nb}
+				$html = str_replace(array($this->aliasNbPgGp, $this->aliasNbPg), array($pntstr, $nb), $html); // {nbpg}, {nb}
 				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 
 				$this->HTMLheaderPageLinks = [];
@@ -9619,8 +9617,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 
 				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace($this->aliasNbPgGp, $pntstr, $html); // {nbpg}
-				$html = str_replace($this->aliasNbPg, $nb, $html); // {nb}
+				$html = str_replace(array($this->aliasNbPgGp, $this->aliasNbPg), array($pntstr, $nb), $html); // {nbpg}, {nb}
 				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 
 
@@ -12228,8 +12225,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->x = $this->lMargin;
 		$this->y = $this->margin_header;
 		$html = str_replace('{PAGENO}', $this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix, $html);
-		$html = str_replace($this->aliasNbPgGp, $this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $html);
-		$html = str_replace($this->aliasNbPg, $this->page, $html);
+        $html = str_replace(
+            array($this->aliasNbPgGp, $this->aliasNbPg),
+            array($this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $this->page),
+            $html
+        );
 		$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 		$this->HTMLheaderPageLinks = [];
 		$this->HTMLheaderPageAnnots = [];
@@ -13188,10 +13188,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Don't allow non-breaking spaces that are converted to substituted chars or will break anyway and mess up table width calc.
-		$html = str_replace('<tta>160</tta>', chr(32), $html);
-		$html = str_replace('</tta><tta>', '|', $html);
-		$html = str_replace('</tts><tts>', '|', $html);
-		$html = str_replace('</ttz><ttz>', '|', $html);
+        $html = str_replace(array('<tta>160</tta>', '</tta><tta>'), array(chr(32), '|'), $html);
+        $html = str_replace(array('</tts><tts>', '</ttz><ttz>'), '|', $html);
 
 		// Add new supported tags in the DisableTags function
 		$html = strip_tags($html, $this->enabledtags); // remove all unsupported tags, but the ones inside the 'enabledtags' string
@@ -26474,8 +26472,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 						// ZZZ99 Undo lesser_entity_decode as above - but only for <>&
 						$s = str_replace("&", "&amp;", $s);
-						$s = str_replace("<", "&lt;", $s);
-						$s = str_replace(">", "&gt;", $s);
+                        $s = str_replace(array("<", ">"), array("&lt;", "&gt;"), $s);
 
 						// Check Vietnamese if Latin script - even if Basescript
 						if ($scriptblocks[$sch] == Ucdn::SCRIPT_LATIN && $this->autoVietnamese && preg_match("/([" . $this->scriptToLanguage->getLanguageDelimiters('viet') . "])/u", $s)) {
@@ -26614,11 +26611,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	{
 		// supports the most used entity codes (only does ascii safe characters)
 		$html = str_replace("&lt;", "<", $html);
-		$html = str_replace("&gt;", ">", $html);
-
-		$html = str_replace("&apos;", "'", $html);
-		$html = str_replace("&quot;", '"', $html);
-		$html = str_replace("&amp;", "&", $html);
+        $html = str_replace(array("&gt;", "&apos;"), array(">", "'"), $html);
+        $html = str_replace(array("&quot;", "&amp;"), array('"', "&"), $html);
 
 		return $html;
 	}
@@ -26679,8 +26673,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Concatenates any Substitute characters from symbols/dingbats
 		$html = str_replace('</tts><tts>', '|', $html);
-		$html = str_replace('</ttz><ttz>', '|', $html);
-		$html = str_replace('</tta><tta>', '|', $html);
+        $html = str_replace(array('</ttz><ttz>', '</tta><tta>'), '|', $html);
 
 		$html = preg_replace('/<br \/>\s*/is', "<br />", $html);
 
@@ -26765,12 +26758,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Restore original tag names
-		$html = str_replace("<erp", "<pre", $html);
-		$html = str_replace("</erp>", "</pre>", $html);
-		$html = str_replace("<aeratxet", "<textarea", $html);
-		$html = str_replace("</aeratxet>", "</textarea>", $html);
-		$html = str_replace("</innerpre", "</pre", $html);
-		$html = str_replace("<innerpre", "<pre", $html);
+        $html = str_replace(array("<erp", "</erp>"), array("<pre", "</pre>"), $html);
+        $html = str_replace(array("<aeratxet", "</aeratxet>"), array("<textarea", "</textarea>"), $html);
+        $html = str_replace(array("</innerpre", "<innerpre"), array("</pre", "<pre"), $html);
 
 		$html = preg_replace('/<textarea([^>]*)><\/textarea>/si', '<textarea\\1> </textarea>', $html);
 		$html = preg_replace('/(<table[^>]*>)\s*(<caption)(.*?<\/caption>)(.*?<\/table>)/si', '\\2 position="top"\\3\\1\\4\\2 position="bottom"\\3', $html); // *TABLES*

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -7289,7 +7289,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						throw new \Mpdf\MpdfException('Class Mpdf\QrCode\QrCode does not exists. Install the package from Packagist with "composer require mpdf/qrcode"');
 					}
 
-                    $barcodeContent = str_replace(array('\r\n', '\n'), array("\r\n", "\n"), $objattr['code']);
+                    $barcodeContent = str_replace(['\r\n', '\n'], ["\r\n", "\n"], $objattr['code']);
 
 					$qrcode = new QrCode\QrCode($barcodeContent, $objattr['errorlevel']);
 					if ($objattr['disableborder']) {
@@ -9536,8 +9536,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->x = $this->lMargin;
 				$this->y = $this->margin_header;
-				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace(array($this->aliasNbPgGp, $this->aliasNbPg), array($pntstr, $nb), $html); // {nbpg}, {nb}
+				$html = str_replace(['{PAGENO}', $this->aliasNbPgGp, $this->aliasNbPg], [$pnstr, $pntstr, $nb], $html); // {nbpg}, {nb}
 				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 
 				$this->HTMLheaderPageLinks = [];
@@ -9616,8 +9615,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$top_y = $this->y = ($this->h + 0.01);
 				}
 
-				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace(array($this->aliasNbPgGp, $this->aliasNbPg), array($pntstr, $nb), $html); // {nbpg}, {nb}
+				$html = str_replace(['{PAGENO}', $this->aliasNbPgGp, $this->aliasNbPg], [$pnstr, $pntstr, $nb], $html); // {nbpg}, {nb}
 				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 
 
@@ -12224,12 +12222,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$save_y = $this->y;
 		$this->x = $this->lMargin;
 		$this->y = $this->margin_header;
-		$html = str_replace('{PAGENO}', $this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix, $html);
-        $html = str_replace(
-            array($this->aliasNbPgGp, $this->aliasNbPg),
-            array($this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $this->page),
-            $html
-        );
+		$html = str_replace(array('{PAGENO}', $this->aliasNbPgGp, $this->aliasNbPg), [$this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix, $this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $this->page], $html);
 		$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
 		$this->HTMLheaderPageLinks = [];
 		$this->HTMLheaderPageAnnots = [];
@@ -13188,8 +13181,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Don't allow non-breaking spaces that are converted to substituted chars or will break anyway and mess up table width calc.
-        $html = str_replace(array('<tta>160</tta>', '</tta><tta>'), array(chr(32), '|'), $html);
-        $html = str_replace(array('</tts><tts>', '</ttz><ttz>'), '|', $html);
+        $html = str_replace(array('<tta>160</tta>', '</tta><tta>', '</tts><tts>', '</ttz><ttz>'), [chr(32), '|', '|', '|'], $html);
 
 		// Add new supported tags in the DisableTags function
 		$html = strip_tags($html, $this->enabledtags); // remove all unsupported tags, but the ones inside the 'enabledtags' string
@@ -26471,8 +26463,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						}
 
 						// ZZZ99 Undo lesser_entity_decode as above - but only for <>&
-						$s = str_replace("&", "&amp;", $s);
-                        $s = str_replace(array("<", ">"), array("&lt;", "&gt;"), $s);
+						$s = str_replace(array("&", "<", ">"), ["&amp;", "&lt;", "&gt;"], $s);
 
 						// Check Vietnamese if Latin script - even if Basescript
 						if ($scriptblocks[$sch] == Ucdn::SCRIPT_LATIN && $this->autoVietnamese && preg_match("/([" . $this->scriptToLanguage->getLanguageDelimiters('viet') . "])/u", $s)) {
@@ -26611,8 +26602,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	{
 		// supports the most used entity codes (only does ascii safe characters)
 		$html = str_replace("&lt;", "<", $html);
-        $html = str_replace(array("&gt;", "&apos;"), array(">", "'"), $html);
-        $html = str_replace(array("&quot;", "&amp;"), array('"', "&"), $html);
+        $html = str_replace(array("&gt;", "&apos;","&quot;", "&amp;"), [">", "'", '"', "&"], $html);
 
 		return $html;
 	}
@@ -26672,8 +26662,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$html = preg_replace("/[ ]*<dottab\s*[\/]*>[ ]*/", '<dottab />', $html);
 
 		// Concatenates any Substitute characters from symbols/dingbats
-		$html = str_replace('</tts><tts>', '|', $html);
-        $html = str_replace(array('</ttz><ttz>', '</tta><tta>'), '|', $html);
+		$html = str_replace(array('</tts><tts>','</ttz><ttz>', '</tta><tta>'), '|', $html);
 
 		$html = preg_replace('/<br \/>\s*/is', "<br />", $html);
 
@@ -26759,8 +26748,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Restore original tag names
         $html = str_replace(array("<erp", "</erp>"), array("<pre", "</pre>"), $html);
-        $html = str_replace(array("<aeratxet", "</aeratxet>"), array("<textarea", "</textarea>"), $html);
-        $html = str_replace(array("</innerpre", "<innerpre"), array("</pre", "<pre"), $html);
+        $html = str_replace(array("<aeratxet", "</aeratxet>", "</innerpre", "<innerpre"), ["<textarea", "</textarea>", "</pre", "<pre"], $html);
 
 		$html = preg_replace('/<textarea([^>]*)><\/textarea>/si', '<textarea\\1> </textarea>', $html);
 		$html = preg_replace('/(<table[^>]*>)\s*(<caption)(.*?<\/caption>)(.*?<\/table>)/si', '\\2 position="top"\\3\\1\\4\\2 position="bottom"\\3', $html); // *TABLES*

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -26705,7 +26705,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				} elseif (preg_match('/^<\/pre/i', $s)) {
 					$c--;
 				}
-				array_push($h, $s);
+				$h[] = $s;
 			}
 
 			$html = implode('', $h);

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1338,13 +1338,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 		} elseif (substr($mode, -2) == '-s') {
 			$this->percentSubset = 100;
-			$mode = substr($mode, 0, strlen($mode) - 2);
+			$mode = substr($mode, 0, -2);
 		} elseif (substr($mode, -2) == '-c') {
 			$onlyCoreFonts = true;
-			$mode = substr($mode, 0, strlen($mode) - 2);
+			$mode = substr($mode, 0, -2);
 		} elseif (substr($mode, -2) == '-x') {
 			$optcore = true;
-			$mode = substr($mode, 0, strlen($mode) - 2);
+			$mode = substr($mode, 0, -2);
 		}
 
 		// Autodetect if mode is a language_country string (en-GB or en_GB or en)

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2043,12 +2043,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$h = $ch;
 				}
 			} else {
-				if (stristr($size['w'], '%')) {
+				if (false !== stripos($size['w'], '%')) {
 					$size['w'] = (float) $size['w'];
 					$size['w'] /= 100;
 					$size['w'] = ($cw * $size['w']);
 				}
-				if (stristr($size['h'], '%')) {
+				if (false !== stripos($size['h'], '%')) {
 					$size['h'] = (float) $size['h'];
 					$size['h'] /= 100;
 					$size['h'] = ($ch * $size['h']);
@@ -2107,9 +2107,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		if (isset($properties['BACKGROUND-SIZE'])) {
-			if (stristr($properties['BACKGROUND-SIZE'], 'contain')) {
+			if (false !== stripos($properties['BACKGROUND-SIZE'], 'contain')) {
 				$bsw = $bsh = 'contain';
-			} elseif (stristr($properties['BACKGROUND-SIZE'], 'cover')) {
+			} elseif (false !== stripos($properties['BACKGROUND-SIZE'], 'cover')) {
 				$bsw = $bsh = 'cover';
 			} else {
 				$bsw = $bsh = 'auto';
@@ -2120,10 +2120,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				} else {
 					$bsw = $sz[0];
 				}
-				if (!stristr($bsw, '%') && !stristr($bsw, 'auto')) {
+				if (false === stripos($bsw, '%') && false === stripos($bsw, 'auto')) {
 					$bsw = $this->sizeConverter->convert($bsw, $maxwidth, $this->FontSize);
 				}
-				if (!stristr($bsh, '%') && !stristr($bsh, 'auto')) {
+				if (false === stripos($bsh, '%') && false === stripos($bsh, 'auto')) {
 					$bsh = $this->sizeConverter->convert($bsh, $maxwidth, $this->FontSize);
 				}
 			}
@@ -2168,10 +2168,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$ppos = preg_split('/\s+/', $properties['BACKGROUND-POSITION']);
 					$x_pos = $ppos[0];
 					$y_pos = $ppos[1];
-					if (!stristr($x_pos, '%')) {
+					if (false === stripos($x_pos, '%')) {
 						$x_pos = $this->sizeConverter->convert($x_pos, $maxwidth, $this->FontSize);
 					}
-					if (!stristr($y_pos, '%')) {
+					if (false === stripos($y_pos, '%')) {
 						$y_pos = $this->sizeConverter->convert($y_pos, $maxwidth, $this->FontSize);
 					}
 				}
@@ -2458,7 +2458,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						}
 
 						$x_pos = $pb['x_pos'];
-						if (stristr($x_pos, '%')) {
+						if (false !== stripos($x_pos, '%')) {
 							$x_pos = (float) $x_pos;
 							$x_pos /= 100;
 							$x_pos = ($pb['bpa']['w'] * $x_pos) - ($iw * $x_pos);
@@ -2466,7 +2466,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 						$y_pos = $pb['y_pos'];
 
-						if (stristr($y_pos, '%')) {
+						if (false !== stripos($y_pos, '%')) {
 							$y_pos = (float) $y_pos;
 							$y_pos /= 100;
 							$y_pos = ($pb['bpa']['h'] * $y_pos) - ($ih * $y_pos);
@@ -13552,7 +13552,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 					// Fix path values, if needed
 					$orig_srcpath = '';
-					if ((stristr($e, "href=") !== false) or ( stristr($e, "src=") !== false)) {
+					if ((false !== stripos($e, "href=")) or (false !== stripos($e, "src="))) {
 						$regexp = '/ (href|src)\s*=\s*"(.*?)"/i';
 						preg_match($regexp, $e, $auxiliararray);
 						if (isset($auxiliararray[2])) {
@@ -13560,7 +13560,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						} else {
 							$path = '';
 						}
-						if (trim($path) != '' && !(stristr($e, "src=") !== false && substr($path, 0, 4) == 'var:') && substr($path, 0, 1) != '@') {
+						if (trim($path) != '' && !(false !== stripos($e, "src=") && substr($path, 0, 4) == 'var:') && substr($path, 0, 1) != '@') {
 							$path = htmlspecialchars_decode($path); // mPDF 5.7.4 URLs
 							$orig_srcpath = $path;
 							$this->GetFullPath($path);
@@ -17415,14 +17415,14 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					if (isset($this->blk[$blvl]['background-image']['size']['w']) && $this->blk[$blvl]['background-image']['size']['w']) {
 						$size = $this->blk[$blvl]['background-image']['size'];
 						if ($size['w'] != 'contain' && $size['w'] != 'cover') {
-							if (stristr($size['w'], '%')) {
+							if (false !== stripos($size['w'], '%')) {
 								$size['w'] = (float) $size['w'];
 								$size['w'] /= 100;
 								$w *= $size['w'];
 							} elseif ($size['w'] != 'auto') {
 								$w = $size['w'];
 							}
-							if (stristr($size['h'], '%')) {
+							if (false !== stripos($size['h'], '%')) {
 								$size['h'] = (float) $size['h'];
 								$size['h'] /= 100;
 								$h *= $size['h'];
@@ -18679,7 +18679,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		// Needs to be set at the end - after vertical-align = super/sub, so that textparam['text-baseline'] is set
 		if (isset($arrayaux['TEXT-DECORATION'])) {
 			$v = $arrayaux['TEXT-DECORATION']; // none underline line-through (strikeout) // Does not support: blink
-			if (stristr($v, 'LINE-THROUGH')) {
+			if (false !== stripos($v, 'LINE-THROUGH')) {
 				$this->textvar = ($this->textvar | TextVars::FD_LINETHROUGH);
 				// mPDF 5.7.3  inline text-decoration parameters
 				if (isset($this->textparam['text-baseline'])) {
@@ -18691,7 +18691,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->textparam['s-decoration']['fontsize'] = $this->FontSize;
 				$this->textparam['s-decoration']['color'] = strtoupper($this->TextColor); // change 0 0 0 rg to 0 0 0 RG
 			}
-			if (stristr($v, 'UNDERLINE')) {
+			if (false !== stripos($v, 'UNDERLINE')) {
 				$this->textvar = ($this->textvar | TextVars::FD_UNDERLINE);
 				// mPDF 5.7.3  inline text-decoration parameters
 				if (isset($this->textparam['text-baseline'])) {
@@ -18703,7 +18703,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->textparam['u-decoration']['fontsize'] = $this->FontSize;
 				$this->textparam['u-decoration']['color'] = strtoupper($this->TextColor); // change 0 0 0 rg to 0 0 0 RG
 			}
-			if (stristr($v, 'OVERLINE')) {
+			if (false !== stripos($v, 'OVERLINE')) {
 				$this->textvar = ($this->textvar | TextVars::FD_OVERLINE);
 				// mPDF 5.7.3  inline text-decoration parameters
 				if (isset($this->textparam['text-baseline'])) {
@@ -18715,7 +18715,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->textparam['o-decoration']['fontsize'] = $this->FontSize;
 				$this->textparam['o-decoration']['color'] = strtoupper($this->TextColor); // change 0 0 0 rg to 0 0 0 RG
 			}
-			if (stristr($v, 'NONE')) {
+			if (false !== stripos($v, 'NONE')) {
 				$this->textvar = ($this->textvar & ~TextVars::FD_UNDERLINE);
 				$this->textvar = ($this->textvar & ~TextVars::FD_LINETHROUGH);
 				$this->textvar = ($this->textvar & ~TextVars::FD_OVERLINE);
@@ -25799,7 +25799,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			$code .= $arrcode['checkdigit'];
 
-			if (stristr($codestr, '-')) {
+			if (false !== stripos($codestr, '-')) {
 				$codestr .= '-' . $arrcode['checkdigit'];
 			} else {
 				$codestr .= $arrcode['checkdigit'];

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -4543,8 +4543,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$kashida_present = false;
 		$kashida_space = 0;
 		if ($w > 0 && $inclCursive && isset($this->CurrentFont['useKashida']) && $this->CurrentFont['useKashida'] && !empty($cOTLdata)) {
-			for ($c = 0; $c < count($cOTLdata); $c++) {
-				for ($i = 0; $i < strlen($cOTLdata[$c]['group']); $i++) {
+			for ($c = 0, $cMax = count($cOTLdata); $c < $cMax; $c++) {
+				for ($i = 0, $iMax = strlen($cOTLdata[$c]['group']); $i < $iMax; $i++) {
 					if (isset($cOTLdata[$c]['GPOSinfo'][$i]['kashida']) && $cOTLdata[$c]['GPOSinfo'][$i]['kashida'] > 0) {
 						$kashida_present = true;
 						break 2;
@@ -4560,8 +4560,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$max_kashida_in_word = 0;
 			$last_kashida_in_word = -1;
 
-			for ($c = 0; $c < count($cOTLdata); $c++) {
-				for ($i = 0; $i < strlen($cOTLdata[$c]['group']); $i++) {
+			for ($c = 0, $cMax = count($cOTLdata); $c < $cMax; $c++) {
+				for ($i = 0, $iMax = strlen($cOTLdata[$c]['group']); $i < $iMax; $i++) {
 					if ($cOTLdata[$c]['group']{$i} == 'S') {
 						// Save from last word
 						if ($max_kashida_in_word) {
@@ -4608,8 +4608,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			// Otherwise fontstretch is too small and errors
 			// If not just leave to adjust word-spacing
 			if ($tatw && (($kashida_space / $k_ctr) / $tatw) > 0.01) {
-				for ($c = 0; $c < count($cOTLdata); $c++) {
-					for ($i = 0; $i < strlen($cOTLdata[$c]['group']); $i++) {
+				for ($c = 0, $cMax = count($cOTLdata); $c < $cMax; $c++) {
+					for ($i = 0, $iMax = strlen($cOTLdata[$c]['group']); $i < $iMax; $i++) {
 						if (isset($cOTLdata[$c]['GPOSinfo'][$i]['kashida']) && $cOTLdata[$c]['GPOSinfo'][$i]['kashida'] > 0) {
 							// At this point kashida is a number representing priority (higher number - higher priority)
 							// We are now going to set it as an actual length
@@ -5402,7 +5402,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$tj = '(';
 		}
 
-		for ($i = 0; $i < count($unicode); $i++) {
+		for ($i = 0, $iMax = count($unicode); $i < $iMax; $i++) {
 			$c = $unicode[$i];
 			$tx = '';
 			$XshiftBefore = $XshiftAfter;
@@ -5714,12 +5714,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$space = $this->writer->escape($space);
 			$s = sprintf(' BT ' . $aix, $x * Mpdf::SCALE, ($this->h - $y) * Mpdf::SCALE);
 			$t = explode(' ', $txt);
-			for ($i = 0; $i < count($t); $i++) {
+			for ($i = 0, $iMax = count($t); $i < $iMax; $i++) {
 				$tx = $t[$i];
 
 				$tj = '(';
 				$unicode = $this->UTF8StringToArray($tx);
-				for ($ti = 0; $ti < count($unicode); $ti++) {
+				for ($ti = 0, $tiMax = count($unicode); $ti < $tiMax; $ti++) {
 					if ($ti > 0 && isset($this->CurrentFont['kerninfo'][$unicode[($ti - 1)]][$unicode[$ti]])) {
 						$kern = -$this->CurrentFont['kerninfo'][$unicode[($ti - 1)]][$unicode[$ti]];
 						$tj .= sprintf(')%d(', $kern);
@@ -5741,7 +5741,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$s = '';
 			$tj = '(';
 			$unicode = $this->UTF8StringToArray($txt);
-			for ($i = 0; $i < count($unicode); $i++) {
+			for ($i = 0, $iMax = count($unicode); $i < $iMax; $i++) {
 				if ($i > 0 && isset($this->CurrentFont['kerninfo'][$unicode[($i - 1)]][$unicode[$i]])) {
 					$kern = -$this->CurrentFont['kerninfo'][$unicode[($i - 1)]][$unicode[$i]];
 					$tj .= sprintf(')%d(', $kern);
@@ -7105,7 +7105,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$cy = $y + $h / 2;
 					preg_match_all('/(translatex|translatey|translate|scalex|scaley|scale|rotate|skewX|skewY|skew)\((.*?)\)/is', $objattr['transform'], $m);
 					if (count($m[0])) {
-						for ($i = 0; $i < count($m[0]); $i++) {
+						for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 							$c = strtolower($m[1][$i]);
 							$v = trim($m[2][$i]);
 							$vv = preg_split('/[ ,]+/', $v);
@@ -9806,7 +9806,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 				if (count($m[0])) {
 					$sortarr = [];
-					for ($i = 0; $i < count($m[0]); $i++) {
+					for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 						$key = $m[1][$i] * 2;
 						if ($m[3][$i] == 'EMCZ') {
 							$key +=2; // background first then gradient then normal
@@ -13132,14 +13132,14 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		preg_match_all('/<htmlpageheader([^>]*)>(.*?)<\/htmlpageheader>/si', $html, $h);
-		for ($i = 0; $i < count($h[1]); $i++) {
+		for ($i = 0, $iMax = count($h[1]); $i < $iMax; $i++) {
 			if (preg_match('/name=[\'|\"](.*?)[\'|\"]/', $h[1][$i], $n)) {
 				$this->pageHTMLheaders[$n[1]]['html'] = $h[2][$i];
 				$this->pageHTMLheaders[$n[1]]['h'] = $this->_getHtmlHeight($h[2][$i]);
 			}
 		}
 		preg_match_all('/<htmlpagefooter([^>]*)>(.*?)<\/htmlpagefooter>/si', $html, $f);
-		for ($i = 0; $i < count($f[1]); $i++) {
+		for ($i = 0, $iMax = count($f[1]); $i < $iMax; $i++) {
 			if (preg_match('/name=[\'|\"](.*?)[\'|\"]/', $f[1][$i], $n)) {
 				$this->pageHTMLfooters[$n[1]]['html'] = $f[2][$i];
 				$this->pageHTMLfooters[$n[1]]['h'] = $this->_getHtmlHeight($f[2][$i]);
@@ -15361,7 +15361,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$maxnum = $this->listcounter[$this->listlvl];
 		if ($currblk['list_style_type'] != 'disc' && $currblk['list_style_type'] != 'circle' && $currblk['list_style_type'] != 'square') {
 			$lvl = 1;
-			for ($j = $i + 2; $j < count($a); $j+=2) {
+			for ($j = $i + 2, $jMax = count($a); $j < $jMax; $j+=2) {
 				$e = $a[$j];
 				if (!$e) {
 					continue;
@@ -17862,7 +17862,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		preg_match_all('/<meta [^>]*?(name|content)="([^>]*?)" [^>]*?(name|content)="([^>]*?)".*?>/si', $html, $aux);
 		$firstattr = $aux[1];
 		$secondattr = $aux[3];
-		for ($i = 0; $i < count($aux[0]); $i++) {
+		for ($i = 0, $iMax = count($aux[0]); $i < $iMax; $i++) {
 			$name = ( strtoupper($firstattr[$i]) == "NAME" ) ? strtoupper($aux[2][$i]) : strtoupper($aux[4][$i]);
 			$content = ( strtoupper($firstattr[$i]) == "CONTENT" ) ? $aux[2][$i] : $aux[4][$i];
 			switch ($name) {
@@ -20542,7 +20542,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		} elseif ($bord) {
 			if (!$bSeparate && $buffer) {
 				$priority = 'LRTB';
-				for ($p = 0; $p < strlen($priority); $p++) {
+				for ($p = 0, $pMax = strlen($priority); $p < $pMax; $p++) {
 					$side = $priority[$p];
 					$details['p'] = $side;
 
@@ -20624,7 +20624,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$y2 = $y + $h;
 			$oldlinewidth = $this->LineWidth;
 
-			for ($p = 0; $p < strlen($priority); $p++) {
+			for ($p = 0, $pMax = strlen($priority); $p < $pMax; $p++) {
 				$side = $priority[$p];
 				$xadj = 0;
 				$xadj2 = 0;
@@ -21532,7 +21532,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					}
 					// Nested content
 					if (isset($cell['textbuffer'])) {
-						for ($n = 0; $n < count($cell['textbuffer']); $n++) {
+						for ($n = 0, $nMax = count($cell['textbuffer']); $n < $nMax; $n++) {
 							$t = $cell['textbuffer'][$n][0];
 							if (substr($t, 0, 19) == "\xbb\xa4\xactype=nestedtable") {
 								$objattr = $this->_getObjAttr($t);
@@ -22995,7 +22995,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	function _putextgstates()
 	{
-		for ($i = 1; $i <= count($this->extgstates); $i++) {
+		for ($i = 1, $iMax = count($this->extgstates); $i <= $iMax; $i++) {
 			$this->writer->object();
 			$this->extgstates[$i]['n'] = $this->n;
 			$this->writer->write('<</Type /ExtGState');
@@ -23820,7 +23820,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 					$html .= $spacer;
 
-					for ($zi = 1; $zi < count($ppp); $zi++) {
+					for ($zi = 1, $ziMax = count($ppp); $zi < $ziMax; $zi++) {
 						if ($ppp[$zi] == ($ppp[($zi - 1)] + 1)) {
 							$range_end = $ppp[$zi];
 						} else {
@@ -24846,7 +24846,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 				$Present = 0;
 
-				for ($i = 0; $i < count($this->Reference); $i++) {
+				for ($i = 0, $iMax = count($this->Reference); $i < $iMax; $i++) {
 					if ($this->Reference[$i]['t'] == $v['t']) {
 						$Present = 1;
 						if (!in_array($v['op'], $this->Reference[$i]['p'])) {
@@ -24950,7 +24950,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$Present = 0;
 
 			// Search the reference (AND Ref/PageNo) in the array
-			for ($i = 0; $i < count($this->Reference); $i++) {
+			for ($i = 0, $iMax = count($this->Reference); $i < $iMax; $i++) {
 				if ($this->Reference[$i]['t'] == $v['t']) {
 					$Present = 1;
 					if (!in_array($this->page, $this->Reference[$i]['p'])) {
@@ -26466,7 +26466,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 					if (isset($chardata[$sch])) {
 						$s = '';
-						for ($j = 0; $j < count($chardata[$sch]); $j++) {
+						for ($j = 0, $jMax = count($chardata[$sch]); $j < $jMax; $j++) {
 							$s .= UtfString::code2utf($chardata[$sch][$j]['uni']);
 						}
 
@@ -26629,7 +26629,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		preg_match_all("/(<annotation.*?>)/si", $html, $m);
 		if (count($m[1])) {
-			for ($i = 0; $i < count($m[1]); $i++) {
+			for ($i = 0, $iMax = count($m[1]); $i < $iMax; $i++) {
 				$sub = preg_replace("/\n/si", "\xbb\xa4\xac", $m[1][$i]);
 				$html = preg_replace('/' . preg_quote($m[1][$i], '/') . '/si', $sub, $html);
 			}
@@ -26637,7 +26637,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		preg_match_all("/(<svg.*?<\/svg>)/si", $html, $svgi);
 		if (count($svgi[0])) {
-			for ($i = 0; $i < count($svgi[0]); $i++) {
+			for ($i = 0, $iMax = count($svgi[0]); $i < $iMax; $i++) {
 				$file = $this->cache->write('/_tempSVG' . uniqid(random_int(1, 100000), true) . '_' . $i . '.svg', $svgi[0][$i]);
 				$html = str_replace($svgi[0][$i], '<img src="' . $file . '" />', $html);
 			}
@@ -26818,7 +26818,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		preg_match("/xref\n0 (\d+)\n(.*?)\ntrailer/s", $pdf, $m);
 		$xref_objid = $m[1];
 		preg_match_all('/(\d{10}) (\d{5}) (f|n)/', $m[2], $x);
-		for ($i = 0; $i < count($x[0]); $i++) {
+		for ($i = 0, $iMax = count($x[0]); $i < $iMax; $i++) {
 			$xref[] = [intval($x[1][$i]), $x[2][$i], $x[3][$i]];
 		}
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -7289,7 +7289,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						throw new \Mpdf\MpdfException('Class Mpdf\QrCode\QrCode does not exists. Install the package from Packagist with "composer require mpdf/qrcode"');
 					}
 
-                    $barcodeContent = str_replace(['\r\n', '\n'], ["\r\n", "\n"], $objattr['code']);
+					$barcodeContent = str_replace(['\r\n', '\n'], ["\r\n", "\n"], $objattr['code']);
 
 					$qrcode = new QrCode\QrCode($barcodeContent, $objattr['errorlevel']);
 					if ($objattr['disableborder']) {
@@ -13181,7 +13181,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Don't allow non-breaking spaces that are converted to substituted chars or will break anyway and mess up table width calc.
-        $html = str_replace(array('<tta>160</tta>', '</tta><tta>', '</tts><tts>', '</ttz><ttz>'), [chr(32), '|', '|', '|'], $html);
+		$html = str_replace(array('<tta>160</tta>', '</tta><tta>', '</tts><tts>', '</ttz><ttz>'), [chr(32), '|', '|', '|'], $html);
 
 		// Add new supported tags in the DisableTags function
 		$html = strip_tags($html, $this->enabledtags); // remove all unsupported tags, but the ones inside the 'enabledtags' string
@@ -26602,7 +26602,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	{
 		// supports the most used entity codes (only does ascii safe characters)
 		$html = str_replace("&lt;", "<", $html);
-        $html = str_replace(array("&gt;", "&apos;","&quot;", "&amp;"), [">", "'", '"', "&"], $html);
+		$html = str_replace(["&gt;", "&apos;","&quot;", "&amp;"], [">", "'", '"', "&"], $html);
 
 		return $html;
 	}
@@ -26747,8 +26747,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Restore original tag names
-        $html = str_replace(array("<erp", "</erp>"), array("<pre", "</pre>"), $html);
-        $html = str_replace(array("<aeratxet", "</aeratxet>", "</innerpre", "<innerpre"), ["<textarea", "</textarea>", "</pre", "<pre"], $html);
+		$html = str_replace(["<erp", "</erp>"], ["<pre", "</pre>"], $html);
+		$html = str_replace(["<aeratxet", "</aeratxet>", "</innerpre", "<innerpre"], ["<textarea", "</textarea>", "</pre", "<pre"], $html);
 
 		$html = preg_replace('/<textarea([^>]*)><\/textarea>/si', '<textarea\\1> </textarea>', $html);
 		$html = preg_replace('/(<table[^>]*>)\s*(<caption)(.*?<\/caption>)(.*?<\/table>)/si', '\\2 position="top"\\3\\1\\4\\2 position="bottom"\\3', $html); // *TABLES*

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -310,7 +310,7 @@ class Otl
 
 			if (!$GSUBscriptTag && !$GSUBlangsys && !$GPOSscriptTag && !$GPOSlangsys) {
 				// Remove ZWJ and ZWNJ
-				$iMax = count($this->OTLdata)
+				$iMax = count($this->OTLdata);
 				for ($i = 0; $i < $iMax; $i++) {
 					if ($this->OTLdata[$i]['uni'] == 8204 || $this->OTLdata[$i]['uni'] == 8205) {
 						array_splice($this->OTLdata, $i, 1);

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -310,7 +310,8 @@ class Otl
 
 			if (!$GSUBscriptTag && !$GSUBlangsys && !$GPOSscriptTag && !$GPOSlangsys) {
 				// Remove ZWJ and ZWNJ
-				for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+				$iMax = count($this->OTLdata)
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($this->OTLdata[$i]['uni'] == 8204 || $this->OTLdata[$i]['uni'] == 8205) {
 						array_splice($this->OTLdata, $i, 1);
 					}
@@ -438,7 +439,8 @@ class Otl
 					// c. Set Kashida points (after joining occurred - medi, fina, init) but before other substitutions
 					//-----------------------------------------------------------------------------------
 					//if ($scriptblock == Ucdn::SCRIPT_ARABIC ) {
-					for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+					$iMax = count($this->OTLdata);
+					for ($i = 0; $i < $iMax; $i++) {
 						// Put the kashida marker on the character BEFORE which is inserted the kashida
 						// Kashida marker is inverse of priority i.e. Priority 1 => 7, Priority 7 => 1.
 						// Priority 1   User-inserted Kashida 0640 = Tatweel
@@ -530,7 +532,8 @@ class Otl
 					// e. NOT IN SPEC
 					// If space precedes a mark -> substitute a &nbsp; before the Mark, to prevent line breaking Test:
 					//-----------------------------------------------------------------------------------
-					for ($ptr = 1, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
+					$ptrMax = count($this->OTLdata);
+					for ($ptr = 1; $ptr < $ptrMax; $ptr++) {
 						if ($this->OTLdata[$ptr]['general_category'] == Ucdn::UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK && $this->OTLdata[$ptr - 1]['uni'] == 32) {
 							$this->OTLdata[$ptr - 1]['uni'] = 0xa0;
 							$this->OTLdata[$ptr - 1]['hex'] = '000A0';
@@ -544,12 +547,14 @@ class Otl
 					// a. First decompose/compose split mattras
 					// (normalize) ??????? Nukta/Halant order etc ??????????????????????????????????????????????????????????????????????????
 					//-----------------------------------------------------------------------------------
-					for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
+					$ptrMax = count($this->OTLdata);
+					for ($ptr = 0; $ptr < $ptrMax; $ptr++) {
 						$char = $this->OTLdata[$ptr]['uni'];
 						$sub = Indic::decompose_indic($char);
 						if ($sub) {
 							$newinfo = [];
-							for ($i = 0, $iMax = count($sub); $i < $iMax; $i++) {
+							$iMax = count($sub);
+							for ($i = 0; $i < $iMax; $i++) {
 								$newinfo[$i] = [];
 								$ucd_record = Ucdn::get_ucd_record($sub[$i]);
 								$newinfo[$i]['general_category'] = $ucd_record[0];
@@ -849,7 +854,8 @@ class Otl
 					 * Lao versions are the same as Thai + 0x80.
 					 */
 					if ($this->shaper == 'T' || $this->shaper == 'L') {
-						for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
+						$ptrMax = count($this->OTLdata);
+						for ($ptr = 0; $ptr < $ptrMax; $ptr++) {
 							$char = $this->OTLdata[$ptr]['uni'];
 							if (($char & ~0x0080) == 0x0E33) { // if SARA_AM (U+0E33 or U+0EB3)
 								$NIKHAHIT = $char + 0x1A;
@@ -1006,7 +1012,8 @@ class Otl
 			//=======================================================
 			if ($this->shaper == 'I' || $this->shaper == 'S' || $this->shaper == 'A' || $this->shaper == 'K' || $this->shaper == 'M') {
 				// Remove ZWJ and ZWNJ
-				for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+				$iMax = count($this->OTLdata);
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($this->OTLdata[$i]['uni'] == 8204 || $this->OTLdata[$i]['uni'] == 8205) {
 						array_splice($this->OTLdata, $i, 1);
 						$this->_updateLigatureMarks($i, -1);
@@ -1126,7 +1133,8 @@ class Otl
 					}
 					// LTR
 					$incurs = false;
-					for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+					$iMax = count($this->OTLdata);
+					for ($i = 0; $i < $iMax; $i++) {
 						if (isset($this->Exit[$i]) && isset($this->Exit[$i]['Y']) && $this->Exit[$i]['dir'] == 'LTR') {
 							$nextbase = $i + 1; // Set as next base ignoring marks
 							while (strpos($this->GlyphClassMarks, $this->OTLdata[$nextbase]['hex']) !== false) {
@@ -1187,7 +1195,8 @@ class Otl
 		$ectr = 0;
 
 		for ($sch = 0; $sch <= $subchunk; $sch++) {
-			for ($i = 0, $iMax = count($this->schOTLdata[$sch]); $i < $iMax; $i++) {
+			$iMax = count($this->schOTLdata[$sch]);
+			for ($i = 0; $i < $iMax; $i++) {
 				if (isset($this->schOTLdata[$sch][$i]['GPOSinfo'])) {
 					$newGPOSinfo[$ectr] = $this->schOTLdata[$sch][$i]['GPOSinfo'];
 				}
@@ -1229,7 +1238,8 @@ class Otl
 			$fp = $this->mpdf->OTLtags['Plus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $fp, $m);
-		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+		$iMax = count($m[0]);
+		for ($i = 0; $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1242,7 +1252,8 @@ class Otl
 			$fm = $this->mpdf->OTLtags['Minus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $fm, $m);
-		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+		$iMax = count($m[0]);
+		for ($i = 0; $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1255,7 +1266,8 @@ class Otl
 			$ffp = $this->mpdf->OTLtags['FFPlus']; // Font Features - may include integer: salt4
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})([\d+]*)/', $ffp, $m);
-		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+		$iMax = count($m[0]);
+		for ($i = 0; $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1268,7 +1280,8 @@ class Otl
 			$ffm = $this->mpdf->OTLtags['FFMinus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $ffm, $m);
-		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
+		$iMax = count($m[0]);
+		for ($i = 0; $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1957,7 +1970,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($InputClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -2182,7 +2196,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($InputClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -2203,7 +2218,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$bclass0excl = [];
-							for ($gc = 1, $gcMax = count($BacktrackClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($BacktrackClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($BacktrackClasses[$gc])) {
 									$bclass0excl = $bclass0excl + $BacktrackClasses[$gc];
 								}
@@ -2225,7 +2241,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$lclass0excl = [];
-							for ($gc = 1, $gcMax = count($LookaheadClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($LookaheadClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($LookaheadClasses[$gc])) {
 									$lclass0excl = $lclass0excl + $LookaheadClasses[$gc];
 								}
@@ -2394,14 +2411,16 @@ class Otl
 		} elseif ($n < 1) { // glyphs removed
 			$nrem = -$n;
 			// Update position of pre-existing Ligatures and associated Marks
-			for ($p = ($pos + 1), $pMax = count($this->OTLdata); $p < $pMax; $p++) {
+			$pMax = count($this->OTLdata);
+			for ($p = ($pos + 1); $p < $pMax; $p++) {
 				if (isset($this->assocLigs[$p])) {
 					$tmp = $this->assocLigs[$p];
 					unset($this->assocLigs[$p]);
 					$this->assocLigs[($p - $nrem)] = $tmp;
 				}
 			}
-			for ($p = 0, $pMax = count($this->OTLdata); $p < $pMax; $p++) {
+			$pMax = count($this->OTLdata);
+			for ($p = 0; $p < $pMax; $p++) {
 				if (isset($this->assocMarks[$p])) {
 					if ($this->assocMarks[$p]['ligPos'] >= ($pos)) {
 						$this->assocMarks[$p]['ligPos'] -= $nrem;
@@ -2427,7 +2446,8 @@ class Otl
 			return 1;
 		} // LookupType 2: Multiple Substitution Subtable : 1 to n
 		elseif ($Type == 2) {
-			for ($i = 0, $iMax = count($substitute); $i < $iMax; $i++) {
+			$iMax = count($substitute);
+			for ($i = 0; $i < $iMax; $i++) {
 				$uni = $substitute[$i];
 				$newOTLdata[$i] = [];
 				$newOTLdata[$i]['uni'] = $uni;
@@ -2495,7 +2515,8 @@ class Otl
 			} else {
 				$current_syllable = 0;
 			}
-			for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
+			$iMax = count($GlyphPos);
+			for ($i = 0; $i < $iMax; $i++) {
 				// If subsequent components are not Marks as well - don't ligate
 				$unistr = $this->OTLdata[$GlyphPos[$i]]['hex'];
 				if ($this->restrictToSyllable && isset($this->OTLdata[$GlyphPos[$i]]['syllable']) && $this->OTLdata[$GlyphPos[$i]]['syllable'] != $current_syllable) {
@@ -2514,7 +2535,8 @@ class Otl
 					$firstMarkAssoc = $this->assocMarks[$pos];
 				}
 				// If all components of the ligature are marks, we call this a mark ligature.
-				for ($i = 1, $iMax = count($GlyphPos); $i < $iMax; $i++) {
+				$iMax = count($GlyphPos);
+				for ($i = 1; $i < $iMax; $i++) {
 					// If subsequent components are not Marks as well - don't ligate
 					//      $unistr = $this->OTLdata[$GlyphPos[$i]]['hex'];
 					//      if (strpos($this->GlyphClassMarks, $unistr )===false) { return; }
@@ -2586,7 +2608,8 @@ class Otl
 				 */
 
 				$currComp = 0;
-				for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
+				$iMax = count($GlyphPos);
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($i > 0 && isset($this->assocLigs[$GlyphPos[$i]])) { // One of the other components is already a ligature
 						$nc = $this->assocLigs[$GlyphPos[$i]];
 					} else {
@@ -2682,7 +2705,8 @@ class Otl
 			// count($GlyphPos)-1  is the number of glyphs removed from string
 			for ($p = ($GlyphPos[0] + 1); $p < (count($this->OTLdata) + count($GlyphPos) - 1); $p++) {
 				$nrem = 0; // Number of Glyphs removed at this point in the string
-				for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
+				$iMax = count($GlyphPos);
+				for ($i = 0; $i < $iMax; $i++) {
 					if ($i > 0 && $p > $GlyphPos[$i]) {
 						$nrem++;
 					}
@@ -2838,7 +2862,8 @@ class Otl
 	private function arabic_shaper($usetags, $scriptTag)
 	{
 		$chars = [];
-		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+		$iMax = count($this->OTLdata);
+		for ($i = 0; $i < $iMax; $i++) {
 			$chars[] = $this->OTLdata[$i]['hex'];
 		}
 
@@ -2889,7 +2914,8 @@ class Otl
 			$nextChar = $crntChar;
 		}
 		$ra = array_reverse($output);
-		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+		$iMax = count($this->OTLdata);
+		for ($i = 0; $i < $iMax; $i++) {
 			$this->OTLdata[$i]['uni'] = hexdec($ra[$i][0]);
 			$this->OTLdata[$i]['hex'] = $ra[$i][0];
 			$this->OTLdata[$i]['form'] = $ra[$i][1]; // Actaul form substituted 0=ISOLATED FORM :: 1=FINAL :: 2=INITIAL :: 3=MEDIAL
@@ -2996,7 +3022,8 @@ class Otl
 	// Sets $this->OTLdata[$i]['wordend']=true at possible end of word boundaries
 	private function tibetanLineBreaking()
 	{
-		for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
+		$ptrMax = count($this->OTLdata);
+		for ($ptr = 0; $ptr < $ptrMax; $ptr++) {
 			// Break opportunities at U+0F0B Tsheg or U=0F0D
 			if (isset($this->OTLdata[$ptr]['uni']) && ($this->OTLdata[$ptr]['uni'] == 0x0F0B || $this->OTLdata[$ptr]['uni'] == 0x0F0D)) {
 				if (isset($this->OTLdata[$ptr + 1]['uni']) && ($this->OTLdata[$ptr + 1]['uni'] == 0x0F0D || $this->OTLdata[$ptr + 1]['uni'] == 0xF0E)) {
@@ -3839,7 +3866,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($InputClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -3980,7 +4008,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($InputClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($InputClasses[$gc]) && is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -4002,7 +4031,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$bclass0excl = [];
-							for ($gc = 1, $gcMax = count($BacktrackClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($BacktrackClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($BacktrackClasses[$gc]) && is_array($BacktrackClasses[$gc])) {
 									$bclass0excl = $bclass0excl + $BacktrackClasses[$gc];
 								}
@@ -4024,7 +4054,8 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$lclass0excl = [];
-							for ($gc = 1, $gcMax = count($LookaheadClasses); $gc <= $gcMax; $gc++) {
+							$gcMax = count($LookaheadClasses);
+							for ($gc = 1; $gc <= $gcMax; $gc++) {
 								if (isset($LookaheadClasses[$gc]) && is_array($LookaheadClasses[$gc])) {
 									$lclass0excl = $lclass0excl + $LookaheadClasses[$gc];
 								}
@@ -4172,7 +4203,8 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
+		$iMax = count($Backtrack);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4188,7 +4220,8 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) {
+		$iMax = count($Input);
+		for ($i = 1; $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4204,7 +4237,8 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
+		$iMax = count($Lookahead);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4232,7 +4266,8 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
+		$iMax = count($Backtrack);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4251,7 +4286,8 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
+		$iMax = count($Input);
+		for ($i = 1; $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4270,7 +4306,8 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
+		$iMax = count($Lookahead);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4300,7 +4337,8 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
+		$iMax = count($Backtrack);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4319,7 +4357,8 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
+		$iMax = count($Input);
+		for ($i = 1; $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4338,7 +4377,8 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
+		$iMax = count($Lookahead);
+		for ($i = 0; $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -6173,7 +6213,8 @@ class Otl
 		echo '<div style="font-family:monospace">';
 		echo 'Glyph position: ' . $ptr . ' Current Glyph: ' . $currGlyph . '<br />';
 
-		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+		$iMax = count($this->OTLdata);
+		for ($i = 0; $i < $iMax; $i++) {
 			if ($i == $ptr) {
 				echo '<b>';
 			}
@@ -6184,7 +6225,8 @@ class Otl
 		}
 		echo '<br />';
 
-		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+		$iMax = count($this->OTLdata);
+		for ($i = 0; $i < $iMax; $i++) {
 			if ($i == $ptr) {
 				echo '<b>';
 			}
@@ -6196,7 +6238,8 @@ class Otl
 		echo '<br />';
 
 		if ($GPOSSUB == 'GPOS') {
-			for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
+			$iMax = count($this->OTLdata);
+			for ($i = 0; $i < $iMax; $i++) {
 				if (!empty($this->OTLdata[$i]['GPOSinfo'])) {
 					echo $this->OTLdata[$i]['hex'] . ' &#x' . $this->OTLdata[$i]['hex'] . '; ';
 					print_r($this->OTLdata[$i]['GPOSinfo']);

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -310,7 +310,7 @@ class Otl
 
 			if (!$GSUBscriptTag && !$GSUBlangsys && !$GPOSscriptTag && !$GPOSlangsys) {
 				// Remove ZWJ and ZWNJ
-				for ($i = 0; $i < count($this->OTLdata); $i++) {
+				for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 					if ($this->OTLdata[$i]['uni'] == 8204 || $this->OTLdata[$i]['uni'] == 8205) {
 						array_splice($this->OTLdata, $i, 1);
 					}
@@ -438,7 +438,7 @@ class Otl
 					// c. Set Kashida points (after joining occurred - medi, fina, init) but before other substitutions
 					//-----------------------------------------------------------------------------------
 					//if ($scriptblock == Ucdn::SCRIPT_ARABIC ) {
-					for ($i = 0; $i < count($this->OTLdata); $i++) {
+					for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 						// Put the kashida marker on the character BEFORE which is inserted the kashida
 						// Kashida marker is inverse of priority i.e. Priority 1 => 7, Priority 7 => 1.
 						// Priority 1   User-inserted Kashida 0640 = Tatweel
@@ -530,7 +530,7 @@ class Otl
 					// e. NOT IN SPEC
 					// If space precedes a mark -> substitute a &nbsp; before the Mark, to prevent line breaking Test:
 					//-----------------------------------------------------------------------------------
-					for ($ptr = 1; $ptr < count($this->OTLdata); $ptr++) {
+					for ($ptr = 1, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
 						if ($this->OTLdata[$ptr]['general_category'] == Ucdn::UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK && $this->OTLdata[$ptr - 1]['uni'] == 32) {
 							$this->OTLdata[$ptr - 1]['uni'] = 0xa0;
 							$this->OTLdata[$ptr - 1]['hex'] = '000A0';
@@ -544,12 +544,12 @@ class Otl
 					// a. First decompose/compose split mattras
 					// (normalize) ??????? Nukta/Halant order etc ??????????????????????????????????????????????????????????????????????????
 					//-----------------------------------------------------------------------------------
-					for ($ptr = 0; $ptr < count($this->OTLdata); $ptr++) {
+					for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
 						$char = $this->OTLdata[$ptr]['uni'];
 						$sub = Indic::decompose_indic($char);
 						if ($sub) {
 							$newinfo = [];
-							for ($i = 0; $i < count($sub); $i++) {
+							for ($i = 0, $iMax = count($sub); $i < $iMax; $i++) {
 								$newinfo[$i] = [];
 								$ucd_record = Ucdn::get_ucd_record($sub[$i]);
 								$newinfo[$i]['general_category'] = $ucd_record[0];
@@ -849,7 +849,7 @@ class Otl
 					 * Lao versions are the same as Thai + 0x80.
 					 */
 					if ($this->shaper == 'T' || $this->shaper == 'L') {
-						for ($ptr = 0; $ptr < count($this->OTLdata); $ptr++) {
+						for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
 							$char = $this->OTLdata[$ptr]['uni'];
 							if (($char & ~0x0080) == 0x0E33) { // if SARA_AM (U+0E33 or U+0EB3)
 								$NIKHAHIT = $char + 0x1A;
@@ -1006,7 +1006,7 @@ class Otl
 			//=======================================================
 			if ($this->shaper == 'I' || $this->shaper == 'S' || $this->shaper == 'A' || $this->shaper == 'K' || $this->shaper == 'M') {
 				// Remove ZWJ and ZWNJ
-				for ($i = 0; $i < count($this->OTLdata); $i++) {
+				for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 					if ($this->OTLdata[$i]['uni'] == 8204 || $this->OTLdata[$i]['uni'] == 8205) {
 						array_splice($this->OTLdata, $i, 1);
 						$this->_updateLigatureMarks($i, -1);
@@ -1126,7 +1126,7 @@ class Otl
 					}
 					// LTR
 					$incurs = false;
-					for ($i = 0; $i < count($this->OTLdata); $i++) {
+					for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 						if (isset($this->Exit[$i]) && isset($this->Exit[$i]['Y']) && $this->Exit[$i]['dir'] == 'LTR') {
 							$nextbase = $i + 1; // Set as next base ignoring marks
 							while (strpos($this->GlyphClassMarks, $this->OTLdata[$nextbase]['hex']) !== false) {
@@ -1187,7 +1187,7 @@ class Otl
 		$ectr = 0;
 
 		for ($sch = 0; $sch <= $subchunk; $sch++) {
-			for ($i = 0; $i < count($this->schOTLdata[$sch]); $i++) {
+			for ($i = 0, $iMax = count($this->schOTLdata[$sch]); $i < $iMax; $i++) {
 				if (isset($this->schOTLdata[$sch][$i]['GPOSinfo'])) {
 					$newGPOSinfo[$ectr] = $this->schOTLdata[$sch][$i]['GPOSinfo'];
 				}
@@ -1229,7 +1229,7 @@ class Otl
 			$fp = $this->mpdf->OTLtags['Plus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $fp, $m);
-		for ($i = 0; $i < count($m[0]); $i++) {
+		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1242,7 +1242,7 @@ class Otl
 			$fm = $this->mpdf->OTLtags['Minus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $fm, $m);
-		for ($i = 0; $i < count($m[0]); $i++) {
+		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1255,7 +1255,7 @@ class Otl
 			$ffp = $this->mpdf->OTLtags['FFPlus']; // Font Features - may include integer: salt4
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})([\d+]*)/', $ffp, $m);
-		for ($i = 0; $i < count($m[0]); $i++) {
+		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1268,7 +1268,7 @@ class Otl
 			$ffm = $this->mpdf->OTLtags['FFMinus'];
 		}
 		preg_match_all('/([a-zA-Z0-9]{4})/', $ffm, $m);
-		for ($i = 0; $i < count($m[0]); $i++) {
+		for ($i = 0, $iMax = count($m[0]); $i < $iMax; $i++) {
 			$t = $m[1][$i];
 			// Is it a valid tag?
 			if (isset($Features[$t]) && strpos($omittags, $t) === false && (!$onlytags || strpos($tags, $t) !== false )) {
@@ -1957,7 +1957,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1; $gc <= count($InputClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
 								if (is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -2182,7 +2182,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1; $gc <= count($InputClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
 								if (isset($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -2203,7 +2203,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$bclass0excl = [];
-							for ($gc = 1; $gc <= count($BacktrackClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($BacktrackClasses); $gc <= $gcMax; $gc++) {
 								if (isset($BacktrackClasses[$gc])) {
 									$bclass0excl = $bclass0excl + $BacktrackClasses[$gc];
 								}
@@ -2225,7 +2225,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$lclass0excl = [];
-							for ($gc = 1; $gc <= count($LookaheadClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($LookaheadClasses); $gc <= $gcMax; $gc++) {
 								if (isset($LookaheadClasses[$gc])) {
 									$lclass0excl = $lclass0excl + $LookaheadClasses[$gc];
 								}
@@ -2394,14 +2394,14 @@ class Otl
 		} elseif ($n < 1) { // glyphs removed
 			$nrem = -$n;
 			// Update position of pre-existing Ligatures and associated Marks
-			for ($p = ($pos + 1); $p < count($this->OTLdata); $p++) {
+			for ($p = ($pos + 1), $pMax = count($this->OTLdata); $p < $pMax; $p++) {
 				if (isset($this->assocLigs[$p])) {
 					$tmp = $this->assocLigs[$p];
 					unset($this->assocLigs[$p]);
 					$this->assocLigs[($p - $nrem)] = $tmp;
 				}
 			}
-			for ($p = 0; $p < count($this->OTLdata); $p++) {
+			for ($p = 0, $pMax = count($this->OTLdata); $p < $pMax; $p++) {
 				if (isset($this->assocMarks[$p])) {
 					if ($this->assocMarks[$p]['ligPos'] >= ($pos)) {
 						$this->assocMarks[$p]['ligPos'] -= $nrem;
@@ -2427,7 +2427,7 @@ class Otl
 			return 1;
 		} // LookupType 2: Multiple Substitution Subtable : 1 to n
 		elseif ($Type == 2) {
-			for ($i = 0; $i < count($substitute); $i++) {
+			for ($i = 0, $iMax = count($substitute); $i < $iMax; $i++) {
 				$uni = $substitute[$i];
 				$newOTLdata[$i] = [];
 				$newOTLdata[$i]['uni'] = $uni;
@@ -2495,7 +2495,7 @@ class Otl
 			} else {
 				$current_syllable = 0;
 			}
-			for ($i = 0; $i < count($GlyphPos); $i++) {
+			for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
 				// If subsequent components are not Marks as well - don't ligate
 				$unistr = $this->OTLdata[$GlyphPos[$i]]['hex'];
 				if ($this->restrictToSyllable && isset($this->OTLdata[$GlyphPos[$i]]['syllable']) && $this->OTLdata[$GlyphPos[$i]]['syllable'] != $current_syllable) {
@@ -2514,7 +2514,7 @@ class Otl
 					$firstMarkAssoc = $this->assocMarks[$pos];
 				}
 				// If all components of the ligature are marks, we call this a mark ligature.
-				for ($i = 1; $i < count($GlyphPos); $i++) {
+				for ($i = 1, $iMax = count($GlyphPos); $i < $iMax; $i++) {
 					// If subsequent components are not Marks as well - don't ligate
 					//      $unistr = $this->OTLdata[$GlyphPos[$i]]['hex'];
 					//      if (strpos($this->GlyphClassMarks, $unistr )===false) { return; }
@@ -2586,7 +2586,7 @@ class Otl
 				 */
 
 				$currComp = 0;
-				for ($i = 0; $i < count($GlyphPos); $i++) {
+				for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
 					if ($i > 0 && isset($this->assocLigs[$GlyphPos[$i]])) { // One of the other components is already a ligature
 						$nc = $this->assocLigs[$GlyphPos[$i]];
 					} else {
@@ -2682,7 +2682,7 @@ class Otl
 			// count($GlyphPos)-1  is the number of glyphs removed from string
 			for ($p = ($GlyphPos[0] + 1); $p < (count($this->OTLdata) + count($GlyphPos) - 1); $p++) {
 				$nrem = 0; // Number of Glyphs removed at this point in the string
-				for ($i = 0; $i < count($GlyphPos); $i++) {
+				for ($i = 0, $iMax = count($GlyphPos); $i < $iMax; $i++) {
 					if ($i > 0 && $p > $GlyphPos[$i]) {
 						$nrem++;
 					}
@@ -2838,7 +2838,7 @@ class Otl
 	private function arabic_shaper($usetags, $scriptTag)
 	{
 		$chars = [];
-		for ($i = 0; $i < count($this->OTLdata); $i++) {
+		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 			$chars[] = $this->OTLdata[$i]['hex'];
 		}
 
@@ -2889,7 +2889,7 @@ class Otl
 			$nextChar = $crntChar;
 		}
 		$ra = array_reverse($output);
-		for ($i = 0; $i < count($this->OTLdata); $i++) {
+		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 			$this->OTLdata[$i]['uni'] = hexdec($ra[$i][0]);
 			$this->OTLdata[$i]['hex'] = $ra[$i][0];
 			$this->OTLdata[$i]['form'] = $ra[$i][1]; // Actaul form substituted 0=ISOLATED FORM :: 1=FINAL :: 2=INITIAL :: 3=MEDIAL
@@ -2996,7 +2996,7 @@ class Otl
 	// Sets $this->OTLdata[$i]['wordend']=true at possible end of word boundaries
 	private function tibetanLineBreaking()
 	{
-		for ($ptr = 0; $ptr < count($this->OTLdata); $ptr++) {
+		for ($ptr = 0, $ptrMax = count($this->OTLdata); $ptr < $ptrMax; $ptr++) {
 			// Break opportunities at U+0F0B Tsheg or U=0F0D
 			if (isset($this->OTLdata[$ptr]['uni']) && ($this->OTLdata[$ptr]['uni'] == 0x0F0B || $this->OTLdata[$ptr]['uni'] == 0x0F0D)) {
 				if (isset($this->OTLdata[$ptr + 1]['uni']) && ($this->OTLdata[$ptr + 1]['uni'] == 0x0F0D || $this->OTLdata[$ptr + 1]['uni'] == 0xF0E)) {
@@ -3839,7 +3839,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1; $gc <= count($InputClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
 								if (is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -3980,7 +3980,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$class0excl = [];
-							for ($gc = 1; $gc <= count($InputClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($InputClasses); $gc <= $gcMax; $gc++) {
 								if (isset($InputClasses[$gc]) && is_array($InputClasses[$gc])) {
 									$class0excl = $class0excl + $InputClasses[$gc];
 								}
@@ -4002,7 +4002,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$bclass0excl = [];
-							for ($gc = 1; $gc <= count($BacktrackClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($BacktrackClasses); $gc <= $gcMax; $gc++) {
 								if (isset($BacktrackClasses[$gc]) && is_array($BacktrackClasses[$gc])) {
 									$bclass0excl = $bclass0excl + $BacktrackClasses[$gc];
 								}
@@ -4024,7 +4024,7 @@ class Otl
 
 							// Class 0 contains all the glyphs NOT in the other classes
 							$lclass0excl = [];
-							for ($gc = 1; $gc <= count($LookaheadClasses); $gc++) {
+							for ($gc = 1, $gcMax = count($LookaheadClasses); $gc <= $gcMax; $gc++) {
 								if (isset($LookaheadClasses[$gc]) && is_array($LookaheadClasses[$gc])) {
 									$lclass0excl = $lclass0excl + $LookaheadClasses[$gc];
 								}
@@ -4172,7 +4172,7 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0; $i < count($Backtrack); $i++) {
+		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4188,7 +4188,7 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1; $i < count($Input); $i++) {
+		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4204,7 +4204,7 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0; $i < count($Lookahead); $i++) {
+		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4232,7 +4232,7 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0; $i < count($Backtrack); $i++) {
+		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4251,7 +4251,7 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1; $i < count($Input); $i++) { // Start at 1 - already matched the first InputGlyph
+		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4270,7 +4270,7 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0; $i < count($Lookahead); $i++) {
+		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4300,7 +4300,7 @@ class Otl
 
 		// BACKTRACK
 		$checkpos = $ptr;
-		for ($i = 0; $i < count($Backtrack); $i++) {
+		for ($i = 0, $iMax = count($Backtrack); $i < $iMax; $i++) {
 			$checkpos--;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos--;
@@ -4319,7 +4319,7 @@ class Otl
 		// INPUT
 		$matched = [0 => $ptr];
 		$checkpos = $ptr;
-		for ($i = 1; $i < count($Input); $i++) { // Start at 1 - already matched the first InputGlyph
+		for ($i = 1, $iMax = count($Input); $i < $iMax; $i++) { // Start at 1 - already matched the first InputGlyph
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -4338,7 +4338,7 @@ class Otl
 		}
 
 		// LOOKAHEAD
-		for ($i = 0; $i < count($Lookahead); $i++) {
+		for ($i = 0, $iMax = count($Lookahead); $i < $iMax; $i++) {
 			$checkpos++;
 			while (isset($this->OTLdata[$checkpos]) && strpos($ignore, $this->OTLdata[$checkpos]['hex']) !== false) {
 				$checkpos++;
@@ -6173,7 +6173,7 @@ class Otl
 		echo '<div style="font-family:monospace">';
 		echo 'Glyph position: ' . $ptr . ' Current Glyph: ' . $currGlyph . '<br />';
 
-		for ($i = 0; $i < count($this->OTLdata); $i++) {
+		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 			if ($i == $ptr) {
 				echo '<b>';
 			}
@@ -6184,7 +6184,7 @@ class Otl
 		}
 		echo '<br />';
 
-		for ($i = 0; $i < count($this->OTLdata); $i++) {
+		for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 			if ($i == $ptr) {
 				echo '<b>';
 			}
@@ -6196,7 +6196,7 @@ class Otl
 		echo '<br />';
 
 		if ($GPOSSUB == 'GPOS') {
-			for ($i = 0; $i < count($this->OTLdata); $i++) {
+			for ($i = 0, $iMax = count($this->OTLdata); $i < $iMax; $i++) {
 				if (!empty($this->OTLdata[$i]['GPOSinfo'])) {
 					echo $this->OTLdata[$i]['hex'] . ' &#x' . $this->OTLdata[$i]['hex'] . '; ';
 					print_r($this->OTLdata[$i]['GPOSinfo']);

--- a/src/OtlDump.php
+++ b/src/OtlDump.php
@@ -539,7 +539,8 @@ class OtlDump
 			throw new \Mpdf\MpdfException("Could not find PostScript font name: " . $this->filename);
 		}
 		if ($debug) {
-			for ($i = 0, $iMax = count($psName); $i < $iMax; $i++) {
+			$iMax = count($psName);
+			for ($i = 0; $i < $iMax; $i++) {
 				$c = $psName[$i];
 				$oc = ord($c);
 				if ($oc > 126 || strpos(' [](){}<>/%', $c) !== false) {
@@ -646,7 +647,8 @@ class OtlDump
 			$this->_pos += 10;  //PANOSE = 10 byte length
 			$panose = fread($this->fh, 10);
 			$this->panose = [];
-			for ($p = 0, $pMax = strlen($panose); $p < $pMax; $p++) {
+			$pMax = strlen($panose);
+			for ($p = 0; $p < $pMax; $p++) {
 				$this->panose[] = ord($panose[$p]);
 			}
 			$this->skip(26);
@@ -1646,7 +1648,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 					if ($Lookup[$i]['Type'] == 1) {
 						$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 						$glyphs = $this->_getCoverage(false);
-						for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+						$gMax = count($glyphs);
+						for ($g = 0; $g < $gMax; $g++) {
 							$replace = [];
 							$substitute = [];
 							$replace[] = unicode_hex($this->glyphToChar[$glyphs[$g]][0]);
@@ -1666,7 +1669,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 						if ($Lookup[$i]['Type'] == 2) {
 							$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 							$glyphs = $this->_getCoverage();
-							for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+							$gMax = count($glyphs);
+							for ($g = 0; $g < $gMax; $g++) {
 								$replace = [];
 								$substitute = [];
 								$replace[] = $glyphs[$g];
@@ -1687,7 +1691,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 							if ($Lookup[$i]['Type'] == 3) {
 								$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 								$glyphs = $this->_getCoverage();
-								for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+								$gMax = count($glyphs);
+								for ($g = 0; $g < $gMax; $g++) {
 									$replace = [];
 									$substitute = [];
 									$replace[] = $glyphs[$g];
@@ -2012,7 +2017,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 				// LookupType 1: Single Substitution Subtable
 				if ($Lookup[$i]['Type'] == 1) {
 					$html .= '<div class="lookuptype">LookupType 1: Single Substitution Subtable</div>';
-					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+					$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+					for ($s = 0; $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2042,7 +2048,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 				else {
 					if ($Lookup[$i]['Type'] == 2) {
 						$html .= '<div class="lookuptype">LookupType 2: Multiple Substitution Subtable</div>';
-						for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+						$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+						for ($s = 0; $s < $sMax; $s++) {
 							$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 							$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'];
 							if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2072,7 +2079,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 					else {
 						if ($Lookup[$i]['Type'] == 3) {
 							$html .= '<div class="lookuptype">LookupType 3: Alternate Forms</div>';
-							for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+							$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+							for ($s = 0; $s < $sMax; $s++) {
 								$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 								$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 								if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2097,7 +2105,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 								}
 								$html .= '&nbsp; <span class="unicode">' . $this->formatUni($substitute) . '</span> ';
 								if (count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']) > 1) {
-									for ($alt = 1, $altMax = count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']); $alt < $altMax; $alt++) {
+									$altMax = count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']);
+									for ($alt = 1; $alt < $altMax; $alt++) {
 										$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][$alt];
 										$html .= '&nbsp; | &nbsp; ALT #' . $alt . ' &nbsp; ';
 										$html .= '<span class="changed">&nbsp;' . $this->formatEntity($substitute) . '</span>';
@@ -2110,7 +2119,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 						else {
 							if ($Lookup[$i]['Type'] == 4) {
 								$html .= '<div class="lookuptype">LookupType 4: Ligature Substitution Subtable</div>';
-								for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+								$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+								for ($s = 0; $s < $sMax; $s++) {
 									$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 									$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 									if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2160,7 +2170,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 												$exampleI = [];
 												$html .= '<div class="context">CONTEXT: ';
-												for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+												$ffMax = count($inputGlyphs);
+												for ($ff = 0; $ff < $ffMax; $ff++) {
 													$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 													$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 												}
@@ -2182,7 +2193,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 													}
 													if (count($inputGlyphs) > ($seqIndex + 1)) {
 														$exL .= '<span class="inputother">';
-														for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+														$ipMax = count($inputGlyphs);
+														for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 															$exL .= $this->formatEntity($inputGlyphs[$ip]) . '&#x200d;';
 														}
 														$exL .= '</span>';
@@ -2230,7 +2242,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 													$exampleI = [];
 													$html .= '<div class="context">CONTEXT: ';
-													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+													$ffMax = count($inputGlyphs);
+													for ($ff = 0; $ff < $ffMax; $ff++) {
 														if (!$inputGlyphs[$ff]) {
 															$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 															$exampleI[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2263,7 +2276,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+															$ipMax = count($inputGlyphs);
+															for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 																if (!$inputGlyphs[$ip]) {
 																	$exL .= '[*]';
 																} else {
@@ -2299,7 +2313,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 												$exampleI = [];
 												$html .= '<div class="context">CONTEXT: ';
-												for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+												$ffMax = count($inputGlyphs);
+												for ($ff = 0; $ff < $ffMax; $ff++) {
 													$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 													$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 												}
@@ -2321,7 +2336,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 													if (count($inputGlyphs) > ($seqIndex + 1)) {
 														$exL .= '<span class="inputother">';
-														for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+														$ipMax = count($inputGlyphs);
+														for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 															$exL .= $exampleI[$ip] . '&#x200d;';
 														}
 														$exL .= '</span>';
@@ -2389,11 +2405,13 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 														$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 														$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 													}
-													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+													$ffMax = count($inputGlyphs);
+													for ($ff = 0; $ff < $ffMax; $ff++) {
 														$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 														$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 													}
-													for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
+													$ffMax = count($lookaheadGlyphs);
+													for ($ff = 0; $ff < $ffMax; $ff++) {
 														$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 														$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 													}
@@ -2420,7 +2438,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+															$ipMax = count($inputGlyphs);
+															for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 																$exL .= $this->formatEntity($inputGlyphs[$ip]) . '&#x200d;';
 															}
 															$exL .= '</span>';
@@ -2509,7 +2528,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 															}
 														}
-														for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+														$ffMax = count($inputGlyphs);
+														for ($ff = 0; $ff < $ffMax; $ff++) {
 															if (!$inputGlyphs[$ff]) {
 																$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 																$exampleI[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2518,7 +2538,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 															}
 														}
-														for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
+														$ffMax = count($lookaheadGlyphs);
+														for ($ff = 0; $ff < $ffMax; $ff++) {
 															if (!$lookaheadGlyphs[$ff]) {
 																$html .= '<div>Lookahead #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 																$exampleL[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2554,7 +2575,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 															if (count($inputGlyphs) > ($seqIndex + 1)) {
 																$exL .= '<span class="inputother">';
-																for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+																$ipMax = count($inputGlyphs);
+																for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 																	if (!$inputGlyphs[$ip]) {
 																		$exL .= '[*]';
 																	} else {
@@ -2611,11 +2633,13 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 														$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 														$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 													}
-													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+													$ffMax = count($inputGlyphs);
+													for ($ff = 0; $ff < $ffMax; $ff++) {
 														$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 														$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 													}
-													for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
+													$ffMax = count($lookaheadGlyphs);
+													for ($ff = 0; $ff < $ffMax; $ff++) {
 														$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 														$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 													}
@@ -2642,7 +2666,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+															$ipMax = count($inputGlyphs);
+															for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 																$exL .= $exampleI[$ip] . '&#x200d;';
 															}
 															$exL .= '</span>';
@@ -2839,7 +2864,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 		// $inputGlyphs = array of glyphs(glyphstrings) making up Input sequence in Context
 		// $lookupGlyphs = array of glyphs making up Lookup Input sequence - if applicable
 		$str = "";
-		for ($i = 1, $iMax = count($inputGlyphs); $i <= $iMax; $i++) {
+		$iMax = count($inputGlyphs);
+		for ($i = 1; $i <= $iMax; $i++) {
 			if ($i > 1) {
 				$str .= $ignore . " ";
 			}
@@ -2872,7 +2898,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 		// 0  1  2  3
 		// each item being e.g. E0AD|E0AF|F1FD
 		$str = "";
-		for ($i = 0, $iMax = count($lookaheadGlyphs); $i < $iMax; $i++) {
+		$iMax = count($lookaheadGlyphs)
+		for ($i = 0; $i < $iMax; $i++) {
 			$str .= $ignore . " " . $lookaheadGlyphs[$i] . "";
 		}
 
@@ -3272,7 +3299,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 						$this->seek($Coverage);
 						$glyphs = $this->_getCoverage(); // Array of Hex Glyphs
-						for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+						$gMax = count($glyphs);
+						for ($g = 0; $g < $gMax; $g++) {
 							if ($level == 2 && strpos($lcoverage, $glyphs[$g]) === false) {
 								continue;
 							}
@@ -3323,7 +3351,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 							$this->seek($Coverage);
 							$glyphs = $this->_getCoverage(); // Array of Hex Glyphs
 
-							for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+							$gMax = count($glyphs);
+							for ($g = 0; $g < $gMax; $g++) {
 								if ($level == 2 && strpos($lcoverage, $glyphs[$g]) === false) {
 									continue;
 								}
@@ -3475,13 +3504,15 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 											}
 										}
 
-										for ($c1 = 0, $c1Max = count($Class1[$i]); $c1 < $c1Max; $c1++) {
+										$c1Max = count($Class1[$i]);
+										for ($c1 = 0; $c1 < $c1Max; $c1++) {
 											$FirstGlyph = $Class1[$i][$c1];
 											if ($level == 2 && strpos($lcoverage, $FirstGlyph) === false) {
 												continue;
 											}
 
-											for ($c2 = 0, $c2Max = count($Class2[$j]); $c2 < $c2Max; $c2++) {
+											$c2Max = count($Class2[$j]);
+											for ($c2 = 0; $c2 < $c2Max; $c2++) {
 												$SecondGlyph = $Class2[$j][$c2];
 
 												if (!$Value1['XPlacement'] && !$Value1['YPlacement'] && !$Value1['XAdvance'] && !$Value2['XPlacement'] && !$Value2['YPlacement'] && !$Value2['XAdvance']) {
@@ -3602,7 +3633,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 								$firstMark = '';
 								$html .= '<div class="glyphs">Marks: ';
-								for ($i = 0, $iMax = count($MarkGlyphs); $i < $iMax; $i++) {
+								$iMax = count($MarkGlyphs);
+								for ($i = 0; $i < $iMax; $i++) {
 									if ($level == 2 && strpos($lcoverage, $MarkGlyphs[$i]) === false) {
 										continue;
 									} else {
@@ -3618,14 +3650,16 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 								}
 
 								$html .= '<div class="glyphs">Bases: ';
-								for ($j = 0, $jMax = count($BaseGlyphs); $j < $jMax; $j++) {
+								$jMax = count($BaseGlyphs);
+								for ($j = 0; $j < $jMax; $j++) {
 									$html .= ' ' . $this->formatEntity($BaseGlyphs[$j]) . ' ';
 								}
 								$html .= '</div>';
 
 								// Example
 								$html .= '<div class="glyphs" style="font-feature-settings:\'' . $tag . '\' 1;">Example(s): ';
-								for ($j = 0, $jMax = min(count($BaseGlyphs), 20); $j < $jMax; $j++) {
+								$jMax = min(count($BaseGlyphs), 20);
+								for ($j = 0; $j < $jMax; $j++) {
 									$html .= ' ' . $this->formatEntity($BaseGlyphs[$j]) . $this->formatEntity($firstMark, true) . ' &nbsp; ';
 								}
 								$html .= '</div>';
@@ -3650,7 +3684,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 									$firstMark = '';
 									$html .= '<div class="glyphs">Marks: <span class="unchanged">';
 									$MarkRecord = [];
-									for ($i = 0, $iMax = count($MarkGlyphs); $i < $iMax; $i++) {
+									$iMax = count($MarkGlyphs);
+									for ($i = 0; $i < $iMax; $i++) {
 										if ($level == 2 && strpos($lcoverage, $MarkGlyphs[$i]) === false) {
 											continue;
 										} else {
@@ -3672,7 +3707,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 									$LigatureCount = $this->read_ushort();
 									$LigatureAttach = [];
 									$html .= '<div class="glyphs">Ligatures: <span class="unchanged">';
-									for ($j = 0, $jMax = count($LigatureGlyphs); $j < $jMax; $j++) {
+									$jMax = count($LigatureGlyphs);
+									for ($j = 0; $j < $jMax; $j++) {
 										// Get the relevant LigatureRecord
 										$LigatureAttach[$j] = $LigatureArray + $this->read_ushort();
 										$html .= ' ' . $this->formatEntity($LigatureGlyphs[$j]) . ' ';
@@ -3721,7 +3757,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 										$firstMark = '';
 										$html .= '<div class="glyphs">Marks: <span class="unchanged">';
-										for ($i = 0, $iMax = count($Mark1Glyphs); $i < $iMax; $i++) {
+										$iMax = count($Mark1Glyphs);
+										for ($i = 0; $i < $iMax; $i++) {
 											if ($level == 2 && strpos($lcoverage, $Mark1Glyphs[$i]) === false) {
 												continue;
 											} else {
@@ -3735,14 +3772,16 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 										if ($firstMark) {
 											$html .= '<div class="glyphs">Bases: <span class="unchanged">';
-											for ($j = 0, $jMax = count($Mark2Glyphs); $j < $jMax; $j++) {
+											$jMax = count($Mark2Glyphs);
+											for ($j = 0; $j < $jMax; $j++) {
 												$html .= ' ' . $this->formatEntity($Mark2Glyphs[$j]) . ' ';
 											}
 											$html .= '</span></div>';
 
 											// Example
 											$html .= '<div class="glyphs" style="font-feature-settings:\'' . $tag . '\' 1;">Example(s): <span class="changed">';
-											for ($j = 0, $jMax = min(count($Mark2Glyphs), 20); $j < $jMax; $j++) {
+											$jMax = min(count($Mark2Glyphs), 20);
+											for ($j = 0; $j < $jMax; $j++) {
 												$html .= ' ' . $this->formatEntity($Mark2Glyphs[$j]) . $this->formatEntity($firstMark, true) . ' &nbsp; ';
 											}
 											$html .= '</span></div>';
@@ -3848,11 +3887,13 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 																$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 															}
-															for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
+															$ffMax = count($inputGlyphs);
+															for ($ff = 0; $ff < $ffMax; $ff++) {
 																$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 																$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 															}
-															for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
+															$ffMax = count($lookaheadGlyphs);
+															for ($ff = 0; $ff < $ffMax; $ff++) {
 																$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 																$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 															}
@@ -3879,7 +3920,8 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 																if (count($inputGlyphs) > ($seqIndex + 1)) {
 																	$exL .= '<span class="inputother">';
-																	for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
+																	$ipMax = count($inputGlyphs);
+																	for ($ip = $seqIndex + 1; $ip < $ipMax; $ip++) {
 																		$exL .= '&#x200d;' . $exampleI[$ip];
 																	}
 																	$exL .= '</span>';

--- a/src/OtlDump.php
+++ b/src/OtlDump.php
@@ -539,7 +539,7 @@ class OtlDump
 			throw new \Mpdf\MpdfException("Could not find PostScript font name: " . $this->filename);
 		}
 		if ($debug) {
-			for ($i = 0; $i < count($psName); $i++) {
+			for ($i = 0, $iMax = count($psName); $i < $iMax; $i++) {
 				$c = $psName[$i];
 				$oc = ord($c);
 				if ($oc > 126 || strpos(' [](){}<>/%', $c) !== false) {
@@ -646,7 +646,7 @@ class OtlDump
 			$this->_pos += 10;  //PANOSE = 10 byte length
 			$panose = fread($this->fh, 10);
 			$this->panose = [];
-			for ($p = 0; $p < strlen($panose); $p++) {
+			for ($p = 0, $pMax = strlen($panose); $p < $pMax; $p++) {
 				$this->panose[] = ord($panose[$p]);
 			}
 			$this->skip(26);
@@ -1646,7 +1646,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 					if ($Lookup[$i]['Type'] == 1) {
 						$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 						$glyphs = $this->_getCoverage(false);
-						for ($g = 0; $g < count($glyphs); $g++) {
+						for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 							$replace = [];
 							$substitute = [];
 							$replace[] = unicode_hex($this->glyphToChar[$glyphs[$g]][0]);
@@ -1666,7 +1666,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 						if ($Lookup[$i]['Type'] == 2) {
 							$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 							$glyphs = $this->_getCoverage();
-							for ($g = 0; $g < count($glyphs); $g++) {
+							for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 								$replace = [];
 								$substitute = [];
 								$replace[] = $glyphs[$g];
@@ -1687,7 +1687,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 							if ($Lookup[$i]['Type'] == 3) {
 								$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 								$glyphs = $this->_getCoverage();
-								for ($g = 0; $g < count($glyphs); $g++) {
+								for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 									$replace = [];
 									$substitute = [];
 									$replace[] = $glyphs[$g];
@@ -2012,7 +2012,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 				// LookupType 1: Single Substitution Subtable
 				if ($Lookup[$i]['Type'] == 1) {
 					$html .= '<div class="lookuptype">LookupType 1: Single Substitution Subtable</div>';
-					for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2042,7 +2042,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 				else {
 					if ($Lookup[$i]['Type'] == 2) {
 						$html .= '<div class="lookuptype">LookupType 2: Multiple Substitution Subtable</div>';
-						for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+						for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 							$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 							$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'];
 							if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2072,7 +2072,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 					else {
 						if ($Lookup[$i]['Type'] == 3) {
 							$html .= '<div class="lookuptype">LookupType 3: Alternate Forms</div>';
-							for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+							for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 								$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 								$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 								if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2097,7 +2097,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 								}
 								$html .= '&nbsp; <span class="unicode">' . $this->formatUni($substitute) . '</span> ';
 								if (count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']) > 1) {
-									for ($alt = 1; $alt < count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']); $alt++) {
+									for ($alt = 1, $altMax = count($Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']); $alt < $altMax; $alt++) {
 										$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][$alt];
 										$html .= '&nbsp; | &nbsp; ALT #' . $alt . ' &nbsp; ';
 										$html .= '<span class="changed">&nbsp;' . $this->formatEntity($substitute) . '</span>';
@@ -2110,7 +2110,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 						else {
 							if ($Lookup[$i]['Type'] == 4) {
 								$html .= '<div class="lookuptype">LookupType 4: Ligature Substitution Subtable</div>';
-								for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+								for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 									$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 									$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 									if ($level == 2 && strpos($coverage, $inputGlyphs[0]) === false) {
@@ -2160,7 +2160,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 												$exampleI = [];
 												$html .= '<div class="context">CONTEXT: ';
-												for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+												for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 													$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 													$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 												}
@@ -2182,7 +2182,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 													}
 													if (count($inputGlyphs) > ($seqIndex + 1)) {
 														$exL .= '<span class="inputother">';
-														for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+														for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 															$exL .= $this->formatEntity($inputGlyphs[$ip]) . '&#x200d;';
 														}
 														$exL .= '</span>';
@@ -2230,7 +2230,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 													$exampleI = [];
 													$html .= '<div class="context">CONTEXT: ';
-													for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 														if (!$inputGlyphs[$ff]) {
 															$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 															$exampleI[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2263,7 +2263,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 																if (!$inputGlyphs[$ip]) {
 																	$exL .= '[*]';
 																} else {
@@ -2299,7 +2299,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 												$exampleI = [];
 												$html .= '<div class="context">CONTEXT: ';
-												for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+												for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 													$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 													$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 												}
@@ -2321,7 +2321,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 													if (count($inputGlyphs) > ($seqIndex + 1)) {
 														$exL .= '<span class="inputother">';
-														for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+														for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 															$exL .= $exampleI[$ip] . '&#x200d;';
 														}
 														$exL .= '</span>';
@@ -2389,11 +2389,11 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 														$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 														$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 													}
-													for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 														$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 														$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 													}
-													for ($ff = 0; $ff < count($lookaheadGlyphs); $ff++) {
+													for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
 														$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 														$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 													}
@@ -2420,7 +2420,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 																$exL .= $this->formatEntity($inputGlyphs[$ip]) . '&#x200d;';
 															}
 															$exL .= '</span>';
@@ -2509,7 +2509,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 															}
 														}
-														for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+														for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 															if (!$inputGlyphs[$ff]) {
 																$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 																$exampleI[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2518,7 +2518,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 															}
 														}
-														for ($ff = 0; $ff < count($lookaheadGlyphs); $ff++) {
+														for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
 															if (!$lookaheadGlyphs[$ff]) {
 																$html .= '<div>Lookahead #' . $ff . ': <span class="unchanged">&nbsp;[NOT ' . $this->formatEntityStr($class0excl) . ']&nbsp;</span></div>';
 																$exampleL[] = '[NOT ' . $this->formatEntityFirst($class0excl) . ']';
@@ -2554,7 +2554,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 															if (count($inputGlyphs) > ($seqIndex + 1)) {
 																$exL .= '<span class="inputother">';
-																for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+																for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 																	if (!$inputGlyphs[$ip]) {
 																		$exL .= '[*]';
 																	} else {
@@ -2611,11 +2611,11 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 														$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 														$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 													}
-													for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+													for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 														$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 														$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 													}
-													for ($ff = 0; $ff < count($lookaheadGlyphs); $ff++) {
+													for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
 														$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 														$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 													}
@@ -2642,7 +2642,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 														if (count($inputGlyphs) > ($seqIndex + 1)) {
 															$exL .= '<span class="inputother">';
-															for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+															for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 																$exL .= $exampleI[$ip] . '&#x200d;';
 															}
 															$exL .= '</span>';
@@ -2839,7 +2839,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 		// $inputGlyphs = array of glyphs(glyphstrings) making up Input sequence in Context
 		// $lookupGlyphs = array of glyphs making up Lookup Input sequence - if applicable
 		$str = "";
-		for ($i = 1; $i <= count($inputGlyphs); $i++) {
+		for ($i = 1, $iMax = count($inputGlyphs); $i <= $iMax; $i++) {
 			if ($i > 1) {
 				$str .= $ignore . " ";
 			}
@@ -2872,7 +2872,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 		// 0  1  2  3
 		// each item being e.g. E0AD|E0AF|F1FD
 		$str = "";
-		for ($i = 0; $i < count($lookaheadGlyphs); $i++) {
+		for ($i = 0, $iMax = count($lookaheadGlyphs); $i < $iMax; $i++) {
 			$str .= $ignore . " " . $lookaheadGlyphs[$i] . "";
 		}
 
@@ -3272,7 +3272,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 						$this->seek($Coverage);
 						$glyphs = $this->_getCoverage(); // Array of Hex Glyphs
-						for ($g = 0; $g < count($glyphs); $g++) {
+						for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 							if ($level == 2 && strpos($lcoverage, $glyphs[$g]) === false) {
 								continue;
 							}
@@ -3323,7 +3323,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 							$this->seek($Coverage);
 							$glyphs = $this->_getCoverage(); // Array of Hex Glyphs
 
-							for ($g = 0; $g < count($glyphs); $g++) {
+							for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 								if ($level == 2 && strpos($lcoverage, $glyphs[$g]) === false) {
 									continue;
 								}
@@ -3475,13 +3475,13 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 											}
 										}
 
-										for ($c1 = 0; $c1 < count($Class1[$i]); $c1++) {
+										for ($c1 = 0, $c1Max = count($Class1[$i]); $c1 < $c1Max; $c1++) {
 											$FirstGlyph = $Class1[$i][$c1];
 											if ($level == 2 && strpos($lcoverage, $FirstGlyph) === false) {
 												continue;
 											}
 
-											for ($c2 = 0; $c2 < count($Class2[$j]); $c2++) {
+											for ($c2 = 0, $c2Max = count($Class2[$j]); $c2 < $c2Max; $c2++) {
 												$SecondGlyph = $Class2[$j][$c2];
 
 												if (!$Value1['XPlacement'] && !$Value1['YPlacement'] && !$Value1['XAdvance'] && !$Value2['XPlacement'] && !$Value2['YPlacement'] && !$Value2['XAdvance']) {
@@ -3602,7 +3602,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 								$firstMark = '';
 								$html .= '<div class="glyphs">Marks: ';
-								for ($i = 0; $i < count($MarkGlyphs); $i++) {
+								for ($i = 0, $iMax = count($MarkGlyphs); $i < $iMax; $i++) {
 									if ($level == 2 && strpos($lcoverage, $MarkGlyphs[$i]) === false) {
 										continue;
 									} else {
@@ -3618,14 +3618,14 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 								}
 
 								$html .= '<div class="glyphs">Bases: ';
-								for ($j = 0; $j < count($BaseGlyphs); $j++) {
+								for ($j = 0, $jMax = count($BaseGlyphs); $j < $jMax; $j++) {
 									$html .= ' ' . $this->formatEntity($BaseGlyphs[$j]) . ' ';
 								}
 								$html .= '</div>';
 
 								// Example
 								$html .= '<div class="glyphs" style="font-feature-settings:\'' . $tag . '\' 1;">Example(s): ';
-								for ($j = 0; $j < min(count($BaseGlyphs), 20); $j++) {
+								for ($j = 0, $jMax = min(count($BaseGlyphs), 20); $j < $jMax; $j++) {
 									$html .= ' ' . $this->formatEntity($BaseGlyphs[$j]) . $this->formatEntity($firstMark, true) . ' &nbsp; ';
 								}
 								$html .= '</div>';
@@ -3650,7 +3650,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 									$firstMark = '';
 									$html .= '<div class="glyphs">Marks: <span class="unchanged">';
 									$MarkRecord = [];
-									for ($i = 0; $i < count($MarkGlyphs); $i++) {
+									for ($i = 0, $iMax = count($MarkGlyphs); $i < $iMax; $i++) {
 										if ($level == 2 && strpos($lcoverage, $MarkGlyphs[$i]) === false) {
 											continue;
 										} else {
@@ -3672,7 +3672,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 									$LigatureCount = $this->read_ushort();
 									$LigatureAttach = [];
 									$html .= '<div class="glyphs">Ligatures: <span class="unchanged">';
-									for ($j = 0; $j < count($LigatureGlyphs); $j++) {
+									for ($j = 0, $jMax = count($LigatureGlyphs); $j < $jMax; $j++) {
 										// Get the relevant LigatureRecord
 										$LigatureAttach[$j] = $LigatureArray + $this->read_ushort();
 										$html .= ' ' . $this->formatEntity($LigatureGlyphs[$j]) . ' ';
@@ -3721,7 +3721,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 										$firstMark = '';
 										$html .= '<div class="glyphs">Marks: <span class="unchanged">';
-										for ($i = 0; $i < count($Mark1Glyphs); $i++) {
+										for ($i = 0, $iMax = count($Mark1Glyphs); $i < $iMax; $i++) {
 											if ($level == 2 && strpos($lcoverage, $Mark1Glyphs[$i]) === false) {
 												continue;
 											} else {
@@ -3735,14 +3735,14 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 										if ($firstMark) {
 											$html .= '<div class="glyphs">Bases: <span class="unchanged">';
-											for ($j = 0; $j < count($Mark2Glyphs); $j++) {
+											for ($j = 0, $jMax = count($Mark2Glyphs); $j < $jMax; $j++) {
 												$html .= ' ' . $this->formatEntity($Mark2Glyphs[$j]) . ' ';
 											}
 											$html .= '</span></div>';
 
 											// Example
 											$html .= '<div class="glyphs" style="font-feature-settings:\'' . $tag . '\' 1;">Example(s): <span class="changed">';
-											for ($j = 0; $j < min(count($Mark2Glyphs), 20); $j++) {
+											for ($j = 0, $jMax = min(count($Mark2Glyphs), 20); $j < $jMax; $j++) {
 												$html .= ' ' . $this->formatEntity($Mark2Glyphs[$j]) . $this->formatEntity($firstMark, true) . ' &nbsp; ';
 											}
 											$html .= '</span></div>';
@@ -3848,11 +3848,11 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 																$html .= '<div>Backtrack #' . $ff . ': <span class="unicode">' . $this->formatUniStr($backtrackGlyphs[$ff]) . '</span></div>';
 																$exampleB[] = $this->formatEntityFirst($backtrackGlyphs[$ff]);
 															}
-															for ($ff = 0; $ff < count($inputGlyphs); $ff++) {
+															for ($ff = 0, $ffMax = count($inputGlyphs); $ff < $ffMax; $ff++) {
 																$html .= '<div>Input #' . $ff . ': <span class="unchanged">&nbsp;' . $this->formatEntityStr($inputGlyphs[$ff]) . '&nbsp;</span></div>';
 																$exampleI[] = $this->formatEntityFirst($inputGlyphs[$ff]);
 															}
-															for ($ff = 0; $ff < count($lookaheadGlyphs); $ff++) {
+															for ($ff = 0, $ffMax = count($lookaheadGlyphs); $ff < $ffMax; $ff++) {
 																$html .= '<div>Lookahead #' . $ff . ': <span class="unicode">' . $this->formatUniStr($lookaheadGlyphs[$ff]) . '</span></div>';
 																$exampleL[] = $this->formatEntityFirst($lookaheadGlyphs[$ff]);
 															}
@@ -3879,7 +3879,7 @@ $MarkAttachmentType = ' . var_export($this->MarkAttachmentType, true) . ';
 
 																if (count($inputGlyphs) > ($seqIndex + 1)) {
 																	$exL .= '<span class="inputother">';
-																	for ($ip = $seqIndex + 1; $ip < count($inputGlyphs); $ip++) {
+																	for ($ip = $seqIndex + 1, $ipMax = count($inputGlyphs); $ip < $ipMax; $ip++) {
 																		$exL .= '&#x200d;' . $exampleI[$ip];
 																	}
 																	$exL .= '</span>';

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -1887,7 +1887,7 @@ class TTFontFile
 				elseif ($Lookup[$i]['Type'] == 3) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage();
-					$gMax = count($glyphs); $g < $gMax;
+					$gMax = count($glyphs);
 					for ($g = 0; $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -1846,7 +1846,7 @@ class TTFontFile
 				if ($Lookup[$i]['Type'] == 1) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage(false);
-					for ($g = 0; $g < count($glyphs); $g++) {
+					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = unicode_hex($this->glyphToChar[$glyphs[$g]][0]);
@@ -1865,7 +1865,7 @@ class TTFontFile
 				elseif ($Lookup[$i]['Type'] == 2) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage();
-					for ($g = 0; $g < count($glyphs); $g++) {
+					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = $glyphs[$g];
@@ -1885,7 +1885,7 @@ class TTFontFile
 				elseif ($Lookup[$i]['Type'] == 3) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage();
-					for ($g = 0; $g < count($glyphs); $g++) {
+					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = $glyphs[$g];
@@ -2429,7 +2429,7 @@ class TTFontFile
 					}
 				} // LookupType 2: Multiple Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 2) {
-					for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = implode(" ", $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']);
 						// Ignore has already been applied earlier on
@@ -2439,7 +2439,7 @@ class TTFontFile
 					}
 				} // LookupType 3: Alternate Forms
 				elseif ($Lookup[$i]['Type'] == 3) {
-					for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						// Ignore has already been applied earlier on
@@ -2449,7 +2449,7 @@ class TTFontFile
 					}
 				} // LookupType 4: Ligature Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 4) {
-					for ($s = 0; $s < count($Lookup[$i]['Subtable'][$c]['subs']); $s++) {
+					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						// Ignore has already been applied earlier on
@@ -3080,7 +3080,7 @@ class TTFontFile
 		// $inputGlyphs = array of glyphs(glyphstrings) making up Input sequence in Context
 		// $lookupGlyphs = array of glyphs making up Lookup Input sequence - if applicable
 		$str = "";
-		for ($i = 1; $i <= count($inputGlyphs); $i++) {
+		for ($i = 1, $iMax = count($inputGlyphs); $i <= $iMax; $i++) {
 			if ($i > 1) {
 				$str .= $ignore . " ";
 			}
@@ -3113,7 +3113,7 @@ class TTFontFile
 		// 0  1  2  3
 		// each item being e.g. E0AD|E0AF|F1FD
 		$str = "";
-		for ($i = 0; $i < count($lookaheadGlyphs); $i++) {
+		for ($i = 0, $iMax = count($lookaheadGlyphs); $i < $iMax; $i++) {
 			$str .= $ignore . " (" . $lookaheadGlyphs[$i] . ")";
 		}
 

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -1846,7 +1846,8 @@ class TTFontFile
 				if ($Lookup[$i]['Type'] == 1) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage(false);
-					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+					$gMax = count($glyphs);
+					for ($g = 0; $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = unicode_hex($this->glyphToChar[$glyphs[$g]][0]);
@@ -1865,7 +1866,8 @@ class TTFontFile
 				elseif ($Lookup[$i]['Type'] == 2) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage();
-					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+					$gMax = count($glyphs);
+					for ($g = 0; $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = $glyphs[$g];
@@ -1885,7 +1887,8 @@ class TTFontFile
 				elseif ($Lookup[$i]['Type'] == 3) {
 					$this->seek($Lookup[$i]['Subtable'][$c]['CoverageTableOffset']);
 					$glyphs = $this->_getCoverage();
-					for ($g = 0, $gMax = count($glyphs); $g < $gMax; $g++) {
+					$gMax = count($glyphs); $g < $gMax;
+					for ($g = 0; $g < $gMax; $g++) {
 						$replace = [];
 						$substitute = [];
 						$replace[] = $glyphs[$g];
@@ -2429,7 +2432,8 @@ class TTFontFile
 					}
 				} // LookupType 2: Multiple Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 2) {
-					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+					$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+					for ($s = 0; $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = implode(" ", $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute']);
 						// Ignore has already been applied earlier on
@@ -2439,7 +2443,8 @@ class TTFontFile
 					}
 				} // LookupType 3: Alternate Forms
 				elseif ($Lookup[$i]['Type'] == 3) {
-					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+					$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+					for ($s = 0; $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						// Ignore has already been applied earlier on
@@ -2449,7 +2454,8 @@ class TTFontFile
 					}
 				} // LookupType 4: Ligature Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 4) {
-					for ($s = 0, $sMax = count($Lookup[$i]['Subtable'][$c]['subs']); $s < $sMax; $s++) {
+					$sMax = count($Lookup[$i]['Subtable'][$c]['subs']);
+					for ($s = 0; $s < $sMax; $s++) {
 						$inputGlyphs = $Lookup[$i]['Subtable'][$c]['subs'][$s]['Replace'];
 						$substitute = $Lookup[$i]['Subtable'][$c]['subs'][$s]['substitute'][0];
 						// Ignore has already been applied earlier on
@@ -3080,7 +3086,8 @@ class TTFontFile
 		// $inputGlyphs = array of glyphs(glyphstrings) making up Input sequence in Context
 		// $lookupGlyphs = array of glyphs making up Lookup Input sequence - if applicable
 		$str = "";
-		for ($i = 1, $iMax = count($inputGlyphs); $i <= $iMax; $i++) {
+		$iMax = count($inputGlyphs);
+		for ($i = 1; $i <= $iMax; $i++) {
 			if ($i > 1) {
 				$str .= $ignore . " ";
 			}
@@ -3113,7 +3120,8 @@ class TTFontFile
 		// 0  1  2  3
 		// each item being e.g. E0AD|E0AF|F1FD
 		$str = "";
-		for ($i = 0, $iMax = count($lookaheadGlyphs); $i < $iMax; $i++) {
+		$iMax = count($lookaheadGlyphs);
+		for ($i = 0; $i < $iMax; $i++) {
 			$str .= $ignore . " (" . $lookaheadGlyphs[$i] . ")";
 		}
 

--- a/src/TTFontFileAnalysis.php
+++ b/src/TTFontFileAnalysis.php
@@ -227,7 +227,8 @@ class TTFontFileAnalysis extends TTFontFile
 			$this->_pos += 10;  //PANOSE = 10 byte length
 			$panose = fread($this->fh, 10);
 			$this->panose = [];
-			for ($p = 0, $pMax = strlen($panose); $p < $pMax; $p++) {
+			$pMax = strlen($panose);
+			for ($p = 0; $p < $pMax; $p++) {
 				$this->panose[] = ord($panose[$p]);
 			}
 			$this->skip(20);

--- a/src/TTFontFileAnalysis.php
+++ b/src/TTFontFileAnalysis.php
@@ -227,7 +227,7 @@ class TTFontFileAnalysis extends TTFontFile
 			$this->_pos += 10;  //PANOSE = 10 byte length
 			$panose = fread($this->fh, 10);
 			$this->panose = [];
-			for ($p = 0; $p < strlen($panose); $p++) {
+			for ($p = 0, $pMax = strlen($panose); $p < $pMax; $p++) {
 				$this->panose[] = ord($panose[$p]);
 			}
 			$this->skip(20);

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -989,7 +989,7 @@ abstract class BlockTag extends Tag
 				if (count($this->mpdf->textbuffer) == 1) {
 					$content = $this->mpdf->textbuffer[0][0];
 				} else {
-					for ($i = 0; $i < count($this->mpdf->textbuffer); $i++) {
+					for ($i = 0, $iMax = count($this->mpdf->textbuffer); $i < $iMax; $i++) {
 						if (0 !== strpos($this->mpdf->textbuffer[$i][0], "\xbb\xa4\xac")) { //inline object
 							$content .= $this->mpdf->textbuffer[$i][0];
 						}

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -989,7 +989,8 @@ abstract class BlockTag extends Tag
 				if (count($this->mpdf->textbuffer) == 1) {
 					$content = $this->mpdf->textbuffer[0][0];
 				} else {
-					for ($i = 0, $iMax = count($this->mpdf->textbuffer); $i < $iMax; $i++) {
+					$iMax = count($this->mpdf->textbuffer);
+					for ($i = 0; $i < $iMax; $i++) {
 						if (0 !== strpos($this->mpdf->textbuffer[$i][0], "\xbb\xa4\xac")) { //inline object
 							$content .= $this->mpdf->textbuffer[$i][0];
 						}

--- a/src/Tag/Br.php
+++ b/src/Tag/Br.php
@@ -43,7 +43,7 @@ class Br extends Tag
 				for ($i = count($iBDF) - 1; $i >= 0; $i--) {
 					$inlinepre .= $this->mpdf->_setBidiCodes('end', $iBDF[$i]);
 				}
-				for ($i = 0; $i < count($iBDF); $i++) {
+				for ($i = 0, $iMax = count($iBDF); $i < $iMax; $i++) {
 					$inlinepost .= $this->mpdf->_setBidiCodes('start', $iBDF[$i]);
 				}
 			}

--- a/src/Tag/Br.php
+++ b/src/Tag/Br.php
@@ -43,7 +43,8 @@ class Br extends Tag
 				for ($i = count($iBDF) - 1; $i >= 0; $i--) {
 					$inlinepre .= $this->mpdf->_setBidiCodes('end', $iBDF[$i]);
 				}
-				for ($i = 0, $iMax = count($iBDF); $i < $iMax; $i++) {
+				$iMax = count($iBDF);
+				for ($i = 0; $i < $iMax; $i++) {
 					$inlinepost .= $this->mpdf->_setBidiCodes('start', $iBDF[$i]);
 				}
 			}

--- a/src/Writer/BookmarkWriter.php
+++ b/src/Writer/BookmarkWriter.php
@@ -36,7 +36,8 @@ final class BookmarkWriter
 		$bmo = $this->mpdf->BMoutlines;
 		$this->mpdf->BMoutlines = [];
 		$lastlevel = -1;
-		for ($i = 0, $iMax = count($bmo); $i < $iMax; $i++) {
+		$iMax = count($bmo);
+		for ($i = 0; $i < $iMax; $i++) {
 			if ($bmo[$i]['l'] > 0) {
 				while ($bmo[$i]['l'] - $lastlevel > 1) { // If jump down more than one level, insert a new entry
 					$new = $bmo[$i];

--- a/src/Writer/BookmarkWriter.php
+++ b/src/Writer/BookmarkWriter.php
@@ -36,7 +36,7 @@ final class BookmarkWriter
 		$bmo = $this->mpdf->BMoutlines;
 		$this->mpdf->BMoutlines = [];
 		$lastlevel = -1;
-		for ($i = 0; $i < count($bmo); $i++) {
+		for ($i = 0, $iMax = count($bmo); $i < $iMax; $i++) {
 			if ($bmo[$i]['l'] > 0) {
 				while ($bmo[$i]['l'] - $lastlevel > 1) { // If jump down more than one level, insert a new entry
 					$new = $bmo[$i];

--- a/utils/font_coverage.php
+++ b/utils/font_coverage.php
@@ -68,7 +68,8 @@ foreach ($ff as $f) {
 		$ret[] = $ttf->extractCoreInfo($ttfdir . '/' . $f);
 	}
 
-	for ($i = 0, $iMax = count($ret); $i < $iMax; $i++) {
+	$iMax = count($ret);
+	for ($i = 0; $i < $iMax; $i++) {
 		if (is_array($ret[$i])) {
 			$tfname = $ret[$i][0];
 			$bold = $ret[$i][1];

--- a/utils/font_coverage.php
+++ b/utils/font_coverage.php
@@ -68,7 +68,7 @@ foreach ($ff as $f) {
 		$ret[] = $ttf->extractCoreInfo($ttfdir . '/' . $f);
 	}
 
-	for ($i = 0; $i < count($ret); $i++) {
+	for ($i = 0, $iMax = count($ret); $i < $iMax; $i++) {
 		if (is_array($ret[$i])) {
 			$tfname = $ret[$i][0];
 			$bold = $ret[$i][1];

--- a/utils/font_names.php
+++ b/utils/font_names.php
@@ -44,7 +44,7 @@ foreach ($ff as $f) {
 	} else if (strtolower(substr($f, -4, 4)) == '.ttf' || strtolower(substr($f, -4, 4)) == '.otf') {
 		$ret[] = $ttf->extractCoreInfo($ttfdir . '/' . $f);
 	}
-	for ($i = 0; $i < count($ret); $i++) {
+	for ($i = 0, $iMax = count($ret); $i < $iMax; $i++) {
 		if (!is_array($ret[$i])) {
 			if (!$pdf) {
 				echo $ret[$i] . '<br />';

--- a/utils/font_names.php
+++ b/utils/font_names.php
@@ -44,7 +44,8 @@ foreach ($ff as $f) {
 	} else if (strtolower(substr($f, -4, 4)) == '.ttf' || strtolower(substr($f, -4, 4)) == '.otf') {
 		$ret[] = $ttf->extractCoreInfo($ttfdir . '/' . $f);
 	}
-	for ($i = 0, $iMax = count($ret); $i < $iMax; $i++) {
+	$iMax = count($ret);
+	for ($i = 0; $i < $iMax; $i++) {
 		if (!is_array($ret[$i])) {
 			if (!$pdf) {
 				echo $ret[$i] . '<br />';


### PR DESCRIPTION
These might be considered as minor performance changes, but together they might make a dent.

- array_push(...) calls behaving as '$array []= ...'. ' []= ' works faster than invoking functions in PHP.
- ￼If you only want to determine if a particular needle occurs within haystack, use the faster and less memory intensive function strpos() instead.
- These cases can be refactored by using case-sensitive functions strstr(...)/strpos() for better performance because matched patterns does not contain any characters.
- substr() shorthand can be used instead of strlen().
- A 'substr()' call can behave as array access, but hiding some error-handling logic behind as well. Using array access is a preferred way, because you have to implicitly write (read as document) errors handling code.
- Cascade str_replace() calls when the function has been applied to a variable sequentially.
- Fix count function in loops.