### PR TITLE
Atomic cache writing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ mPDF 8.1.x
 * Add Page Number Myanmar Language Support
 * new `Mpdf\Exception\FontException` extending base `MpdfException` was introduced and is thrown on Font manipulation
 * A bit cleaner exception messages for font-related errors
+* Use atomicity cache writing. Create a temp file, write the content and finally rename the file to the destination.
 
 mPDF 8.0.x
 ===========================

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -70,9 +70,11 @@ class Cache
 
 	public function write($filename, $data)
 	{
-		$path = $this->getFilePath($filename);
+		$tempFile = tempnam($this->basePath, 'cache_tmp_');
+		file_put_contents($tempFile, $data);
 
-		file_put_contents($path, $data);
+		$path = $this->getFilePath($filename);
+		rename($tempFile, $path);
 
 		return $path;
 	}

--- a/src/Fonts/FontCache.php
+++ b/src/Fonts/FontCache.php
@@ -53,9 +53,7 @@ class FontCache
 
 	public function binaryWrite($filename, $data)
 	{
-		$handle = fopen($this->tempFilename($filename), 'wb');
-		fwrite($handle, $data);
-		fclose($handle);
+		return $this->cache->write($filename, $data);
 	}
 
 	public function jsonWrite($filename, $data)


### PR DESCRIPTION
Two parallel running processes writing the cache run into an error.

1. file_put_contents() is binary-safe and FontCache should use write() from Cache.php
2. file_put_contents() is not atomic. Therefore a different technique should be used. Write temp and then use rename().