### PR TITLE
Prevent notice PHP 7.4.21+ & PHP 8.0.8+

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -11492,7 +11492,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			$path = $path . "/" . $filepath; // Make it an absolute path
 
-		} elseif ((strpos($path, ":/") === false || strpos($path, ":/") > 10) && !is_file($path)) { // It is a local link
+		} elseif ((strpos($path, ":/") === false || strpos($path, ":/") > 10) && !@is_file($path)) { // It is a local link
 
 			if (substr($path, 0, 1) == "/") {
 


### PR DESCRIPTION
Prevent useless notice on new PHP versions, since picture file path is succesfully located anyways, see working tests: https://github.com/mpdf/mpdf/blob/development/tests/Mpdf/GetFullPathTest.php

Related issue #1478.