### PR TITLE
Fix missing SCRIPT_NAME

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -11260,7 +11260,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$host = '';
 		}
 		if (!$str) {
-			if ($_SERVER['SCRIPT_NAME']) {
+			if (isset($_SERVER['SCRIPT_NAME'])) {
 				$currentPath = dirname($_SERVER['SCRIPT_NAME']);
 			} else {
 				$currentPath = dirname($_SERVER['PHP_SELF']);


### PR DESCRIPTION
When executed from command line SCRIPT_NAME is missing