### PR TITLE
Add page rotation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ mPDF 8.1.x
 ===========================
 
 * Add proxy support to curl
+* Add function to rotate pages including content (#1108, @AragurDEV)
 * Fixed date and time format in the informations dictionary (#1083, @peterdevpl)
 
 mPDF 8.0.x

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1153,7 +1153,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->fixedlSpacing = false;
 		$this->minwSpacing = 0;
 
-		$this->rotations;
+		$this->rotations = [];
 
 		// Baseline for text
 		$this->baselineC = 0.35;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -254,6 +254,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	var $spanborddet;
 
 	var $visibility;
+	var $rotations;
 
 	var $kerning;
 	var $fixedlSpacing;
@@ -1152,6 +1153,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->fixedlSpacing = false;
 		$this->minwSpacing = 0;
 
+		$this->rotations;
+
 		// Baseline for text
 		$this->baselineC = 0.35;
 
@@ -1939,6 +1942,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			throw new \Mpdf\MpdfException('Incorrect visibility: ' . $v);
 		}
 		$this->visibility = $v;
+	}
+
+	function RotatePage($r)
+	{
+		$this->rotations[$this->page] = $r;
 	}
 
 	function Open()

--- a/src/Writer/PageWriter.php
+++ b/src/Writer/PageWriter.php
@@ -144,10 +144,11 @@ final class PageWriter
 			$this->writer->object();
 			$this->writer->write('<</Type /Page');
 			$this->writer->write('/Parent 1 0 R');
-			if(array_key_exists($n, $this->mpdf->rotations))
+			if (array_key_exists($n, $this->mpdf->rotations)) {
 				$this->writer->write('/Rotate ' . $this->mpdf->rotations[$n]);
-			else 
+			} else {
 				$this->writer->write('/Rotate 0');
+			}
 
 			if (isset($this->mpdf->OrientationChanges[$n])) {
 

--- a/src/Writer/PageWriter.php
+++ b/src/Writer/PageWriter.php
@@ -144,6 +144,10 @@ final class PageWriter
 			$this->writer->object();
 			$this->writer->write('<</Type /Page');
 			$this->writer->write('/Parent 1 0 R');
+			if(array_key_exists($n, $this->mpdf->rotations))
+				$this->writer->write('/Rotate ' . $this->mpdf->rotations[$n]);
+			else 
+				$this->writer->write('/Rotate 0');
 
 			if (isset($this->mpdf->OrientationChanges[$n])) {
 


### PR DESCRIPTION
This PR adds a function `RotatePage(str::degree)` which allows a user to rotate specific pages.  
This has to be injecteted before `Output()` or `AddPage()` is called.

This also fixes #902