### PR TITLE
Valid EAN UPC barcode and throw BarcodeException if is not valid.

### DIFF
--- a/src/Barcode/EanUpc.php
+++ b/src/Barcode/EanUpc.php
@@ -35,6 +35,10 @@ class EanUpc extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Barc
 	 */
 	private function init($code, $length)
 	{
+        if (preg_match('/[\D]+/', $code)) {
+            throw new \Mpdf\Barcode\BarcodeException('Invalid EAN UPC barcode value');
+        }
+
 		$upce = false;
 		$checkdigit = false;
 

--- a/src/Barcode/EanUpc.php
+++ b/src/Barcode/EanUpc.php
@@ -35,9 +35,9 @@ class EanUpc extends \Mpdf\Barcode\AbstractBarcode implements \Mpdf\Barcode\Barc
 	 */
 	private function init($code, $length)
 	{
-        if (preg_match('/[\D]+/', $code)) {
-            throw new \Mpdf\Barcode\BarcodeException('Invalid EAN UPC barcode value');
-        }
+		if (preg_match('/[\D]+/', $code)) {
+			throw new \Mpdf\Barcode\BarcodeException('Invalid EAN UPC barcode value');
+		}
 
 		$upce = false;
 		$checkdigit = false;

--- a/tests/Mpdf/Barcode/EanUpcTest.php
+++ b/tests/Mpdf/Barcode/EanUpcTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mpdf\Barcode;
+
+/**
+ * @group unit
+ */
+class EanUpcTest extends \PHPUnit_Framework_TestCase
+{
+
+	public function testInit()
+	{
+		$barcode = new EanUpc('9783161484100', 13, 11, 7, 0.33, 25.93);
+		$array = $barcode->getData();
+		$this->assertInternalType('array', $array);
+		$this->assertArrayHasKey('bcode', $array);
+		$this->assertInternalType('array', $array['bcode']);
+	}
+
+	public function invalidCodeProvider()
+	{
+		return [
+			['foo'],
+			['foo11bar'],
+		];
+	}
+
+	/**
+	 * @dataProvider invalidCodeProvider
+	 * @expectedException \Mpdf\Barcode\BarcodeException
+     * @expectedExceptionMessage Invalid EAN UPC barcode value
+	 */
+	public function testInvalidCode($code)
+	{
+		new EanUpc($code, 13, 11, 7, 0.33, 25.93);
+	}
+
+}

--- a/tests/Mpdf/Barcode/EanUpcTest.php
+++ b/tests/Mpdf/Barcode/EanUpcTest.php
@@ -28,7 +28,7 @@ class EanUpcTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @dataProvider invalidCodeProvider
 	 * @expectedException \Mpdf\Barcode\BarcodeException
-     * @expectedExceptionMessage Invalid EAN UPC barcode value
+	 * @expectedExceptionMessage Invalid EAN UPC barcode value
 	 */
 	public function testInvalidCode($code)
 	{


### PR DESCRIPTION
Because PHP throws warnings if `$code` has non-numeric chars:

```
PHP Warning:  A non-numeric value encountered in /vendor/mpdf/mpdf/src/Barcode/EanUpc.php on line 54
PHP Warning:  A non-numeric value encountered in /vendor/mpdf/mpdf/src/Barcode/EanUpc.php on line 62
```