### PR TITLE
'Plus' not initialized on Mpdf.php

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -18433,6 +18433,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				case 'FONT-VARIANT-POSITION':
 					if (isset($this->OTLtags['Plus'])) {
 						$this->OTLtags['Plus'] = str_replace(['sups', 'subs'], '', $this->OTLtags['Plus']);
+					} else {
+						$this->OTLtags['Plus'] = '';
 					}
 					switch (strtoupper($v)) {
 						case 'SUPER':


### PR DESCRIPTION
On previous line 18439 I got a warning because it's not initialized. So I added 
else { $this->OTLtags['Plus'] = ''; }
to start 'Plus'.