### PR TITLE
fix mpdf overwrites setasign/fpdi/fpditrait cleanup method

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1514,7 +1514,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->selectoption = [];
 	}
 
-	public function cleanup()
+	public function resetEncoding()
 	{
 		mb_internal_encoding($this->originalMbEnc);
 		@mb_regex_encoding($this->originalMbRegexEnc);

--- a/tests/Issues/Issue421Test.php
+++ b/tests/Issues/Issue421Test.php
@@ -14,7 +14,7 @@ class Issue421Test extends \Mpdf\BaseMpdfTest
 		$mpdf = new \Mpdf\Mpdf(['mode' => 'c']);
 		$mpdf->WriteHTML('');
 
-		$mpdf->cleanup();
+		$mpdf->resetEncoding();
 
 		$this->assertSame('🐙', mb_substr('🐙', 0, 1));
 	}

--- a/tests/Mpdf/BaseMpdfTest.php
+++ b/tests/Mpdf/BaseMpdfTest.php
@@ -23,7 +23,7 @@ abstract class BaseMpdfTest extends \PHPUnit_Framework_TestCase
 	{
 		parent::tearDown();
 
-		$this->mpdf->cleanup();
+		$this->mpdf->resetEncoding();
 	}
 
 }


### PR DESCRIPTION
Reason:
cleanup method from setasign/Fpdi/FpdiTrait is being overwritten by Mpdf.
Fix:
Rename cleanup method from Mpdf to resetEncoding.