### PR TITLE
Fix compound classes support when combining more than three classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mPDF 8.0.x
 * PHP 8.0 is supported since 8.0.10 (#1263)
 * Fix: First header of named page is added twice (@antman3351, #1320)
 * Added `curlExecutionTimeout` configuration variable allowing to `CURLOPT_TIMEOUT` when fetching remote content
+* Fix: Not all combinations were generated for more than three compound classes (@JeppeKnockaert)
 
 mPDF 8.0.0
 ===========================

--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -78,11 +78,19 @@ class Arrays
 			$combinations[] = $combination;
 
 			$anotherCombination = false;
+			$resetFromIndex = -1;
 			for ($i = $k - 1; $i >= 0; $i--) {
 				if ($indexes[$i] < $maxIndexes[$i]) {
 					$indexes[$i]++;
 					$anotherCombination = true;
 					break;
+				}
+				$resetFromIndex = $i;
+			}
+
+			if ($resetFromIndex > 0) {
+				for ($i = $resetFromIndex; $i < $k; $i++) {
+					$indexes[$i] = $indexes[$i - 1] + 1;
 				}
 			}
 		} while ($anotherCombination);

--- a/tests/Issues/Issue538Test.php
+++ b/tests/Issues/Issue538Test.php
@@ -30,6 +30,10 @@ span.three.four {
 span.three.four.five {
 	font-weight: bold;
 }
+
+.one.three {
+    font-size: xx-small;
+}
 </style>
 
 <p class="one">First paragraph</p>
@@ -37,6 +41,7 @@ span.three.four.five {
 <p class="one two one">Third paragraph</p>
 
 <p><span class="three four">A wild fox</span> jumped over <span class="five four three">a lazy dog</span></p>
+<p class="one two three four">This should be really small</p>
 ');
 		$this->mpdf->SetCompression(false);
 		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
@@ -51,5 +56,7 @@ span.three.four.five {
 			"q 0.000 g  0 Tr BT 90.183 705.867 Td  ( jumped over ) Tj ET Q\n" .
 			"BT /F2 11.000 Tf ET\n" .
 			"q 0.000 0.502 0.000 rg  0 Tr BT 150.980 705.867 Td  (a lazy dog) Tj ET Q", $output);
+
+		$this->assertContains("BT /F4 7.700 Tf ET\nq 1.000 0.000 0.000 rg  0 Tr BT 42.520 682.556 Td  (This should be really small) Tj ET Q", $output);
 	}
 }

--- a/tests/Mpdf/Utils/ArraysTest.php
+++ b/tests/Mpdf/Utils/ArraysTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mpdf\Utils;
+
+class ArraysTest extends \PHPUnit_Framework_TestCase
+{
+	public function testAllCombinationsOfTwoItemsAreReturned()
+	{
+		$this->assertEquals(
+			[
+				['a', 'b'],
+				['a', 'c'],
+				['a', 'd'],
+				['b', 'c'],
+				['b', 'd'],
+				['c', 'd'],
+			],
+			Arrays::combinations(['a', 'b', 'c', 'd'], 2)
+		);
+	}
+
+	public function testAllCombinationsOfThreeItemsAreReturned()
+	{
+		$this->assertEquals(
+			[
+				['a', 'b', 'c'],
+				['a', 'b', 'd'],
+				['a', 'b', 'e'],
+				['a', 'c', 'd'],
+				['a', 'c', 'e'],
+				['a', 'd', 'e'],
+				['b', 'c', 'd'],
+				['b', 'c', 'e'],
+				['b', 'd', 'e'],
+				['c', 'd', 'e'],
+			],
+			Arrays::combinations(['a', 'b', 'c', 'd', 'e'], 3)
+		);
+	}
+}


### PR DESCRIPTION
When using more than three classes on an element, not all combinations were generated because of an issue with the combinations function in the Arrays helper class.

e.g. when generating the combinations for 'a', 'b', 'c' and 'd' (with k=2) the combination generating algorithm would correctly generate `ab`,` ac`,`ad` and then jump to `bd` and `cd` instead of generating `bc` as well, because it only increased the middle index, without resetting the last index first: `[0, 3]` became `[1, 3]` instead of `[1, 2]`.