### PR TITLE
Add new barcode type C128RAW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 mPDF 8.1.x
 ===========================
 
+* Add C128RAW barcode type to create any barcode (ex: subtype change in middle of barcode) (#1124)
 * Add proxy support to curl
 * Fixed date and time format in the informations dictionary (#1083, @peterdevpl)
 * Checking allowed stream wrappers in CssManager

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -96,6 +96,9 @@ class Barcode
 			case 'C128C':  // CODE 128 C
 				return new Barcode\Code128($code, 'C');
 
+			case 'C128RAW':  // CODE 128 RAW -- code is a space separated list of codes with startcode but without checkdigit,stop,end ex: "105 12 34"
+				return new Barcode\Code128($code, 'RAW');
+
 			case 'EAN128A':  // EAN 128 A
 				return new Barcode\Code128($code, 'A', true);
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -26316,7 +26316,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$rlm = $arrcode['quietR'] / $k; // Right Quiet margin
 			$tlm = $blm = $arrcode['quietTB'] / $k;
 			$height = 1;  // Overrides
-		} elseif (in_array($btype, ['C128A', 'C128B', 'C128C', 'EAN128A', 'EAN128B', 'EAN128C', 'C39', 'C39+', 'C39E', 'C39E+', 'S25', 'S25+', 'I25', 'I25+', 'I25B', 'I25B+', 'C93', 'MSI', 'MSI+', 'CODABAR', 'CODE11'])) {
+		} elseif (in_array($btype, ['C128A', 'C128B', 'C128C', 'C128RAW', 'EAN128A', 'EAN128B', 'EAN128C', 'C39', 'C39+', 'C39E', 'C39E+', 'S25', 'S25+', 'I25', 'I25+', 'I25B', 'I25B+', 'C93', 'MSI', 'MSI+', 'CODABAR', 'CODE11'])) {
 			$llm = $arrcode['lightmL'] * $xres; // Left Quiet margin
 			$rlm = $arrcode['lightmR'] * $xres; // Right Quiet margin
 			$tlm = $blm = $arrcode['lightTB'] * $xres * $height;

--- a/src/Tag/BarCode.php
+++ b/src/Tag/BarCode.php
@@ -205,7 +205,7 @@ class BarCode extends Tag
 				$w = ($arrcode['maxw'] * $arrcode['nom-X'] * $objattr['bsize']) + $arrcode['quietL'] + $arrcode['quietR'];
 				$h = ($arrcode['nom-H'] * $objattr['bsize']) + (2 * $arrcode['quietTB']);
 
-			} elseif (in_array($objattr['btype'], ['C128A', 'C128B', 'C128C', 'EAN128A', 'EAN128B', 'EAN128C',
+			} elseif (in_array($objattr['btype'], ['C128A', 'C128B', 'C128C', 'C128RAW', 'EAN128A', 'EAN128B', 'EAN128C',
 				'C39', 'C39+', 'C39E', 'C39E+', 'S25', 'S25+', 'I25', 'I25+', 'I25B',
 				'I25B+', 'C93', 'MSI', 'MSI+', 'CODABAR', 'CODE11'])) {
 

--- a/tests/Mpdf/Barcode/Code128Test.php
+++ b/tests/Mpdf/Barcode/Code128Test.php
@@ -1,0 +1,45 @@
+<?php
+namespace Mpdf\Barcode;
+
+/**
+ * @group unit
+ */
+class Code128Test extends \PHPUnit_Framework_TestCase
+{
+
+	public function testInit()
+	{
+		$barcode = new Code128('103 33 99   12  ', 'RAW');
+		$array = $barcode->getData();
+		$this->assertInternalType('array', $array);
+		$this->assertArrayHasKey('bcode', $array);
+		$this->assertInternalType('array', $array['bcode']);
+	}
+
+	public function invalidCodeProvider()
+	{
+		return [
+			['RAW','103 33 99 106 11'],
+			['RAW','102 33 99 11'],
+			['RAW','10.2 33 99 11'],
+			['RAW','10,2 33 99 11'],
+			['RAW','a 33 99 11'],
+			['C','a12345'],
+			['C','a123456'],
+			['C','123456789'],
+			['C','123456a'],
+			['C','1234-6'],
+			['A','1234a6'],
+		];
+	}
+
+	/**
+	 * @dataProvider invalidCodeProvider
+	 * @expectedException \Mpdf\Barcode\BarcodeException
+	 */
+	public function testInvalidCode($SubType, $code)
+	{
+		new Code128($code, $SubType);
+	}
+
+}


### PR DESCRIPTION
Added new barcode type C128RAW.
Needed to generate advanced barcodes.
For example: compressed alfa-numeric barcodes with subtype change in middle of barcode
"A1234567890" is possible to code only in 128A or 128B
`<barcode code="A1234567890" type="C128A"/>`
with RAW type we can change the subtype after letter A
`<barcode code="103 33 99 12 34 56 78 90" type="C128RAW"/>`
103 - start 128A
33 - "A"
99 - change to 128C
12 - "12" ...
check digit and stop are added automaticaly by library
same result with ~30% shorter barcode
![example](https://user-images.githubusercontent.com/5702633/69232377-9f5d2080-0b93-11ea-9b2f-e70a502bc0f8.jpg)
more info https://en.wikipedia.org/wiki/Code_128
