### PR TITLE
Fixed Undefined index: current in BlockTag.php:316

### DIFF
--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -313,7 +313,7 @@ abstract class BlockTag extends Tag
 					);
 				} elseif (strtoupper($p['PAGE-BREAK-BEFORE']) === 'ALWAYS') {
 					$this->mpdf->AddPage($this->mpdf->CurOrientation, '', '', '', '', '', '', '', '', '', '', '', '', '', '', 0, 0, 0, 0, $pagesel);
-				} elseif ($this->mpdf->page_box['current'] != $pagesel) {
+				} elseif (isset($this->mpdf->page_box['current']) && $this->mpdf->page_box['current'] != $pagesel) {
 					$this->mpdf->AddPage($this->mpdf->CurOrientation, '', '', '', '', '', '', '', '', '', '', '', '', '', '', 0, 0, 0, 0, $pagesel);
 				} // *CSS-PAGE*
 			} /* -- CSS-PAGE -- */


### PR DESCRIPTION
Fixing the issue which makes the library unusable as dependency for kartik-v/yii2-mpdf on PHP 7.4.x