### PR TITLE
Set the default language using `/Lang` entry

### DIFF
--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -332,6 +332,12 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 		$this->writer->write('/Type /Catalog');
 		$this->writer->write('/Pages 1 0 R');
 
+        if (is_string($this->mpdf->currentLang)) {
+            $this->writer->write(sprintf('/Lang (%s)', $this->mpdf->currentLang));
+        } elseif (is_string($this->mpdf->default_lang)) {
+            $this->writer->write(sprintf('/Lang (%s)', $this->mpdf->default_lang));
+        }
+
 		if ($this->mpdf->ZoomMode === 'fullpage') {
 			$this->writer->write('/OpenAction [3 0 R /Fit]');
 		} elseif ($this->mpdf->ZoomMode === 'fullwidth') {


### PR DESCRIPTION
Generated pdf file doesn't pass eAccessibility checking which should be fixed/updated:
Checker URL: http://checkers.eiii.eu/en/pdfcheck/
More detail: https://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/PDF16#PDF16-examples
![Screenshot from 2021-04-27 12-57-52](https://user-images.githubusercontent.com/5222395/116230904-782b5b00-a758-11eb-90e9-f75e9f3e5f09.png)
