### PR TITLE
Suppress warning on unlink cache file

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -98,7 +98,7 @@ class Cache
 					&& $item->isFile()
 					&& !$this->isDotFile($item)
 					&& $this->isOld($item)) {
-				unlink($item->getPathname());
+				@unlink($item->getPathname());
 			}
 		}
 	}


### PR DESCRIPTION
Since iterator iterates over all of the files in the directory, I believe there is a race condition when deleting cache file and warning is triggered.
This suppresses the warning