### PR TITLE
Update CssManager to use RemoteContentFetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mPDF 8.0.x
 * Added `curlExecutionTimeout` configuration variable allowing to `CURLOPT_TIMEOUT` when fetching remote content
 * Fix: Not all combinations were generated for more than three compound classes (@JeppeKnockaert)
 * Added `quiet_zone_left` and `quiet_zone_right` to barcodes which support quiet zones in order to customize its width
+* Updated `CssManager` to use the `RemoteContentFetcher` class instead of `curl` natively (@greew)
 
 mPDF 8.0.0
 ===========================

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -52,7 +52,7 @@ class CssManager
 	 */
 	private $remoteContentFetcher;
 
-	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter, RemoteContentFetcher $remoteContentFetcher = null)
+	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter, RemoteContentFetcher $remoteContentFetcher)
 	{
 		$this->mpdf = $mpdf;
 		$this->cache = $cache;
@@ -2318,11 +2318,11 @@ class CssManager
 
 			$contents = @file_get_contents($localpath);
 
-		} elseif ($this->remoteContentFetcher !== null) { // if not use full URL
+		} else { // if not use full URL
 
 			try {
 				$contents = $this->remoteContentFetcher->getFileContentsByCurl($path);
-			} catch (MpdfException $e) {
+			} catch (\Mpdf\MpdfException $e) {
 				// Ignore error
 			}
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -47,7 +47,12 @@ class CssManager
 
 	var $cell_border_dominance_T;
 
-	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter)
+	/**
+	 * @var \Mpdf\RemoteContentFetcher
+	 */
+	private $remoteContentFetcher;
+
+	public function __construct(Mpdf $mpdf, Cache $cache, SizeConverter $sizeConverter, ColorConverter $colorConverter, RemoteContentFetcher $remoteContentFetcher = null)
 	{
 		$this->mpdf = $mpdf;
 		$this->cache = $cache;
@@ -58,6 +63,7 @@ class CssManager
 		$this->cascadeCSS = [];
 		$this->tbCSSlvl = 0;
 		$this->colorConverter = $colorConverter;
+		$this->remoteContentFetcher = $remoteContentFetcher;
 	}
 
 	function ReadCSS($html)
@@ -2312,13 +2318,13 @@ class CssManager
 
 			$contents = @file_get_contents($localpath);
 
-		} elseif (!$contents && !ini_get('allow_url_fopen') && function_exists('curl_init')) { // if not use full URL
+		} elseif ($this->remoteContentFetcher !== null) { // if not use full URL
 
-			$ch = curl_init($path);
-			curl_setopt($ch, CURLOPT_HEADER, 0);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			$contents = curl_exec($ch);
-			curl_close($ch);
+			try {
+				$contents = $this->remoteContentFetcher->getFileContentsByCurl($path);
+			} catch (MpdfException $e) {
+				// Ignore error
+			}
 
 		}
 

--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -58,7 +58,9 @@ class ServiceFactory
 
 		$fontFileFinder = new FontFileFinder($config['fontDir']);
 
-		$cssManager = new CssManager($mpdf, $cache, $sizeConverter, $colorConverter);
+		$remoteContentFetcher = new RemoteContentFetcher($mpdf, $logger);
+
+		$cssManager = new CssManager($mpdf, $cache, $sizeConverter, $colorConverter, $remoteContentFetcher);
 
 		$otl = new Otl($mpdf, $fontCache);
 
@@ -73,8 +75,6 @@ class ServiceFactory
 		$form = new Form($mpdf, $otl, $colorConverter, $writer, $formWriter);
 
 		$hyphenator = new Hyphenator($mpdf);
-
-		$remoteContentFetcher = new RemoteContentFetcher($mpdf, $logger);
 
 		$imageProcessor = new ImageProcessor(
 			$mpdf,


### PR DESCRIPTION
The `CssManager` class didn't make use of the `RemoteContentFetcher` class, meaning that when it tried to fetch data via `curl`, it wouldn't all the options that the `RemoteContentFetcher` was able to use.