### PR TITLE
Added `fileContentLoader` configuration variable allowing to override default file_get_contents (Closes #672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mPDF 8.0.x
 * PHP 8.0 is supported since 8.0.10 (#1263)
 * Fix: First header of named page is added twice (@antman3351, #1320)
 * Added `curlExecutionTimeout` configuration variable allowing to `CURLOPT_TIMEOUT` when fetching remote content
+* Added `fileContentLoader` configuration variable allowing to override default file_get_contents
 
 mPDF 8.0.0
 ===========================

--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -517,6 +517,9 @@ class ConfigVariables
 			'curlProxyAuth' => null,
 			'curlUserAgent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:13.0) Gecko/20100101 Firefox/13.0.1',
 
+			'fileContentLoader' => function ($path) {
+				return @file_get_contents($path);
+			},
 			'exposeVersion' => true,
 		];
 	}

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2286,7 +2286,7 @@ class CssManager
 			$path = preg_replace('/\.css\?.*$/', '.css', $path);
 		}
 
-		$contents = @file_get_contents($path);
+		$contents = $this->mpdf->loadContent($path);
 
 		if ($contents) {
 			return $contents;

--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -215,15 +215,15 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 			if ($orig_srcpath && $this->mpdf->basepathIsLocal && $check = @fopen($orig_srcpath, 'rb')) {
 				fclose($check);
 				$file = $orig_srcpath;
-				$this->logger->debug(sprintf('Fetching (file_get_contents) content of file "%s" with local basepath', $file), ['context' => LogContext::REMOTE_CONTENT]);
-				$data = file_get_contents($file);
+				$this->logger->debug(sprintf('Fetching (content loader) content of file "%s" with local basepath', $file), ['context' => LogContext::REMOTE_CONTENT]);
+				$data = $this->mpdf->loadContent($file);
 				$type = $this->guesser->guess($data);
 			}
 
 			if ($file && !$data && $check = @fopen($file, 'rb')) {
 				fclose($check);
-				$this->logger->debug(sprintf('Fetching (file_get_contents) content of file "%s" with non-local basepath', $file), ['context' => LogContext::REMOTE_CONTENT]);
-				$data = file_get_contents($file);
+				$this->logger->debug(sprintf('Fetching (content loader) content of file "%s" with non-local basepath', $file), ['context' => LogContext::REMOTE_CONTENT]);
+				$data = $this->mpdf->loadContent($file);
 				$type = $this->guesser->guess($data);
 			}
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -211,6 +211,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	var $defaultPageNumStyle; // mPDF 6
 
+	/**
+	 * @var callable
+	 *
+	 * Customize your content loader here. If not provided, file_get_contents will be used
+	 */
+	public $fileContentLoader;
+
 	//////////////////////
 	// INTERNAL VARIABLES
 	//////////////////////
@@ -1456,7 +1463,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		if (file_exists($this->defaultCssFile)) {
-			$css = file_get_contents($this->defaultCssFile);
+			$css = $this->loadContent($this->defaultCssFile);
 			$this->cssManager->ReadCSS('<style> ' . $css . ' </style>');
 		} else {
 			throw new \Mpdf\MpdfException(sprintf('Unable to read default CSS file "%s"', $this->defaultCssFile));
@@ -27086,7 +27093,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	// ========== OVERWRITE SEARCH STRING IN A PDF FILE ================
 	function OverWrite($file_in, $search, $replacement, $dest = Destination::DOWNLOAD, $file_out = "mpdf")
 	{
-		$pdf = file_get_contents($file_in);
+		$pdf = $this->loadContent($file_in);
 
 		if (!is_array($search)) {
 			$x = $search;
@@ -27355,6 +27362,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	public function _out($s)
 	{
 		$this->writer->write($s);
+	}
+
+	public function loadContent($path)
+	{
+		return call_user_func($this->fileContentLoader, $path);
 	}
 
 	/**

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -3017,7 +3017,7 @@ class Otl
 	{
 		// Load Line-breaking dictionary
 		if (!isset($this->lbdicts[$this->shaper]) && file_exists(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat')) {
-			$this->lbdicts[$this->shaper] = file_get_contents(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat');
+			$this->lbdicts[$this->shaper] = $this->mpdf->loadContent(__DIR__ . '/../data/linebrdict' . $this->shaper . '.dat');
 		}
 
 		$dict = &$this->lbdicts[$this->shaper];

--- a/src/Writer/FontWriter.php
+++ b/src/Writer/FontWriter.php
@@ -92,7 +92,7 @@ class FontWriter
 					} elseif ($this->fontCache->has($fontkey . '.z')) {
 						$font = $this->fontCache->load($fontkey . '.z');
 					} else {
-						$font = file_get_contents($this->mpdf->FontFiles[$fontkey]['ttffile']);
+						$font = $this->mpdf->loadContent($this->mpdf->FontFiles[$fontkey]['ttffile']);
 						$font = gzcompress($font);
 						$this->fontCache->binaryWrite($fontkey . '.z', $font);
 					}

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -232,9 +232,9 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			if (!file_exists($this->mpdf->ICCProfile)) {
 				throw new \Mpdf\MpdfException(sprintf('Unable to find ICC profile "%s"', $this->mpdf->ICCProfile));
 			}
-			$s = file_get_contents($this->mpdf->ICCProfile);
+			$s = $this->mpdf->loadContent($this->mpdf->ICCProfile);
 		} else {
-			$s = file_get_contents(__DIR__ . '/../../data/iccprofiles/sRGB_IEC61966-2-1.icc');
+			$s = $this->mpdf->loadContent(__DIR__ . '/../../data/iccprofiles/sRGB_IEC61966-2-1.icc');
 		}
 
 		if ($this->mpdf->compress) {
@@ -287,7 +287,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 
 			$fileContent = null;
 			if (isset($file['path'])) {
-				$fileContent = @file_get_contents($file['path']);
+				$fileContent = $this->mpdf->loadContent($file['path']);
 			} elseif (isset($file['content'])) {
 				$fileContent = $file['content'];
 			}
@@ -706,7 +706,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 
 						if ($fileAttachment) {
 
-							$file = @file_get_contents($pl['opt']['file']);
+							$file = $this->mpdf->loadContent($pl['opt']['file']);
 							if (!$file) {
 								throw new \Mpdf\MpdfException('mPDF Error: Cannot access file attachment - ' . $pl['opt']['file']);
 							}

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -106,6 +106,23 @@ class MpdfTest extends \PHPUnit_Framework_TestCase
 		$this->assertRegExp('/<zf:DocumentFileName>ZUGFeRD-invoice\.xml<\/zf:DocumentFileName>/', $output);
 	}
 
+	public function testDefaultFileContentLoader()
+	{
+		$selfContent = file_get_contents(__FILE__);
+
+		$this->assertEquals($selfContent, $this->mpdf->loadContent(__FILE__));
+	}
+
+	public function testCustomFileContentLoader()
+	{
+		$customMessage = 'Oh, hey you';
+		$this->mpdf->fileContentLoader = function () use ($customMessage) {
+			return $customMessage;
+		};
+
+		$this->assertEquals($customMessage, $this->mpdf->loadContent(__FILE__));
+	}
+
 	private function ZugferdXmpRdf()
 	{
 		$s  = '<rdf:Description rdf:about="" xmlns:zf="urn:ferd:pdfa:CrossIndustryDocument:invoice:1p0#">'."\n";


### PR DESCRIPTION
As discussed in #672, this PR adds a configuration variable fileContentLoader that allows a user to override the default `file_get_contents` when gathering a file content.