### PR TITLE
Fix non http URI schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ mPDF 8.0.x
 * Fixed skipping ordered list numbering with page-break-inside: avoid (#339)
 * Compound classes selector support, like `.one.two` or `div.message.special` (#538, @peterdevpl)
 * Fixed CMYK colors in text-shadow (#1115, @lexilya)
+* Skip non supported wrappers when resolving paths (#1204, @MarkVaughn)
 
 mPDF 8.0.0
 ===========================

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -11425,7 +11425,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			return;
 		}
 
-		if (preg_match('@^(mailto|tel|fax):.*@i', $path)) {
+		// Skip schemes not supported by installed stream wrappers
+		$wrappers = stream_get_wrappers();
+		$pattern = sprintf('@^(?!%s)[a-z0-9\.\-+]+:.*@i', implode('|', $wrappers));
+		if (preg_match($pattern, $path)) {
 			return;
 		}
 

--- a/tests/Issues/Issue1204Test.php
+++ b/tests/Issues/Issue1204Test.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Issues;
+
+class Issue1204Test extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * Addresses Issue:
+	 *
+	 * is_file(): Unable to find the wrapper "chrome-extension" - did you forget to enable it when you configured PHP?
+	 *
+	 * @throws \Mpdf\MpdfException
+	 */
+	public function testIgnoresNonHttpURIs()
+	{
+		$mpdf = new \Mpdf\Mpdf();
+
+		$mpdf->WriteHTML('<a href="chrome-extension://fooobarextension"></a>');
+		$mpdf->WriteHTML('<img src="chrome-extension://fooobarextension">');
+	}
+
+}


### PR DESCRIPTION
Addresses Exception:
```
ErrorException is_file(): Unable to find the wrapper "chrome-extension" - did you forget to enable it when you configured PHP? 
    /var/www/foo/vendor/mpdf/mpdf/src/Mpdf.php:11353 Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
    [internal] is_file
    /var/www/foo/vendor/mpdf/mpdf/src/Mpdf.php:11353 Mpdf\Mpdf::GetFullPath
    /var/www/foo/vendor/mpdf/mpdf/src/Mpdf.php:13591 Mpdf\Mpdf::WriteHTML
```

There are plenty of URI schemes other than fax, tel & mailto to ignore
https://en.wikipedia.org/wiki/List_of_URI_schemes & https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

I created a pattern that ignores all  non-HTTP schemes, [here it is in action ](https://regex101.com/r/4RqJMZ/1 )