### PR TITLE
Fix TypeError in PHP8

### DIFF
--- a/src/Color/ColorConverter.php
+++ b/src/Color/ColorConverter.php
@@ -173,7 +173,7 @@ class ColorConverter
 		$c = false;
 
 		if (preg_match('/^[\d]+$/', $color)) {
-			$c = [static::MODE_GRAYSCALE, (float)$color]; // i.e. integer only
+			$c = [static::MODE_GRAYSCALE, (float) $color]; // i.e. integer only
 		} elseif (strpos($color, '#') === 0) { // case of #nnnnnn or #nnn
 			$c = $this->processHashColor($color);
 		} elseif (preg_match('/(rgba|rgb|device-cmyka|cmyka|device-cmyk|cmyk|hsla|hsl|spot)\((.*?)\)/', $color, $m)) {

--- a/src/Color/ColorConverter.php
+++ b/src/Color/ColorConverter.php
@@ -173,7 +173,7 @@ class ColorConverter
 		$c = false;
 
 		if (preg_match('/^[\d]+$/', $color)) {
-			$c = [static::MODE_GRAYSCALE, $color]; // i.e. integer only
+			$c = [static::MODE_GRAYSCALE, (float)$color]; // i.e. integer only
 		} elseif (strpos($color, '#') === 0) { // case of #nnnnnn or #nnn
 			$c = $this->processHashColor($color);
 		} elseif (preg_match('/(rgba|rgb|device-cmyka|cmyka|device-cmyk|cmyk|hsla|hsl|spot)\((.*?)\)/', $color, $m)) {


### PR DESCRIPTION
We get the error "Unsupported operand types: string & int" because convertPlain() return `string[]`.
Although the return value describes the following `@return bool|float[]`.
I think converting to a float should solve the problem.