### PR TITLE
use system temp dir for default tempDir value

### DIFF
--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -453,7 +453,7 @@ class ConfigVariables
 				__DIR__ . '/../../ttfonts'
 			],
 
-			'tempDir' => __DIR__ . '/../../tmp',
+			'tempDir' => sys_get_temp_dir(),
 
 			'allowAnnotationFiles' => false,
 


### PR DESCRIPTION
If the vendor dir is not writable for any reason, we can't create tempDir folder to it.
While the system temp dir assume to be always writable