### PR TITLE
Filesystem wrapper for sandboxing

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -15,18 +15,18 @@ class Cache
 
 	public function __construct($basePath, FileSystem $fileSystem, $cleanupInterval = 3600)
 	{
+        $this->basePath = $basePath;
+        $this->fileSystem = $fileSystem;
+        $this->cleanupInterval = $cleanupInterval;
+
 		if (!$this->createBasePath($basePath)) {
 			throw new \Mpdf\MpdfException(sprintf('Temporary files directory "%s" is not writable', $basePath));
 		}
-
-		$this->basePath = $basePath;
-		$this->fileSystem = $fileSystem;
-		$this->cleanupInterval = $cleanupInterval;
 	}
 
 	protected function createBasePath($basePath)
 	{
-		if (!file_exists($basePath)) {
+		if (!$this->fileSystem->file_exists($basePath)) {
 			if (!$this->createBasePath(dirname($basePath))) {
 				return false;
 			}
@@ -63,7 +63,7 @@ class Cache
 
 	public function has($filename)
 	{
-		return file_exists($this->getFilePath($filename));
+		return $this->fileSystem->file_exists($this->getFilePath($filename));
 	}
 
 	public function load($filename)

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -36,7 +36,7 @@ class Cache
 			}
 		}
 
-		if (!is_writable($basePath) || !is_dir($basePath)) {
+		if (!$this->fileSystem->is_writable($basePath) || !$this->fileSystem->is_dir($basePath)) {
 			return false;
 		}
 
@@ -45,11 +45,11 @@ class Cache
 
 	protected function createDirectory($basePath)
 	{
-		if (!mkdir($basePath)) {
+		if (!$this->fileSystem->mkdir($basePath)) {
 			return false;
 		}
 
-		if (!chmod($basePath, 0777)) {
+		if (!$this->fileSystem->chmod($basePath, 0777)) {
 			return false;
 		}
 
@@ -82,7 +82,7 @@ class Cache
 
 	public function remove($filename)
 	{
-		return unlink($this->getFilePath($filename));
+		return $this->fileSystem->unlink($this->getFilePath($filename));
 	}
 
 	public function clearOld()
@@ -95,7 +95,7 @@ class Cache
 					&& $item->isFile()
 					&& !$this->isDotFile($item)
 					&& $this->isOld($item)) {
-				unlink($item->getPathname());
+				$this->fileSystem->unlink($item->getPathname());
 			}
 		}
 	}

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -15,9 +15,9 @@ class Cache
 
 	public function __construct($basePath, FileSystem $fileSystem, $cleanupInterval = 3600)
 	{
-        $this->basePath = $basePath;
-        $this->fileSystem = $fileSystem;
-        $this->cleanupInterval = $cleanupInterval;
+		$this->basePath = $basePath;
+		$this->fileSystem = $fileSystem;
+		$this->cleanupInterval = $cleanupInterval;
 
 		if (!$this->createBasePath($basePath)) {
 			throw new \Mpdf\MpdfException(sprintf('Temporary files directory "%s" is not writable', $basePath));

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -11,13 +11,16 @@ class Cache
 
 	private $cleanupInterval;
 
-	public function __construct($basePath, $cleanupInterval = 3600)
+	private $fileSystem;
+
+	public function __construct($basePath, FileSystem $fileSystem, $cleanupInterval = 3600)
 	{
 		if (!$this->createBasePath($basePath)) {
 			throw new \Mpdf\MpdfException(sprintf('Temporary files directory "%s" is not writable', $basePath));
 		}
 
 		$this->basePath = $basePath;
+		$this->fileSystem = $fileSystem;
 		$this->cleanupInterval = $cleanupInterval;
 	}
 
@@ -65,14 +68,14 @@ class Cache
 
 	public function load($filename)
 	{
-		return file_get_contents($this->getFilePath($filename));
+		return $this->fileSystem->file_get_contents($this->getFilePath($filename));
 	}
 
 	public function write($filename, $data)
 	{
 		$path = $this->getFilePath($filename);
 
-		file_put_contents($path, $data);
+		$this->fileSystem->file_put_contents($path, $data);
 
 		return $path;
 	}

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2264,7 +2264,7 @@ class CssManager
 
 			$tr = parse_url($path);
 			$lp = __FILE__;
-			$ap = realpath($lp);
+			$ap = $this->fileSystem->realpath($lp);
 			$ap = str_replace("\\", '/', $ap);
 			$docroot = substr($ap, 0, strpos($ap, $lp));
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -31,6 +31,11 @@ class CssManager
 	 */
 	private $colorConverter;
 
+	/**
+	 * @var \Mpdf\FileSystem
+	 */
+	private $fileSystem;
+
 	var $tablecascadeCSS;
 
 	var $cascadeCSS;
@@ -47,7 +52,7 @@ class CssManager
 
 	var $cell_border_dominance_T;
 
-	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter)
+	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter, FileSystem $fileSystem)
 	{
 		$this->mpdf = $mpdf;
 		$this->cache = $cache;
@@ -58,6 +63,7 @@ class CssManager
 		$this->cascadeCSS = [];
 		$this->tbCSSlvl = 0;
 		$this->colorConverter = $colorConverter;
+		$this->fileSystem = $fileSystem;
 	}
 
 	function ReadCSS($html)
@@ -2248,7 +2254,7 @@ class CssManager
 			$path = preg_replace('/\.css\?.*$/', '.css', $path);
 		}
 
-		$contents = @file_get_contents($path);
+		$contents = $this->fileSystem->Silentfile_get_contents($path);
 
 		if ($contents) {
 			return $contents;
@@ -2272,7 +2278,7 @@ class CssManager
 				$localpath = $path;
 			}
 
-			$contents = @file_get_contents($localpath);
+			$contents = $this->fileSystem->silentFile_get_contents($localpath);
 
 		} elseif (!$contents && !ini_get('allow_url_fopen') && function_exists('curl_init')) { // if not use full URL
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2282,11 +2282,11 @@ class CssManager
 
 		} elseif (!$contents && !ini_get('allow_url_fopen') && function_exists('curl_init')) { // if not use full URL
 
-			$ch = curl_init($path);
+			$ch = $this->fileSystem->curl_init($path);
 			curl_setopt($ch, CURLOPT_HEADER, 0);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			$contents = curl_exec($ch);
-			curl_close($ch);
+			$contents = $this->fileSystem->curl_exec($ch);
+            $this->fileSystem->curl_close($ch);
 
 		}
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2286,7 +2286,7 @@ class CssManager
 			curl_setopt($ch, CURLOPT_HEADER, 0);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			$contents = $this->fileSystem->curl_exec($ch);
-            $this->fileSystem->curl_close($ch);
+			$this->fileSystem->curl_close($ch);
 
 		}
 

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -4,29 +4,29 @@ namespace Mpdf;
 
 class FileSystem
 {
-	public function fopen($filename, $mode, $use_include_path = null, $context = null)
+	public function fopen($filename, $mode)
 	{
-		return \fopen($filename, $mode, $use_include_path, $context);
+		return \fopen($filename, $mode);
 	}
 
-	public function silentFopen($filename, $mode, $use_include_path = null, $context = null)
+	public function silentFopen($filename, $mode)
 	{
-		return @\fopen($filename, $mode, $use_include_path, $context);
+		return @\fopen($filename, $mode);
 	}
 
-	public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+	public function file_get_contents($filename)
 	{
-		return \file_get_contents($filename, $use_include_path, $context, $offset);
+		return \file_get_contents($filename);
 	}
 
-	public function file_put_contents($filename, $data, $flags = 0, $context = null)
+	public function file_put_contents($filename, $data, $flags = 0)
 	{
-		return \file_put_contents($filename, $data, $flags, $context);
+		return \file_put_contents($filename, $data, $flags);
 	}
 
-	public function silentFile_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+	public function silentFile_get_contents($filename)
 	{
-		return @\file_get_contents($filename, $use_include_path, $context, $offset);
+		return @\file_get_contents($filename);
 	}
 
 	public function file_exists($filename)

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mpdf;
+
+class FileSystem
+{
+    public function fopen($filename, $mode, $use_include_path = null, $context = null) {
+        return \fopen($filename, $mode, $use_include_path, $context);
+    }
+
+    public function silentFopen($filename, $mode, $use_include_path = null, $context = null) {
+        return @\fopen($filename, $mode, $use_include_path, $context);
+    }
+
+    public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+    {
+        return \file_get_contents($filename, $use_include_path, $context, $offset);
+    }
+
+    public function file_put_contents($filename, $data, $flags = 0, $context = null)
+    {
+        return \file_put_contents($filename, $data, $flags, $context);
+    }
+
+    public function silentFile_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+    {
+        return @\file_get_contents($filename, $use_include_path, $context, $offset);
+    }
+
+    // file_exists
+    // unlink
+    // rmdir
+}

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -27,7 +27,14 @@ class FileSystem
         return @\file_get_contents($filename, $use_include_path, $context, $offset);
     }
 
+    public function file_exists($filename) {
+        return \file_exists($filename);
+    }
+
     // file_exists
+    // is_writable
+    // is_dir
+    // mkdir
     // unlink
     // rmdir
 }

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -89,7 +89,23 @@ class FileSystem
         return \stat($filename);
     }
 
-    // is_file
+    public function curl_init($url)
+    {
+        return \curl_init($url);
+    }
 
-    // rmdir
+    public function curl_exec($ch)
+    {
+        return \curl_exec($ch);
+    }
+
+    public function curl_close($ch)
+    {
+        return \curl_close($ch);
+    }
+
+    public function curl_error($ch)
+    {
+        return \curl_error($ch);
+    }
 }

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -4,108 +4,108 @@ namespace Mpdf;
 
 class FileSystem
 {
-    public function fopen($filename, $mode, $use_include_path = null, $context = null)
-    {
-        return \fopen($filename, $mode, $use_include_path, $context);
-    }
+	public function fopen($filename, $mode, $use_include_path = null, $context = null)
+	{
+		return \fopen($filename, $mode, $use_include_path, $context);
+	}
 
-    public function silentFopen($filename, $mode, $use_include_path = null, $context = null)
-    {
-        return @\fopen($filename, $mode, $use_include_path, $context);
-    }
+	public function silentFopen($filename, $mode, $use_include_path = null, $context = null)
+	{
+		return @\fopen($filename, $mode, $use_include_path, $context);
+	}
 
-    public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
-    {
-        return \file_get_contents($filename, $use_include_path, $context, $offset);
-    }
+	public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+	{
+		return \file_get_contents($filename, $use_include_path, $context, $offset);
+	}
 
-    public function file_put_contents($filename, $data, $flags = 0, $context = null)
-    {
-        return \file_put_contents($filename, $data, $flags, $context);
-    }
+	public function file_put_contents($filename, $data, $flags = 0, $context = null)
+	{
+		return \file_put_contents($filename, $data, $flags, $context);
+	}
 
-    public function silentFile_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
-    {
-        return @\file_get_contents($filename, $use_include_path, $context, $offset);
-    }
+	public function silentFile_get_contents($filename, $use_include_path = false, $context = null, $offset = 0)
+	{
+		return @\file_get_contents($filename, $use_include_path, $context, $offset);
+	}
 
-    public function file_exists($filename)
-    {
-        return \file_exists($filename);
-    }
+	public function file_exists($filename)
+	{
+		return \file_exists($filename);
+	}
 
-    public function is_writable($filename)
-    {
-        return \is_writeable($filename);
-    }
+	public function is_writable($filename)
+	{
+		return \is_writeable($filename);
+	}
 
-    public function is_dir($filename)
-    {
-        return \is_dir($filename);
-    }
+	public function is_dir($filename)
+	{
+		return \is_dir($filename);
+	}
 
-    public function mkdir($filename)
-    {
-        return \mkdir($filename);
-    }
+	public function mkdir($filename)
+	{
+		return \mkdir($filename);
+	}
 
-    public function unlink($filename)
-    {
-        return \unlink($filename);
-    }
+	public function unlink($filename)
+	{
+		return \unlink($filename);
+	}
 
-    public function chmod($filename, $mode)
-    {
-        return \chmod($filename, $mode);
-    }
+	public function chmod($filename, $mode)
+	{
+		return \chmod($filename, $mode);
+	}
 
-    public function file($filename)
-    {
-        return \file($filename);
-    }
+	public function file($filename)
+	{
+		return \file($filename);
+	}
 
-    public function is_file($filename)
-    {
-        return \is_file($filename);
-    }
+	public function is_file($filename)
+	{
+		return \is_file($filename);
+	}
 
-    public function SilentFile($filename)
-    {
-        return @\file($filename);
-    }
+	public function SilentFile($filename)
+	{
+		return @\file($filename);
+	}
 
-    public function filemtime($filename)
-    {
-        return \filemtime($filename);
-    }
+	public function filemtime($filename)
+	{
+		return \filemtime($filename);
+	}
 
-    public function realpath($filename)
-    {
-        return \realpath($filename);
-    }
+	public function realpath($filename)
+	{
+		return \realpath($filename);
+	}
 
-    public function stat($filename)
-    {
-        return \stat($filename);
-    }
+	public function stat($filename)
+	{
+		return \stat($filename);
+	}
 
-    public function curl_init($url)
-    {
-        return \curl_init($url);
-    }
+	public function curl_init($url)
+	{
+		return \curl_init($url);
+	}
 
-    public function curl_exec($ch)
-    {
-        return \curl_exec($ch);
-    }
+	public function curl_exec($ch)
+	{
+		return \curl_exec($ch);
+	}
 
-    public function curl_close($ch)
-    {
-        return \curl_close($ch);
-    }
+	public function curl_close($ch)
+	{
+		return \curl_close($ch);
+	}
 
-    public function curl_error($ch)
-    {
-        return \curl_error($ch);
-    }
+	public function curl_error($ch)
+	{
+		return \curl_error($ch);
+	}
 }

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -4,11 +4,13 @@ namespace Mpdf;
 
 class FileSystem
 {
-    public function fopen($filename, $mode, $use_include_path = null, $context = null) {
+    public function fopen($filename, $mode, $use_include_path = null, $context = null)
+    {
         return \fopen($filename, $mode, $use_include_path, $context);
     }
 
-    public function silentFopen($filename, $mode, $use_include_path = null, $context = null) {
+    public function silentFopen($filename, $mode, $use_include_path = null, $context = null)
+    {
         return @\fopen($filename, $mode, $use_include_path, $context);
     }
 
@@ -27,14 +29,67 @@ class FileSystem
         return @\file_get_contents($filename, $use_include_path, $context, $offset);
     }
 
-    public function file_exists($filename) {
+    public function file_exists($filename)
+    {
         return \file_exists($filename);
     }
 
-    // file_exists
-    // is_writable
-    // is_dir
-    // mkdir
-    // unlink
+    public function is_writable($filename)
+    {
+        return \is_writeable($filename);
+    }
+
+    public function is_dir($filename)
+    {
+        return \is_dir($filename);
+    }
+
+    public function mkdir($filename)
+    {
+        return \mkdir($filename);
+    }
+
+    public function unlink($filename)
+    {
+        return \unlink($filename);
+    }
+
+    public function chmod($filename, $mode)
+    {
+        return \chmod($filename, $mode);
+    }
+
+    public function file($filename)
+    {
+        return \file($filename);
+    }
+
+    public function is_file($filename)
+    {
+        return \is_file($filename);
+    }
+
+    public function SilentFile($filename)
+    {
+        return @\file($filename);
+    }
+
+    public function filemtime($filename)
+    {
+        return \filemtime($filename);
+    }
+
+    public function realpath($filename)
+    {
+        return \realpath($filename);
+    }
+
+    public function stat($filename)
+    {
+        return \stat($filename);
+    }
+
+    // is_file
+
     // rmdir
 }

--- a/src/Fonts/FontCache.php
+++ b/src/Fonts/FontCache.php
@@ -3,6 +3,7 @@
 namespace Mpdf\Fonts;
 
 use Mpdf\Cache;
+use Mpdf\FileSystem;
 
 class FontCache
 {
@@ -11,9 +12,12 @@ class FontCache
 
 	private $cache;
 
-	public function __construct(Cache $cache)
+	private $fileSystem;
+
+	public function __construct(Cache $cache, FileSystem $fileSystem)
 	{
 		$this->cache = $cache;
+		$this->fileSystem = $fileSystem;
 	}
 
 	public function tempFilename($filename)
@@ -53,7 +57,7 @@ class FontCache
 
 	public function binaryWrite($filename, $data)
 	{
-		$handle = fopen($this->tempFilename($filename), 'wb');
+		$handle = $this->fileSystem->fopen($this->tempFilename($filename), 'wb');
 		fwrite($handle, $data);
 		fclose($handle);
 	}

--- a/src/Fonts/FontFileFinder.php
+++ b/src/Fonts/FontFileFinder.php
@@ -2,14 +2,18 @@
 
 namespace Mpdf\Fonts;
 
+use Mpdf\FileSystem;
+
 class FontFileFinder
 {
+    private $fileSystem;
 
 	private $directories;
 
-	public function __construct($directories)
+	public function __construct($directories, FileSystem $fileSystem)
 	{
 		$this->setDirectories($directories);
+		$this->fileSystem = $fileSystem;
 	}
 
 	public function setDirectories($directories)
@@ -25,7 +29,7 @@ class FontFileFinder
 	{
 		foreach ($this->directories as $directory) {
 			$filename = $directory . '/' . $name;
-			if (file_exists($filename)) {
+			if ($this->fileSystem->file_exists($filename)) {
 				return $filename;
 			}
 		}

--- a/src/Fonts/FontFileFinder.php
+++ b/src/Fonts/FontFileFinder.php
@@ -6,7 +6,7 @@ use Mpdf\FileSystem;
 
 class FontFileFinder
 {
-    private $fileSystem;
+	private $fileSystem;
 
 	private $directories;
 

--- a/src/Fonts/MetricsGenerator.php
+++ b/src/Fonts/MetricsGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Mpdf\Fonts;
 
+use Mpdf\FileSystem;
 use Mpdf\TTFontFile;
 
 class MetricsGenerator
@@ -11,15 +12,18 @@ class MetricsGenerator
 
 	private $fontDescriptor;
 
-	public function __construct(FontCache $fontCache, $fontDescriptor)
+	private $fileSystem;
+
+	public function __construct(FontCache $fontCache, $fontDescriptor, FileSystem $fileSystem)
 	{
 		$this->fontCache = $fontCache;
 		$this->fontDescriptor = $fontDescriptor;
+		$this->fileSystem = $fileSystem;
 	}
 
 	public function generateMetrics($ttffile, $ttfstat, $fontkey, $TTCfontID, $debugfonts, $BMPonly, $useOTL, $fontUseOTL)
 	{
-		$ttf = new TTFontFile($this->fontCache, $this->fontDescriptor);
+		$ttf = new TTFontFile($this->fontCache, $this->fontDescriptor, $this->fileSystem);
 		$ttf->getMetrics($ttffile, $fontkey, $TTCfontID, $debugfonts, $BMPonly, $useOTL); // mPDF 5.7.1
 
 		$font = [

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -177,7 +177,7 @@ class Hyphenator
 
 	private function loadDictionary()
 	{
-		if (file_exists($this->mpdf->hyphenationDictionaryFile)) {
+		if ($this->mpdf->getFileSystem()->file_exists($this->mpdf->hyphenationDictionaryFile)) {
 			$this->dictionary = file($this->mpdf->hyphenationDictionaryFile, FILE_SKIP_EMPTY_LINES);
 			foreach ($this->dictionary as $entry) {
 				$entry = trim($entry);

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -178,7 +178,7 @@ class Hyphenator
 	private function loadDictionary()
 	{
 		if ($this->mpdf->getFileSystem()->file_exists($this->mpdf->hyphenationDictionaryFile)) {
-			$this->dictionary = file($this->mpdf->hyphenationDictionaryFile, FILE_SKIP_EMPTY_LINES);
+			$this->dictionary = $this->mpdf->getFileSystem()->file($this->mpdf->hyphenationDictionaryFile, FILE_SKIP_EMPTY_LINES);
 			foreach ($this->dictionary as $entry) {
 				$entry = trim($entry);
 				$poss = [];

--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -122,7 +122,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 		ScriptToLanguageInterface $scriptToLanguage,
 		RemoteContentFetcher $remoteContentFetcher,
 		LoggerInterface $logger,
-        FileSystem $fileSystem
+		FileSystem $fileSystem
 	) {
 
 		$this->mpdf = $mpdf;

--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -339,7 +339,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 						return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile . ') created with GD library to parse JPG(CMYK) image');
 					}
 					imagedestroy($im);
-					unlink($tempfile);
+					$this->fileSystem->unlink($tempfile);
 					$info['type'] = 'jpg';
 					if ($firsttime) {
 						$info['i'] = count($this->mpdf->images) + 1;
@@ -686,7 +686,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 					imagedestroy($imgplain);
 					// embed mask image
 					$minfo = $this->getImage($tempfile_alpha, false);
-					unlink($tempfile_alpha);
+					$this->fileSystem->unlink($tempfile_alpha);
 
 					if (!$minfo) {
 						return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile_alpha . ') created with GD library to parse PNG image');
@@ -698,7 +698,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 					$this->mpdf->images[$tempfile_alpha] = $minfo;
 					// embed image, masked with previously embedded mask
 					$info = $this->getImage($tempfile, false);
-					unlink($tempfile);
+					$this->fileSystem->unlink($tempfile);
 
 					if (!$info) {
 						return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile . ') created with GD library to parse PNG image');
@@ -763,7 +763,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 				}
 				imagedestroy($im);
 				$info = $this->getImage($tempfile, false);
-				unlink($tempfile);
+				$this->fileSystem->unlink($tempfile);
 				if (!$info) {
 					return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile . ') created with GD library to parse PNG image');
 				}
@@ -896,7 +896,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 					imagealphablending($im, false);
 					imagesavealpha($im, false);
 					imageinterlace($im, false);
-					if (!is_writable($tempfile)) {
+					if (!$this->fileSystem->is_writable($tempfile)) {
 						ob_start();
 						$check = @imagepng($im);
 						if (!$check) {
@@ -920,7 +920,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 							return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile . ') created with GD library to parse GIF image');
 						}
 						imagedestroy($im);
-						unlink($tempfile);
+						$this->fileSystem->unlink($tempfile);
 					}
 					$info['type'] = 'gif';
 					if ($firsttime) {
@@ -1065,7 +1065,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 				$info = $this->getImage($tempfile, false);
 
 				imagedestroy($im);
-				unlink($tempfile);
+				$this->fileSystem->unlink($tempfile);
 
 				if (!$info) {
 					return $this->imageError($file, $firsttime, 'Error parsing temporary file (' . $tempfile . ') created with GD library to parse unknown image type');

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1431,7 +1431,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$this->useSubstitutions = $config['useSubstitutions'];
 		}
 
-		if (file_exists($this->defaultCssFile)) {
+		if ($this->fileSystem->file_exists($this->defaultCssFile)) {
 			$css = $this->fileSystem->file_get_contents($this->defaultCssFile);
 			$this->cssManager->ReadCSS('<style> ' . $css . ' </style>');
 		} else {

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -3278,7 +3278,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	function AddSpotColorsFromFile($file)
 	{
-		$colors = @file($file);
+		$colors = $this->fileSystem->SilentFile($file);
 		if (!$colors) {
 			throw new \Mpdf\MpdfException("Cannot load spot colors file - " . $file);
 		}
@@ -3837,7 +3837,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		$ttffile = $this->fontFileFinder->findFontFile($this->fontdata[$family][$stylekey]);
-		$ttfstat = stat($ttffile);
+		$ttfstat = $this->fileSystem->stat($ttffile);
 
 		$TTCfontID = isset($this->fontdata[$family]['TTCfontID'][$stylekey]) ? isset($this->fontdata[$family]['TTCfontID'][$stylekey]) : 0;
 		$fontUseOTL = isset($this->fontdata[$family]['useOTL']) ? $this->fontdata[$family]['useOTL'] : false;
@@ -11332,7 +11332,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			$path = $path . "/" . $filepath; // Make it an absolute path
 
-		} elseif ((strpos($path, ":/") === false || strpos($path, ":/") > 10) && !is_file($path)) { // It is a local link
+		} elseif ((strpos($path, ":/") === false || strpos($path, ":/") > 10) && !$this->fileSystem->is_file($path)) { // It is a local link
 
 			if (substr($path, 0, 1) == "/") {
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1017,7 +1017,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$mgh,
 			$mgf,
 			$orientation,
-            $serviceFactoryInstance,
+			$serviceFactoryInstance,
 		) = $this->initConstructorParams($config);
 
 		$this->logger = new NullLogger();
@@ -27069,9 +27069,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	}
 
 	public function getFileSystem()
-    {
-        return $this->fileSystem;
-    }
+	{
+		return $this->fileSystem;
+	}
 
 	/**
 	 * Temporarily return the method to preserve example 44 yearbook

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -28,6 +28,8 @@ class Otl
 
 	private $fontCache;
 
+	private $fileSystem;
+
 	var $arabLeftJoining;
 
 	var $arabRightJoining;
@@ -108,10 +110,11 @@ class Otl
 
 	var $debugOTL = false;
 
-	public function __construct(Mpdf $mpdf, FontCache $fontCache)
+	public function __construct(Mpdf $mpdf, FontCache $fontCache, FileSystem $fileSystem)
 	{
 		$this->mpdf = $mpdf;
 		$this->fontCache = $fontCache;
+		$this->fileSystem = $fileSystem;
 
 		$this->current_fh = '';
 
@@ -3017,7 +3020,7 @@ class Otl
 	{
 		// Load Line-breaking dictionary
 		if (!isset($this->lbdicts[$this->shaper]) && file_exists(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat')) {
-			$this->lbdicts[$this->shaper] = file_get_contents(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat');
+			$this->lbdicts[$this->shaper] = $this->fileSystem->file_get_contents(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat');
 		}
 
 		$dict = &$this->lbdicts[$this->shaper];

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -3019,7 +3019,7 @@ class Otl
 	private function seaLineBreaking()
 	{
 		// Load Line-breaking dictionary
-		if (!isset($this->lbdicts[$this->shaper]) && file_exists(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat')) {
+		if (!isset($this->lbdicts[$this->shaper]) && $this->fileSystem->file_exists(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat')) {
 			$this->lbdicts[$this->shaper] = $this->fileSystem->file_get_contents(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat');
 		}
 

--- a/src/OtlDump.php
+++ b/src/OtlDump.php
@@ -175,7 +175,7 @@ class OtlDump
 		$this->useOTL = $useOTL; // mPDF 5.7.1
 		$this->fontkey = $fontkey; // mPDF 5.7.1
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->mpdf->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file "%s"', $file));

--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -29,7 +29,7 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 	{
 		$this->logger->debug(sprintf('Fetching (cURL) content of remote URL "%s"', $url), ['context' => LogContext::REMOTE_CONTENT]);
 
-		$ch = curl_init($url);
+		$ch = $this->mpdf->getFileSystem()->curl_init($url);
 
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:13.0) Gecko/20100101 Firefox/13.0.1'); // mPDF 5.7.4
 		curl_setopt($ch, CURLOPT_HEADER, 0);
@@ -50,13 +50,13 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 			curl_setopt($ch, CURLOPT_CAINFO, $this->mpdf->curlCaCertificate);
 		}
 
-		$data = curl_exec($ch);
+		$data = $this->mpdf->getFileSystem()->curl_exec($ch);
 
-		if (curl_error($ch)) {
+		if ($this->mpdf->getFileSystem()->curl_error($ch)) {
 			$this->logger->error(sprintf('cURL error: "%s"', curl_error($ch)), ['context' => LogContext::REMOTE_CONTENT]);
 		}
 
-		curl_close($ch);
+        $this->mpdf->getFileSystem()->curl_close($ch);
 
 		return $data;
 	}

--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -56,7 +56,7 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 			$this->logger->error(sprintf('cURL error: "%s"', curl_error($ch)), ['context' => LogContext::REMOTE_CONTENT]);
 		}
 
-        $this->mpdf->getFileSystem()->curl_close($ch);
+		$this->mpdf->getFileSystem()->curl_close($ch);
 
 		return $data;
 	}

--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -46,7 +46,7 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		}
 
-		if (is_file($this->mpdf->curlCaCertificate)) {
+		if ($this->mpdf->getFileSystem()->is_file($this->mpdf->curlCaCertificate)) {
 			curl_setopt($ch, CURLOPT_CAINFO, $this->mpdf->curlCaCertificate);
 		}
 

--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -45,9 +45,9 @@ class ServiceFactory
 		$wmf
 	) {
 
-        $fileSystem = new FileSystem();
+		$fileSystem = new FileSystem();
 
-        $sizeConverter = new SizeConverter($mpdf->dpi, $mpdf->default_font_size, $mpdf, $logger);
+		$sizeConverter = new SizeConverter($mpdf->dpi, $mpdf->default_font_size, $mpdf, $logger);
 
 		$colorModeConverter = new ColorModeConverter();
 		$colorSpaceRestrictor = new ColorSpaceRestrictor(
@@ -94,7 +94,7 @@ class ServiceFactory
 			$scriptToLanguage,
 			$remoteContentFetcher,
 			$logger,
-            $fileSystem
+			$fileSystem
 		);
 
 		$tag = new Tag(
@@ -172,7 +172,7 @@ class ServiceFactory
 
 			'resourceWriter' => $resourceWriter,
 
-            'fileSystem' => $fileSystem
+			'fileSystem' => $fileSystem
 		];
 	}
 

--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -44,7 +44,10 @@ class ServiceFactory
 		$directWrite,
 		$wmf
 	) {
-		$sizeConverter = new SizeConverter($mpdf->dpi, $mpdf->default_font_size, $mpdf, $logger);
+
+        $fileSystem = new FileSystem();
+
+        $sizeConverter = new SizeConverter($mpdf->dpi, $mpdf->default_font_size, $mpdf, $logger);
 
 		$colorModeConverter = new ColorModeConverter();
 		$colorSpaceRestrictor = new ColorSpaceRestrictor(
@@ -56,14 +59,14 @@ class ServiceFactory
 
 		$tableOfContents = new TableOfContents($mpdf, $sizeConverter);
 
-		$cache = new Cache($config['tempDir']);
-		$fontCache = new FontCache(new Cache($config['tempDir'] . '/ttfontdata'));
+		$cache = new Cache($config['tempDir'], $fileSystem);
+		$fontCache = new FontCache(new Cache($config['tempDir'] . '/ttfontdata', $fileSystem), $fileSystem);
 
 		$fontFileFinder = new FontFileFinder($config['fontDir']);
 
-		$cssManager = new CssManager($mpdf, $cache, $sizeConverter, $colorConverter);
+		$cssManager = new CssManager($mpdf, $cache, $sizeConverter, $colorConverter, $fileSystem);
 
-		$otl = new Otl($mpdf, $fontCache);
+		$otl = new Otl($mpdf, $fontCache, $fileSystem);
 
 		$protection = new Protection(new UniqidGenerator());
 
@@ -90,7 +93,8 @@ class ServiceFactory
 			$languageToFont,
 			$scriptToLanguage,
 			$remoteContentFetcher,
-			$logger
+			$logger,
+            $fileSystem
 		);
 
 		$tag = new Tag(
@@ -106,8 +110,8 @@ class ServiceFactory
 			$languageToFont
 		);
 
-		$fontWriter = new FontWriter($mpdf, $writer, $fontCache, $fontDescriptor);
-		$metadataWriter = new MetadataWriter($mpdf, $writer, $form, $protection, $logger);
+		$fontWriter = new FontWriter($mpdf, $writer, $fontCache, $fontDescriptor, $fileSystem);
+		$metadataWriter = new MetadataWriter($mpdf, $writer, $form, $protection, $logger, $fileSystem);
 		$imageWriter = new ImageWriter($mpdf, $writer);
 		$pageWriter = new PageWriter($mpdf, $form, $writer, $metadataWriter);
 		$bookmarkWriter = new BookmarkWriter($mpdf, $writer);
@@ -166,7 +170,9 @@ class ServiceFactory
 			'backgroundWriter' => $backgroundWriter,
 			'javaScriptWriter' => $javaScriptWriter,
 
-			'resourceWriter' => $resourceWriter
+			'resourceWriter' => $resourceWriter,
+
+            'fileSystem' => $fileSystem
 		];
 	}
 

--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -62,7 +62,7 @@ class ServiceFactory
 		$cache = new Cache($config['tempDir'], $fileSystem);
 		$fontCache = new FontCache(new Cache($config['tempDir'] . '/ttfontdata', $fileSystem), $fileSystem);
 
-		$fontFileFinder = new FontFileFinder($config['fontDir']);
+		$fontFileFinder = new FontFileFinder($config['fontDir'], $fileSystem);
 
 		$cssManager = new CssManager($mpdf, $cache, $sizeConverter, $colorConverter, $fileSystem);
 

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -55,6 +55,8 @@ class TTFontFile
 
 	private $fontDescriptor;
 
+	protected $fileSystem;
+
 	var $GPOSFeatures;
 
 	var $GPOSLookups;
@@ -211,10 +213,11 @@ class TTFontFile
 
 	public $GSLuCoverage;
 
-	public function __construct(FontCache $fontCache, $fontDescriptor)
+	public function __construct(FontCache $fontCache, $fontDescriptor, FileSystem $fileSystem)
 	{
 		$this->fontCache = $fontCache;
 		$this->fontDescriptor = $fontDescriptor;
+		$this->fileSystem = $fileSystem;
 
 		// Maximum size of glyf table to read in as string (otherwise reads each glyph from file)
 		$this->maxStrLenRead = 200000;
@@ -225,7 +228,7 @@ class TTFontFile
 		$this->useOTL = $useOTL;
 		$this->fontkey = $fontkey;
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open font file "%s"', $file));
@@ -545,7 +548,7 @@ class TTFontFile
 		// Only called if font is not to be used as embedded subset i.e. NOT called for SIP/SMP fonts
 		$this->useOTL = $useOTL; // mPDF 5.7.1
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file "%s"', $file));
@@ -634,7 +637,7 @@ class TTFontFile
 	{
 		$this->filename = $file;
 
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file "%s"', $file));
 		}
@@ -3446,7 +3449,7 @@ class TTFontFile
 	{
 		$this->useOTL = $useOTL;
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file %s', $file));
@@ -3937,7 +3940,7 @@ class TTFontFile
 
 	function makeSubsetSIP($file, &$subset, $TTCfontID = 0, $debug = false, $useOTL = 0)
 	{
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file "%s"', $file));
@@ -4750,7 +4753,7 @@ class TTFontFile
 	{
 		$this->useOTL = $useOTL;
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException(sprintf('Unable to open file "%s"', $file));

--- a/src/TTFontFileAnalysis.php
+++ b/src/TTFontFileAnalysis.php
@@ -9,7 +9,7 @@ class TTFontFileAnalysis extends TTFontFile
 	function extractCoreInfo($file, $TTCfontID = 0)
 	{
 		$this->filename = $file;
-		$this->fh = fopen($file, 'rb');
+		$this->fh = $this->fileSystem->fopen($file, 'rb');
 		if (!$this->fh) {
 			throw new \Mpdf\MpdfException('ERROR - Can\'t open file ' . $file);
 		}

--- a/src/Writer/FontWriter.php
+++ b/src/Writer/FontWriter.php
@@ -29,9 +29,9 @@ class FontWriter
 	 */
 	private $fontCache;
 
-    /**
-     * @var \Mpdf\FileSystem
-     */
+	/**
+	 * @var \Mpdf\FileSystem
+	 */
 	private $fileSystem;
 
 	/**

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -2,6 +2,7 @@
 
 namespace Mpdf\Writer;
 
+use Mpdf\FileSystem;
 use Mpdf\Strict;
 
 use Mpdf\Form;
@@ -41,13 +42,19 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 	 */
 	private $logger;
 
-	public function __construct(Mpdf $mpdf, BaseWriter $writer, Form $form, Protection $protection, LoggerInterface $logger)
+	/**
+	 * @var \Mpdf\FileSystem
+	 */
+	private $fileSystem;
+
+	public function __construct(Mpdf $mpdf, BaseWriter $writer, Form $form, Protection $protection, LoggerInterface $logger, FileSystem $fileSystem)
 	{
 		$this->mpdf = $mpdf;
 		$this->writer = $writer;
 		$this->form = $form;
 		$this->protection = $protection;
 		$this->logger = $logger;
+		$this->fileSystem = $fileSystem;
 	}
 
 	public function writeMetadata() // _putmetadata
@@ -234,9 +241,9 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			if (!file_exists($this->mpdf->ICCProfile)) {
 				throw new \Mpdf\MpdfException(sprintf('Unable to find ICC profile "%s"', $this->mpdf->ICCProfile));
 			}
-			$s = file_get_contents($this->mpdf->ICCProfile);
+			$s = $this->fileSystem->file_get_contents($this->mpdf->ICCProfile);
 		} else {
-			$s = file_get_contents(__DIR__ . '/../../data/iccprofiles/sRGB_IEC61966-2-1.icc');
+			$s = $this->fileSystem->file_get_contents(__DIR__ . '/../../data/iccprofiles/sRGB_IEC61966-2-1.icc');
 		}
 
 		if ($this->mpdf->compress) {
@@ -289,7 +296,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 
 			$fileContent = null;
 			if (isset($file['path'])) {
-				$fileContent = @file_get_contents($file['path']);
+				$fileContent = $this->fileSystem->silentFile_get_contents($file['path']);
 			} elseif (isset($file['content'])) {
 				$fileContent = $file['content'];
 			}
@@ -699,7 +706,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 
 						if ($fileAttachment) {
 
-							$file = @file_get_contents($pl['opt']['file']);
+							$file = $this->fileSystem->silentFile_get_contents($pl['opt']['file']);
 							if (!$file) {
 								throw new \Mpdf\MpdfException('mPDF Error: Cannot access file attachment - ' . $pl['opt']['file']);
 							}

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -238,7 +238,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 		$this->writer->object();
 
 		if ($this->mpdf->ICCProfile) {
-			if (!file_exists($this->mpdf->ICCProfile)) {
+			if (!$this->fileSystem->file_exists($this->mpdf->ICCProfile)) {
 				throw new \Mpdf\MpdfException(sprintf('Unable to find ICC profile "%s"', $this->mpdf->ICCProfile));
 			}
 			$s = $this->fileSystem->file_get_contents($this->mpdf->ICCProfile);
@@ -811,12 +811,12 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 	{
 		$return = Mpdf::VERSION;
 		$headFile = __DIR__ . '/../../.git/HEAD';
-		if (file_exists($headFile)) {
+		if ($this->fileSystem->file_exists($headFile)) {
 			$ref = file($headFile);
 			$path = explode('/', $ref[0], 3);
 			$branch = isset($path[2]) ? trim($path[2]) : '';
 			$revFile = __DIR__ . '/../../.git/refs/heads/' . $branch;
-			if ($branch && file_exists($revFile)) {
+			if ($branch && $this->fileSystem->file_exists($revFile)) {
 				$rev = file($revFile);
 				$rev = substr($rev[0], 0, 7);
 				$return .= ' (' . $rev . ')';

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -314,7 +314,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			$this->writer->write('/Length '.strlen($filestream));
 			$this->writer->write('/Filter /FlateDecode');
 			if (isset($file['path'])) {
-				$this->writer->write('/Params <</ModDate '.$this->writer->string('D:' . PdfDate::format(filemtime($file['path']))).' >>');
+				$this->writer->write('/Params <</ModDate '.$this->writer->string('D:' . PdfDate::format($this->fileSystem->filemtime($file['path']))).' >>');
 			} else {
 				$this->writer->write('/Params <</ModDate '.$this->writer->string('D:' . PdfDate::format(time())).' >>');
 			}
@@ -812,12 +812,12 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 		$return = Mpdf::VERSION;
 		$headFile = __DIR__ . '/../../.git/HEAD';
 		if ($this->fileSystem->file_exists($headFile)) {
-			$ref = file($headFile);
+			$ref = $this->fileSystem->file($headFile);
 			$path = explode('/', $ref[0], 3);
 			$branch = isset($path[2]) ? trim($path[2]) : '';
 			$revFile = __DIR__ . '/../../.git/refs/heads/' . $branch;
 			if ($branch && $this->fileSystem->file_exists($revFile)) {
-				$rev = file($revFile);
+				$rev = $this->fileSystem->file($revFile);
 				$rev = substr($rev[0], 0, 7);
 				$return .= ' (' . $rev . ')';
 			}

--- a/tests/Mpdf/CacheTest.php
+++ b/tests/Mpdf/CacheTest.php
@@ -41,7 +41,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 		$dir = $this->path("tmp/test1");
 
 		try {
-			new Cache($dir);
+			new Cache($dir, new FileSystem());
 
 			$this->assertDirectoryExists($dir);
 
@@ -56,7 +56,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 		$dir = $this->path("tmp/test2");
 
 		try {
-			new Cache($dir);
+			new Cache($dir, new FileSystem());
 
 			$this->assertEquals(0777, fileperms($dir) & 0777);
 		} finally {
@@ -69,7 +69,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 		$dir = $this->path("tmp/test3/subdir/subdir2");
 
 		try {
-			new Cache($dir);
+			new Cache($dir, new FileSystem());
 
 			$this->assertDirectoryExists($dir);
 		} finally {
@@ -84,7 +84,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 		$dir = $this->path("tmp/test4/subdir/subdir2");
 
 		try {
-			new Cache($dir);
+			new Cache($dir, new FileSystem());
 
 			foreach (array(
 						 "tmp/test4/subdir/subdir2",

--- a/tests/Mpdf/Fonts/FontCacheTest.php
+++ b/tests/Mpdf/Fonts/FontCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Mpdf\Fonts;
 
+use Mpdf\FileSystem;
 use Mpdf\Mpdf;
 use Mpdf\Cache;
 
@@ -23,7 +24,7 @@ class FontCacheTest extends \PHPUnit_Framework_TestCase
 		parent::setUp();
 
 		$this->mpdf = new Mpdf();
-		$this->fontCache = new FontCache(new Cache($this->mpdf->tempDir . '/ttfontdata'));
+		$this->fontCache = new FontCache(new Cache($this->mpdf->tempDir . '/ttfontdata', new FileSystem()), new FileSystem());
 	}
 
 	public function testJson()

--- a/tests/Mpdf/Fonts/MetricsGeneratorTest.php
+++ b/tests/Mpdf/Fonts/MetricsGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Mpdf\Fonts;
 
 use Mockery;
+use Mpdf\FileSystem;
 
 class MetricsGeneratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,7 +23,7 @@ class MetricsGeneratorTest extends \PHPUnit_Framework_TestCase
 		parent::setUp();
 
 		$this->fontCache = Mockery::mock(FontCache::class);
-		$this->generator = new MetricsGenerator($this->fontCache, 'win');
+		$this->generator = new MetricsGenerator($this->fontCache, 'win', new FileSystem());
 	}
 
 	public function testGenerateMetrics()

--- a/tests/Mpdf/HyphenatorTest.php
+++ b/tests/Mpdf/HyphenatorTest.php
@@ -30,6 +30,7 @@ class HyphenatorTest extends \PHPUnit_Framework_TestCase
 		$mpdf->SHYrightmin = 2;
 		$mpdf->SHYcharmin = 2;
 		$mpdf->SHYcharmax = 10;
+        $mpdf->shouldReceive('getFileSystem')->andReturn(new FileSystem());
 
 		$this->hyphenator = new Hyphenator($mpdf);
 	}

--- a/tests/Mpdf/HyphenatorTest.php
+++ b/tests/Mpdf/HyphenatorTest.php
@@ -30,7 +30,7 @@ class HyphenatorTest extends \PHPUnit_Framework_TestCase
 		$mpdf->SHYrightmin = 2;
 		$mpdf->SHYcharmin = 2;
 		$mpdf->SHYcharmax = 10;
-        $mpdf->shouldReceive('getFileSystem')->andReturn(new FileSystem());
+		$mpdf->shouldReceive('getFileSystem')->andReturn(new FileSystem());
 
 		$this->hyphenator = new Hyphenator($mpdf);
 	}

--- a/tests/Mpdf/Image/ImageProcessorTest.php
+++ b/tests/Mpdf/Image/ImageProcessorTest.php
@@ -6,6 +6,7 @@ use Mockery;
 
 use Mpdf\Color\ColorModeConverter;
 use Mpdf\Cache;
+use Mpdf\FileSystem;
 use Mpdf\RemoteContentFetcher;
 use Psr\Log\NullLogger;
 use Mpdf\CssManager;
@@ -59,7 +60,8 @@ class ImageProcessorTest extends \PHPUnit_Framework_TestCase
 			$languageToFont,
 			$scriptToLanguage,
 			$remoteContentFetcher,
-			$logger
+			$logger,
+            new FileSystem()
 		);
 	}
 

--- a/tests/Mpdf/Image/ImageProcessorTest.php
+++ b/tests/Mpdf/Image/ImageProcessorTest.php
@@ -61,7 +61,7 @@ class ImageProcessorTest extends \PHPUnit_Framework_TestCase
 			$scriptToLanguage,
 			$remoteContentFetcher,
 			$logger,
-            new FileSystem()
+			new FileSystem()
 		);
 	}
 

--- a/utils/font_collections.php
+++ b/utils/font_collections.php
@@ -14,11 +14,11 @@ use Mpdf\Fonts\FontCache;
 require_once '../vendor/autoload.php';
 
 $mpdf = new Mpdf();
-$fontCache = new FontCache(new Cache($mpdf->fontTempDir));
+$fontCache = new FontCache(new Cache($mpdf->fontTempDir, $mpdf->getFileSystem()), $mpdf->getFileSystem());
 
 $ttfdir = $mpdf->fontDir;
 
-$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor());
+$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor(), $mpdf->getFileSystem());
 
 $ff = scandir($ttfdir);
 

--- a/utils/font_coverage.php
+++ b/utils/font_coverage.php
@@ -13,7 +13,7 @@ use Mpdf\Fonts\FontCache;
 require_once '../vendor/autoload.php';
 
 $mpdf = new Mpdf(['format' => 'A4-L']);
-$fontCache = new FontCache(new Cache($mpdf->fontTempDir));
+$fontCache = new FontCache(new Cache($mpdf->fontTempDir, $mpdf->getFileSystem()), $mpdf->getFileSystem());
 
 $mpdf->SetDisplayMode('fullpage');
 $mpdf->useSubstitutions = true;
@@ -60,7 +60,7 @@ $ff = scandir($ttfdir);
 $tempfontdata = array();
 
 foreach ($ff as $f) {
-	$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor());
+	$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor(), $mpdf->getFileSystem());
 	$ret = array();
 	$isTTC = false;
 

--- a/utils/font_dump.php
+++ b/utils/font_dump.php
@@ -24,7 +24,7 @@ $showmissing = false;    // Show all missing unicode blocks / characters
 require_once '../vendor/autoload.php';
 
 $mpdf = new Mpdf();
-$fontCache = new FontCache(new Cache($mpdf->tempDir . '/ttfontdata'));
+$fontCache = new FontCache(new Cache($mpdf->tempDir . '/ttfontdata', $mpdf->getFileSystem()), $mpdf->getFileSystem());
 
 $mpdf->SetDisplayMode('fullpage');
 

--- a/utils/font_dump_otl.php
+++ b/utils/font_dump_otl.php
@@ -170,7 +170,7 @@ $mpdf->overrideOTLsettings[$fontkey]['lang'] = $lang;
 
 // include $fontCache->tempFilename($fontkey.'.mtx.php');
 
-$fontFileFinder = new FontFileFinder($mpdf->fontDir);
+$fontFileFinder = new FontFileFinder($mpdf->fontDir, $mpdf->getFileSystem());
 $ttffile = $fontFileFinder->findFontFile($mpdf->fontdata[$family][$stylekey]);
 $ttfstat = stat($ttffile);
 

--- a/utils/font_names.php
+++ b/utils/font_names.php
@@ -15,13 +15,13 @@ $pdf = false;
 require_once '../vendor/autoload.php';
 
 $mpdf = new Mpdf(['mode' => 's']);
-$fontCache = new FontCache(new Cache($mpdf->fontTempDir));
+$fontCache = new FontCache(new Cache($mpdf->fontTempDir, $mpdf->getFileSystem()), $mpdf->getFileSystem());
 
 $mpdf->useSubstitutions = true;
 
 $ttfdir = $mpdf->fontDir;
 
-$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor());
+$ttf = new TTFontFileAnalysis($fontCache, $mpdf->getFontDescriptor(), $mpdf->getFileSystem());
 
 $tempfontdata = array();
 $tempsansfonts = array();


### PR DESCRIPTION
currently it's nearly impossible to restrict / sandbox mpdf.
especially if you accept third party html this could end up in security flaws.

Some Examples:
- https://github.com/mpdf/mpdf/issues/949
- Timeouts in Curl -> Images, CSSManager
- Loading local / remote Images

from security perspective it would be great if it would be possible to restrict mpdf's io.
this PR is the first step to this direction.

i created a new class for handling (hopefully) all io releated stuff. In Later PR's we could create an interface for this class and allow users so restrict/sandbox IO functionality. 