### PR TITLE
Added curlExecutionTimeout configuration variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ mPDF 8.0.x
 * It is possible to disable automatic cache cleanup with `cacheCleanupInterval` config variable
 * PHP 8.0 is supported since 8.0.10 (#1263)
 * Fix: First header of named page is added twice (@antman3351, #1320)
+* Added `curlExecutionTimeout` configuration variable allowing to `CURLOPT_TIMEOUT` when fetching remote content
 
 mPDF 8.0.0
 ===========================

--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -512,6 +512,7 @@ class ConfigVariables
 			'curlAllowUnsafeSslRequests' => false,
 			'curlCaCertificate' => '',
 			'curlTimeout' => 5,
+			'curlExecutionTimeout' => null,
 			'curlProxy' => null,
 			'curlProxyAuth' => null,
 			'curlUserAgent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:13.0) Gecko/20100101 Firefox/13.0.1',

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -669,6 +669,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	var $curlTimeout;
 
 	/**
+	 * Set execution timeout for cURL
+	 *
+	 * @var int
+	 */
+	var $curlExecutionTimeout;
+
+	/**
 	 * Set to true to follow redirects with cURL.
 	 *
 	 * @var bool

--- a/src/RemoteContentFetcher.php
+++ b/src/RemoteContentFetcher.php
@@ -37,6 +37,10 @@ class RemoteContentFetcher implements \Psr\Log\LoggerAwareInterface
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->mpdf->curlTimeout);
 
+		if ($this->mpdf->curlExecutionTimeout) {
+			curl_setopt($ch, CURLOPT_TIMEOUT, $this->mpdf->curlExecutionTimeout);
+		}
+
 		if ($this->mpdf->curlFollowLocation) {
 			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 		}


### PR DESCRIPTION
As discussed in #1376, this PR adds an undocumented configuration variable `curlExecutionTimeout` that allows a user to set the `CURLOPT_TIMEOUT` option when fetching remote content. Variable name was chosen as to be backwards compatible.