### PR TITLE
Fix svg image href check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mPDF 8.0.x
 * PHP 8.0 is supported since 8.0.10 (#1263)
 * Fix: First header of named page is added twice (@antman3351, #1320)
 * Added `curlExecutionTimeout` configuration variable allowing to `CURLOPT_TIMEOUT` when fetching remote content
+* Fixed SVG image href check if it's not a variable (#1382)
 
 mPDF 8.0.0
 ===========================

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -276,9 +276,9 @@ class Svg
 
 		$srcpath = $attribs['xlink:href'];
 		$orig_srcpath = '';
-		if (trim($srcpath) != '' && substr($srcpath, 0, 4) == 'var:') {
+		if (trim($srcpath) != '' && substr($srcpath, 0, 4) != 'var:') {
 			$orig_srcpath = $srcpath;
-			$srcpath = $this->mpdf->GetFullPath($srcpath);
+			$this->mpdf->GetFullPath($srcpath);
 		}
 
 		// Image file (does not allow vector images i.e. WMF/SVG)

--- a/tests/Issues/Issue1382Test.php
+++ b/tests/Issues/Issue1382Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Issues;
+
+class Issue1382Test extends \Mpdf\BaseMpdfTest
+{
+
+	public function testSVGGetImageFunction()
+	{
+
+		$html = '<svg width="292px" height="83px" style="margin: 0 auto; display: block;" viewBox="0 0 292 83">
+			<image xlink:href="var:my_image" width="292px" height="83px" />
+		</svg>';
+
+		$this->mpdf->setCompression(false);
+		$this->mpdf->showImageErrors = true;
+		$this->mpdf->imageVars['my_image'] = file_get_contents(__DIR__ . '/../data/img/bayeux2.jpg');
+		$this->mpdf->WriteHTML($html);
+
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+}


### PR DESCRIPTION
Closes #1382

Fixed the check for `var` in `xlink:href`'s path and removed the assignment to `GetFullPath` result (it doesn't return, so it was always null).