### PR TITLE
security, open require in COLLATION-GROUP

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -23691,6 +23691,20 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->Reference[] = ['t' => $txta . ' - see ' . $txtb, 'p' => []];
 	}
 
+	private function filesInDir($directory)
+	{
+		$files = [];
+		foreach ((new \DirectoryIterator($directory)) as $v) {
+			if ($v->isDir() || $v->isDot()) {
+				continue;
+			}
+
+			$files[] = $v->getPathname();
+		}
+
+		return $files;
+	}
+
 	function InsertIndex($usedivletters = 1, $useLinking = false, $indexCollationLocale = '', $indexCollationGroup = '')
 	{
 		$size = count($this->Reference);
@@ -23727,7 +23741,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		if ($usedivletters) {
-			if ($indexCollationGroup) {
+			if ($indexCollationGroup && \in_array(strtolower($indexCollationGroup), array_map(function ($v) {
+					return strtolower(basename($v, '.php'));
+			}, $this->filesInDir(__DIR__ . '/../data/collations/')))) {
 				$collation = require __DIR__ . '/../data/collations/' . $indexCollationGroup . '.php';
 			} else {
 				$collation = [];

--- a/tests/Issues/Issue1056Test.php
+++ b/tests/Issues/Issue1056Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Mpdf;
+
+class Issue1056Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testValidCollationGroupRequire()
+	{
+		$html = '
+<indexentry content="FOO" /><pagebreak /><INDEXINSERT COLLATION-GROUP="../../../FOOBAR" foo="bar">dsfsadf</INDEXINSERT>
+';
+
+		$this->mpdf->WriteHtml($html, 2);
+
+		$out = $this->mpdf->Output('', 'S');
+	}
+
+	public function testInvalidCollationGroupRequire()
+	{
+		$html = '
+<indexentry content="foo" /><pagebreak /><INDEXINSERT COLLATION-GROUP="Albanian_Albania" foo="foo">dsfsadf</INDEXINSERT>
+';
+
+		$this->mpdf->WriteHtml($html, 2);
+
+		$out = $this->mpdf->Output('', 'S');
+	}
+
+}


### PR DESCRIPTION
currently it is possible to misuse `COLLATION-GROUP` to `require` arbitrary php files.
This can be dangerous if you accept html from third party.

Just have a look at the test. The current master/development would fail because it cant locate FOOBAR.php.