### PR TITLE
Fix for issue 941: "Undefined index: group" when calling MultiCell when using font without OTL data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ mPDF 8.1.x
 * Add Page Number Myanmar Language Support
 * new `Mpdf\Exception\FontException` extending base `MpdfException` was introduced and is thrown on Font manipulation
 * A bit cleaner exception messages for font-related errors
+* Fix: "Undefined index: group" when calling MultiCell when using font without OTL data
 
 mPDF 8.0.x
 ===========================

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -5806,7 +5806,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->biDirectional = true;
 			} // *OTL*
 			/* -- OTL -- */
-			$OTLdata = [];
+			if (!is_array($OTLdata)) {
+				unset($OTLdata);
+			}
+
 			// Use OTL OpenType Table Layout - GSUB & GPOS
 			if (isset($this->CurrentFont['useOTL']) && $this->CurrentFont['useOTL']) {
 				$txt = $this->otl->applyOTL($txt, $this->CurrentFont['useOTL']);

--- a/tests/Issues/Issue941Test.php
+++ b/tests/Issues/Issue941Test.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Issues;
+
+class Issue941Test extends \PHPUnit_Framework_TestCase
+{
+
+	public function testMultiCellDoesNotFailOtl()
+	{
+		$mpdf = new \Mpdf\Mpdf();
+		$mpdf->AddPage();
+		$mpdf->MultiCell(100, 20, 'This is a text string, just for testing');
+
+		$output = $mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+}


### PR DESCRIPTION
Closes mpdf#941