### PR TITLE
Created Align Helper Method

### DIFF
--- a/src/Tag/BarCode.php
+++ b/src/Tag/BarCode.php
@@ -151,7 +151,7 @@ class BarCode extends Tag
 			}
 
 			if (isset($properties['VERTICAL-ALIGN'])) {
-				$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+				$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 			}
 			if (isset($properties['COLOR']) && $properties['COLOR'] != '') {
 				$objattr['color'] = $this->colorConverter->convert($properties['COLOR'], $this->mpdf->PDFAXwarnings);

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -126,7 +126,7 @@ abstract class BlockTag extends Tag
 			}
 			// Cannot set block properties inside table - use Bold to indicate h1-h6
 			if ($tag === 'CENTER' && $this->mpdf->tdbegin) {
-				$this->mpdf->cell[$this->mpdf->row][$this->mpdf->col]['a'] = self::ALIGN['center'];
+				$this->mpdf->cell[$this->mpdf->row][$this->mpdf->col]['a'] = $this->getAlign('center');
 			}
 
 			$this->mpdf->InlineProperties['BLOCKINTABLE'] = $this->mpdf->saveInlineProperties();
@@ -398,7 +398,7 @@ abstract class BlockTag extends Tag
 
 		// mPDF 6
 		if (!empty($attr['ALIGN'])) {
-			$currblk['block-align'] = self::ALIGN[strtolower($attr['ALIGN'])];
+			$currblk['block-align'] = $this->getAlign($attr['ALIGN']);
 		}
 
 

--- a/src/Tag/Columns.php
+++ b/src/Tag/Columns.php
@@ -47,7 +47,7 @@ class Columns extends Tag
 				if ($attr['VALIGN'] === 'J') {
 					$valign = 'J';
 				} else {
-					$valign = self::ALIGN[$attr['VALIGN']];
+					$valign = $this->getAlign($attr['VALIGN']);
 				}
 			} else {
 				$valign = '';

--- a/src/Tag/Hr.php
+++ b/src/Tag/Hr.php
@@ -54,9 +54,9 @@ class Hr extends Tag
 			$objattr['width'] = $this->sizeConverter->convert($attr['WIDTH'], $this->mpdf->blk[$this->mpdf->blklvl]['inner_width']);
 		}
 		if (isset($properties['TEXT-ALIGN'])) {
-			$objattr['align'] = self::ALIGN[strtolower($properties['TEXT-ALIGN'])];
+			$objattr['align'] = $this->getAlign($properties['TEXT-ALIGN']);
 		} elseif (isset($attr['ALIGN']) && $attr['ALIGN'] != '') {
-			$objattr['align'] = self::ALIGN[strtolower($attr['ALIGN'])];
+			$objattr['align'] = $this->getAlign($attr['ALIGN']);
 		}
 
 		if (isset($properties['MARGIN-LEFT']) && strtolower($properties['MARGIN-LEFT']) === 'auto') {

--- a/src/Tag/Img.php
+++ b/src/Tag/Img.php
@@ -128,7 +128,7 @@ class Img extends Tag
 			}
 
 			if (isset($properties['VERTICAL-ALIGN'])) {
-				$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+				$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 			}
 			$w = 0;
 			$h = 0;

--- a/src/Tag/Input.php
+++ b/src/Tag/Input.php
@@ -81,9 +81,9 @@ class Input extends Tag
 		$objattr['fontsize'] = $this->mpdf->FontSizePt;
 		if ($this->mpdf->useActiveForms) {
 			if (isset($attr['ALIGN'])) {
-				$objattr['text_align'] = self::ALIGN[strtolower($attr['ALIGN'])];
+				$objattr['text_align'] = $this->getAlign($attr['ALIGN']);
 			} elseif (isset($properties['TEXT-ALIGN'])) {
-				$objattr['text_align'] = self::ALIGN[strtolower($properties['TEXT-ALIGN'])];
+				$objattr['text_align'] = $this->getAlign($properties['TEXT-ALIGN']);
 			}
 			if (isset($properties['BORDER-TOP-COLOR'])) {
 				$objattr['border-col'] = $this->colorConverter->convert($properties['BORDER-TOP-COLOR'], $this->mpdf->PDFAXwarnings);
@@ -105,7 +105,7 @@ class Input extends Tag
 		}
 
 		if ($properties['VERTICAL-ALIGN']) {
-			$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+			$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 		}
 
 		switch (strtoupper($attr['TYPE'])) {
@@ -199,7 +199,7 @@ class Input extends Tag
 					$objattr['padding_right'] = 0;
 
 					if (isset($properties['VERTICAL-ALIGN'])) {
-						$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+						$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 					}
 
 					$w = 0;

--- a/src/Tag/Meter.php
+++ b/src/Tag/Meter.php
@@ -176,7 +176,7 @@ class Meter extends InlineTag
 		}
 
 		if (isset($properties['VERTICAL-ALIGN'])) {
-			$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+			$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 		}
 		$w = 0;
 		$h = 0;

--- a/src/Tag/Table.php
+++ b/src/Tag/Table.php
@@ -163,7 +163,7 @@ class Table extends Tag
 		}
 
 		if (isset($attr['ALIGN']) && array_key_exists(strtolower($attr['ALIGN']), self::ALIGN)) {
-			$table['a'] = self::ALIGN[strtolower($attr['ALIGN'])];
+			$table['a'] = $this->getAlign($attr['ALIGN']);
 		}
 		if (!$table['a']) {
 			if ($table['direction'] === 'rtl') {
@@ -190,10 +190,10 @@ class Table extends Tag
 		}
 
 		if (isset($properties['VERTICAL-ALIGN']) && array_key_exists(strtolower($properties['VERTICAL-ALIGN']), self::ALIGN)) {
-			$table['va'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+			$table['va'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 		}
 		if (isset($properties['TEXT-ALIGN']) && array_key_exists(strtolower($properties['TEXT-ALIGN']), self::ALIGN)) {
-			$table['txta'] = self::ALIGN[strtolower($properties['TEXT-ALIGN'])];
+			$table['txta'] = $this->getAlign($properties['TEXT-ALIGN']);
 		}
 
 		if (!empty($properties['AUTOSIZE']) && $this->mpdf->tableLevel == 1) {

--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -114,6 +114,12 @@ abstract class Tag
 		return strtoupper(str_replace('Mpdf\Tag\\', '', $tag));
 	}
 
+	protected function getAlign($property)
+	{
+		$property = strtolower($property);
+		return array_key_exists($property, self::ALIGN) ? self::ALIGN[$property] : '';
+	}
+
 	abstract public function open($attr, &$ahtml, &$ihtml);
 
 	abstract public function close(&$ahtml, &$ihtml);

--- a/src/Tag/Td.php
+++ b/src/Tag/Td.php
@@ -118,10 +118,10 @@ class Td extends Tag
 		// INHERITED THEAD CSS Properties
 		if ($this->mpdf->tablethead) {
 			if ($this->mpdf->thead_valign_default) {
-				$c['va'] = self::ALIGN[strtolower($this->mpdf->thead_valign_default)];
+				$c['va'] = $this->getAlign($this->mpdf->thead_valign_default);
 			}
 			if ($this->mpdf->thead_textalign_default) {
-				$c['a'] = self::ALIGN[strtolower($this->mpdf->thead_textalign_default)];
+				$c['a'] = $this->getAlign($this->mpdf->thead_textalign_default);
 			}
 			if ($this->mpdf->thead_font_weight === 'B') {
 				$this->mpdf->SetStyle('B', true);
@@ -137,10 +137,10 @@ class Td extends Tag
 		// INHERITED TFOOT CSS Properties
 		if ($this->mpdf->tabletfoot) {
 			if ($this->mpdf->tfoot_valign_default) {
-				$c['va'] = self::ALIGN[strtolower($this->mpdf->tfoot_valign_default)];
+				$c['va'] = $this->getAlign($this->mpdf->tfoot_valign_default);
 			}
 			if ($this->mpdf->tfoot_textalign_default) {
-				$c['a'] = self::ALIGN[strtolower($this->mpdf->tfoot_textalign_default)];
+				$c['a'] = $this->getAlign($this->mpdf->tfoot_textalign_default);
 			}
 			if ($this->mpdf->tfoot_font_weight === 'B') {
 				$this->mpdf->SetStyle('B', true);
@@ -199,9 +199,9 @@ class Td extends Tag
 		}
 		/* -- END BACKGROUNDS -- */
 		if (isset($properties['VERTICAL-ALIGN'])) {
-			$c['va'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+			$c['va'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 		} elseif (isset($attr['VALIGN'])) {
-			$c['va'] = self::ALIGN[strtolower($attr['VALIGN'])];
+			$c['va'] = $this->getAlign($attr['VALIGN']);
 		}
 
 
@@ -209,7 +209,7 @@ class Td extends Tag
 			if (0 === strpos($properties['TEXT-ALIGN'], 'D')) {
 				$c['a'] = $properties['TEXT-ALIGN'];
 			} else {
-				$c['a'] = self::ALIGN[strtolower($properties['TEXT-ALIGN'])];
+				$c['a'] = $this->getAlign($properties['TEXT-ALIGN']);
 			}
 		}
 		if (!empty($attr['ALIGN'])) {
@@ -225,7 +225,7 @@ class Td extends Tag
 					$c['a'] = 'DPR';
 				}
 			} else {
-				$c['a'] = self::ALIGN[strtolower($attr['ALIGN'])];
+				$c['a'] = $this->getAlign($attr['ALIGN']);
 			}
 		}
 

--- a/src/Tag/TextArea.php
+++ b/src/Tag/TextArea.php
@@ -75,9 +75,9 @@ class TextArea extends Tag
 		$objattr['fontsize'] = $this->mpdf->FontSizePt;
 		if ($this->mpdf->useActiveForms) {
 			if (isset($properties['TEXT-ALIGN'])) {
-				$objattr['text_align'] = self::ALIGN[strtolower($properties['TEXT-ALIGN'])];
+				$objattr['text_align'] = $this->getAlign($properties['TEXT-ALIGN']);
 			} elseif (isset($attr['ALIGN'])) {
-				$objattr['text_align'] = self::ALIGN[strtolower($attr['ALIGN'])];
+				$objattr['text_align'] = $this->getAlign($attr['ALIGN']);
 			}
 			if (isset($properties['OVERFLOW']) && strtolower($properties['OVERFLOW']) === 'hidden') {
 				$objattr['donotscroll'] = true;
@@ -110,7 +110,7 @@ class TextArea extends Tag
 			);
 		}
 		if (isset($properties['VERTICAL-ALIGN'])) {
-			$objattr['vertical-align'] = self::ALIGN[strtolower($properties['VERTICAL-ALIGN'])];
+			$objattr['vertical-align'] = $this->getAlign($properties['VERTICAL-ALIGN']);
 		}
 
 		$colsize = 20; //HTML default value

--- a/tests/Issues/Issue1194Test.php
+++ b/tests/Issues/Issue1194Test.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Issues;
+
+class Issue1194Test extends \PHPUnit_Framework_TestCase
+{
+
+	public function testArrayAccessOnNull()
+	{
+		$mpdf = new \Mpdf\Mpdf();
+
+		$mpdf->WriteHTML('<table><tbody><tr><td style="text-align: inherit">foo</td></tr></tbody></table>');
+	}
+
+}

--- a/tests/Issues/Issue1194Test.php
+++ b/tests/Issues/Issue1194Test.php
@@ -5,7 +5,7 @@ namespace Issues;
 class Issue1194Test extends \PHPUnit_Framework_TestCase
 {
 
-	public function testArrayAccessOnNull()
+	public function testHandelUnknownTextAlign()
 	{
 		$mpdf = new \Mpdf\Mpdf();
 


### PR DESCRIPTION
Instead of accessing the value via `self::ALIGN[strtolower('foo')` `$this->getAlign('foo')` 
Replacing 26 occurrences  and also preventing an exception being thrown for align values we don't know (initial, inherit, start, end)

Related #847 &  #1060 

Currently  \Mpdf\Tag\Tag only supports the values defined in the const which is incomplete
```
	const ALIGN = [
		'left' => 'L',
		'center' => 'C',
		'right' => 'R',
		'top' => 'T',
		'text-top' => 'TT',
		'middle' => 'M',
		'baseline' => 'BS',
		'bottom' => 'B',
		'text-bottom' => 'TB',
		'justify' => 'J'
	];
```
From: 
https://developer.mozilla.org/en-US/docs/Web/CSS/text-align
Here are possible values for text-align
```
/* Keyword values */
text-align: left;
text-align: right;
text-align: center;
text-align: justify;
text-align: justify-all;
text-align: start;
text-align: end;
text-align: match-parent;

/* Character-based alignment in a table column */
text-align: ".";
text-align: "." center;

/* Block alignment values (Non-standard syntax) */
text-align: -moz-center;
text-align: -webkit-center;

/* Global values */
text-align: inherit;
text-align: initial;
text-align: unset;
```

So this helper prevents the notice from being thrown when `self::ALIGN[$foo]` is not set