### PR TITLE
Fix typo in OtlDump.php

### DIFF
--- a/src/OtlDump.php
+++ b/src/OtlDump.php
@@ -543,7 +543,7 @@ class OtlDump
 				$c = $psName[$i];
 				$oc = ord($c);
 				if ($oc > 126 || strpos(' [](){}<>/%', $c) !== false) {
-					throw new \Mpdf\Exception\FontException("psName=" . $psName . " contains invalid character " . $c . " ie U+" . ord(c));
+					throw new \Mpdf\Exception\FontException("psName=" . $psName . " contains invalid character " . $c . " ie U+" . ord($c));
 				}
 			}
 		}


### PR DESCRIPTION
On line 546, a variable $c was missing a $. This results in a undefined constant.