### PR TITLE
Fix date and time format in the info dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ mPDF 8.1.x
 ===========================
 
 * Add proxy support to curl
+* Fixed date and time format in the informations dictionary (#1083, @peterdevpl)
 
 mPDF 8.0.x
 ===========================

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -177,10 +177,9 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			$this->writer->write('/' . $key . ' ' . $this->writer->utf16BigEndianTextString($value));
 		}
 
-		$z = date('O'); // +0200
-		$offset = substr($z, 0, 3) . "'" . substr($z, 3, 2) . "'";
-		$this->writer->write('/CreationDate ' . $this->writer->string(date('YmdHis') . $offset));
-		$this->writer->write('/ModDate ' . $this->writer->string(date('YmdHis') . $offset));
+		$now = PdfDate::format(time());
+		$this->writer->write('/CreationDate ' . $this->writer->string('D:' . $now));
+		$this->writer->write('/ModDate ' . $this->writer->string('D:' . $now));
 		if ($this->mpdf->PDFX) {
 			$this->writer->write('/Trapped/False');
 			$this->writer->write('/GTS_PDFXVersion(PDF/X-1a:2003)');

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -27,6 +27,8 @@ class MpdfTest extends \PHPUnit_Framework_TestCase
 		$output = $this->mpdf->Output(null, 'S');
 
 		$this->assertStringStartsWith('%PDF-', $output);
+		$dateRegex = '\(D:\d{14}[+|-|Z]\d{2}\'\d{2}\'\)';
+		$this->assertRegExp('/\d+ 0 obj\n<<\n\/Producer \((.*?)\)\n\/CreationDate ' . $dateRegex . '\n\/ModDate ' . $dateRegex . '/', $output);
 	}
 
 	/**


### PR DESCRIPTION
I decided to extend existing `MpdfTest` instead of creating a separate case.

Resolves mpdf#1083