### PR TITLE
Allow paragonie/random_compat higher than 9.99.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
 		"psr/log": "^1.0",
 		"setasign/fpdi": "^2.1",
-		"paragonie/random_compat": "~1.4|~2.0|~9.99",
+		"paragonie/random_compat": "^1.4|^2.0|^9.99.99",
 		"myclabs/deep-copy": "^1.7"
 
 	},

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
 		"psr/log": "^1.0",
 		"setasign/fpdi": "^2.1",
-		"paragonie/random_compat": "^1.4|^2.0|9.99.99",
+		"paragonie/random_compat": "~1.4|~2.0|~9.99",
 		"myclabs/deep-copy": "^1.7"
 
 	},


### PR DESCRIPTION
See https://github.com/paragonie/random_compat/compare/v9.99.99...v9.99.100
The `9.99.100` release allow to install on PHP 7 or PHP 8.

Changes in `composer.json` was based on:
```
composer depends paragonie/random_compat
mpdf/mpdf         v8.0.7   requires  paragonie/random_compat (^1.4|^2.0|9.99.99)
symfony/polyfill  v1.18.1  requires  paragonie/random_compat (~1.0|~2.0|~9.99)
```

So `mpdf/mpdf` blocks to update to the latest version.

I think this PR should allow now to it.