### PR TITLE
Ensure index/level exists before check contents

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2874,7 +2874,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 				$this->tag->OpenTag($save_blk[$b]['tag'], $save_blk[$b]['attr'], $arr, $i);
 			}
-			if ($this->blk[$this->blklvl]['box_decoration_break'] != 'clone') {
+			if (isset($this->blk[$this->blklvl]['box_decoration_break'])
+			&& ($this->blk[$this->blklvl]['box_decoration_break'] != 'clone')) {
 				$this->lastblocklevelchange = -1;
 			}
 		} else {


### PR DESCRIPTION
Solves _**Undefined index level**_ errors in a similar way related in https://github.com/ramazantufekci/mpdf/commit/e3de11ac6097cfed032c54ca8532d30a4c6f1f61 and https://github.com/mpdf/mpdf/issues/1285 https://github.com/mpdf/mpdf/issues/1245 https://github.com/mpdf/mpdf/issues/588