### PR TITLE
fix: Display external links on imported PDFs

### DIFF
--- a/src/FpdiTrait.php
+++ b/src/FpdiTrait.php
@@ -209,9 +209,8 @@ trait FpdiTrait
 				$annotation = PdfType::resolve($annotation, $parser)->value;
 
 				/* Skip over any annotations that aren't links */
-				$type = $getAttribute($annotation, 'Type');
 				$subtype = $getAttribute($annotation, 'Subtype');
-				if ($type !== 'Annot' || $subtype !== 'Link' || !isset($annotation['A'])) {
+				if ($subtype !== 'Link' || !isset($annotation['A'])) {
 					continue;
 				}
 


### PR DESCRIPTION
Reason:
Bad condition in getImportedExternalPageLinks() caused ignoring some links in imported pages.