### PR TITLE
Allows `{nb}`, `{nbpg}` and `{PAGENO}` substitution in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ mPDF 8.0.x
 * Fixed CMYK colors in text-shadow (#1115, @lexilya)
 * Skip non supported wrappers when resolving paths (#1204, @MarkVaughn)
 * Fixed SVGs using a style tag, has styles ignored ( Requires ext-dom ) (#450, @antman3351)
+* Allows `{nb}`, `{nbpg}`, `{PAGENO}` and `{DATE ...}` substitution in body (#172 and #267, @Dasc3er)
 
 mPDF 8.0.0
 ===========================

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -9655,10 +9655,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 				$this->x = $this->lMargin;
 				$this->y = $this->margin_header;
-				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace($this->aliasNbPgGp, $pntstr, $html); // {nbpg}
-				$html = str_replace($this->aliasNbPg, $nb, $html); // {nb}
-				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
+
+				// Replace of page number aliases and date format
+				$html = $this->aliasReplace($html, $pnstr, $pntstr, $nb);
 
 				$this->HTMLheaderPageLinks = [];
 				$this->HTMLheaderPageAnnots = [];
@@ -9736,11 +9735,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$top_y = $this->y = ($this->h + 0.01);
 				}
 
-				$html = str_replace('{PAGENO}', $pnstr, $html);
-				$html = str_replace($this->aliasNbPgGp, $pntstr, $html); // {nbpg}
-				$html = str_replace($this->aliasNbPg, $nb, $html); // {nb}
-				$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
-
+				// Replace of page number aliases and date format
+				$html = $this->aliasReplace($html, $pnstr, $pntstr, $nb);
 
 				$this->HTMLheaderPageLinks = [];
 				$this->HTMLheaderPageAnnots = [];
@@ -9814,6 +9810,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 				/* -- END FORMS -- */
 			}
+
+			// Customization for https://github.com/mpdf/mpdf/issues/172
+			// Replace of page number aliases and date format
+			$this->pages[$n] = $this->aliasReplace($this->pages[$n], $pnstr, $pntstr, $nb);
 		}
 
 		$this->page = $nb;
@@ -12353,10 +12353,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$save_y = $this->y;
 		$this->x = $this->lMargin;
 		$this->y = $this->margin_header;
-		$html = str_replace('{PAGENO}', $this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix, $html);
-		$html = str_replace($this->aliasNbPgGp, $this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix, $html);
-		$html = str_replace($this->aliasNbPg, $this->page, $html);
-		$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
+
+		// Replace of page number aliases and date format
+		$pnstr = $this->pagenumPrefix . $this->docPageNum($this->page) . $this->pagenumSuffix;
+		$pntstr = $this->nbpgPrefix . $this->docPageNumTotal($this->page) . $this->nbpgSuffix;
+		$nb = $this->page;
+		$html = $this->aliasReplace($html, $pnstr, $pntstr, $nb);
+
 		$this->HTMLheaderPageLinks = [];
 		$this->HTMLheaderPageAnnots = [];
 		$this->HTMLheaderPageForms = [];
@@ -27327,6 +27330,31 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	public function _out($s)
 	{
 		$this->writer->write($s);
+	}
+
+	/**
+	 * @param string $html
+	 * @param string $PAGENO
+	 * @param string $NbPgGp
+	 * @param string $NbPg
+	 * @return string
+	 */
+	protected function aliasReplace($html, $PAGENO, $NbPgGp, $NbPg)
+	{
+		// Replaces for header and footer
+		$html = str_replace('{PAGENO}', $PAGENO, $html);
+		$html = str_replace($this->aliasNbPgGp, $NbPgGp, $html); // {nbpg}
+		$html = str_replace($this->aliasNbPg, $NbPg, $html); // {nb}
+
+		// Replaces for the body
+		$html = str_replace(mb_convert_encoding('{PAGENO}', 'UTF-16BE', 'UTF-8'), mb_convert_encoding($PAGENO, 'UTF-16BE', 'UTF-8'), $html);
+		$html = str_replace(mb_convert_encoding($this->aliasNbPgGp, 'UTF-16BE', 'UTF-8'), mb_convert_encoding($NbPgGp, 'UTF-16BE', 'UTF-8'), $html); // {nbpg}
+		$html = str_replace(mb_convert_encoding($this->aliasNbPg, 'UTF-16BE', 'UTF-8'), mb_convert_encoding($NbPg, 'UTF-16BE', 'UTF-8'), $html); // {nb}
+
+		// Date replace
+		$html = preg_replace_callback('/\{DATE\s+(.*?)\}/', [$this, 'date_callback'], $html); // mPDF 5.7
+
+		return $html;
 	}
 
 }

--- a/tests/Mpdf/SubstitutionTest.php
+++ b/tests/Mpdf/SubstitutionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Mpdf;
+
+use Mpdf\Pdf\Protection;
+use Mpdf\Pdf\Protection\UniqidGenerator;
+use Mpdf\Writer\BaseWriter;
+
+class SubstitutionTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var \Mpdf\Mpdf
+	 */
+	private $mpdf;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->mpdf = new Mpdf();
+	}
+
+	public function testSubstitutionOutput()
+	{
+		$date_format = 'j-m-Y';
+		$text = 'Page {PAGENO} / {nbpg}';
+
+		$pages = 4;
+		$contents = array_fill(0, $pages, $text);
+
+		$this->mpdf->SetCompression(false);
+		$this->mpdf->SetHTMLHeader('Header: '.$text.' [{DATE '.$date_format.'}]');
+		$this->mpdf->SetHTMLFooter('Footer: '.$text.' [{DATE '.$date_format.'}]');
+		$this->mpdf->WriteHTML('<html><body>
+'.implode('<pagebreak>', $contents).'
+</body></html>');
+		$this->mpdf->Close();
+
+		$date = date($date_format);
+		for ($i = 1; $i <= $pages; $i++) {
+			// Removal of newline elements
+			$page = str_replace("\n", "", $this->mpdf->pages[$i]);
+
+			// Conversion in UTF-16BE
+			$page_string = str_replace(['{PAGENO}', '{nbpg}'], [$i, $pages, $date], $text);
+			$page_string = mb_convert_encoding($page_string, 'UTF-16BE', 'UTF-8');
+
+			$date_string = '['.$date.']';
+			$date_string = mb_convert_encoding($date_string, 'UTF-16BE', 'UTF-8');
+
+			// Counting
+			$number_page_string = substr_count($page, $page_string);
+			$number_date_string = substr_count($page, $date_string);
+
+			// Test
+			$this->assertEquals(3, $number_page_string);
+			$this->assertEquals(2, $number_date_string);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the method `Mpdf::aliasReplace($html, $PAGENO, $NbPgGp, $NbPg)` with a simple refactoring for the substitution of `{nb}`, `{nbpg}`, `{PAGENO}` and `{DATE ...}` aliases in the header and footer.
As requested in #172 and #267, the method is applied on all the pages (as suggested by @jochenwezel) thus allowing the use of these aliases in the body of the PDF.