### PR TITLE
Fix: Uninitialized string offset: 0

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -17944,7 +17944,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		// Set font size first so that e.g. MARGIN 0.83em works on font size for this element
 		if (isset($arrayaux['FONT-SIZE'])) {
 			$v = $arrayaux['FONT-SIZE'];
-			if (is_numeric($v[0]) || ($v[0] === '.')) {
+			$firstLetter = substr($v, 0, 1);
+			if (is_numeric($firstLetter) || ($firstLetter === '.')) {
 				if ($type == 'BLOCK' && $this->blklvl > 0 && isset($this->blk[$this->blklvl - 1]['InlineProperties']) && isset($this->blk[$this->blklvl - 1]['InlineProperties']['size'])) {
 					$mmsize = $this->sizeConverter->convert($v, $this->blk[$this->blklvl - 1]['InlineProperties']['size']);
 				} elseif ($type == 'TABLECELL') {

--- a/tests/Issues/Issue1197Test.php
+++ b/tests/Issues/Issue1197Test.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Issues;
+
+class Issue1197Test extends \PHPUnit_Framework_TestCase
+{
+
+	public function testDontThrowUninitializedStringOffsetException()
+	{
+		$mpdf = new \Mpdf\Mpdf();
+
+		$mpdf->setCSS(['FONT-SIZE' => ''], 'INLINE');
+	}
+}


### PR DESCRIPTION
ErrorException Uninitialized string offset: 0
/var/www/project/vendor/mpdf/mpdf/src/Mpdf.php:17947 ***
/var/www/project/vendor/mpdf/mpdf/src/Mpdf.php:17947 Mpdf\Mpdf::setCSS
/var/www/project/vendor/mpdf/mpdf/src/Tag/A.php:36 Mpdf\Tag\A::open
/var/www/project/vendor/mpdf/mpdf/src/Tag.php:243 Mpdf\Tag::OpenTag
/var/www/project/vendor/mpdf/mpdf/src/Mpdf.php:13628 Mpdf\Mpdf::WriteHTML

It used to work silently in the background and change the variable to an array but as of PHP 7.1 it will fail completely.