### PR TITLE
Ensure that all digits of a string are hexadecimal before decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mPDF 8.0.x
 * Added `quiet_zone_left` and `quiet_zone_right` to barcodes which support quiet zones in order to customize its width
 * Updated `CssManager` to use the `RemoteContentFetcher` class instead of `curl` natively (@greew)
 * Added optional `continue2pages` parameter to `SetDocTemplate` method, allowing a template to continue the last 2 pages alternately (@bmg-ruudv)
+* Ensure that all digits of a string are hexadecimal before decoding in ColorConverter (@derklaro)
 
 mPDF 8.0.0
 ===========================

--- a/src/Color/ColorConverter.php
+++ b/src/Color/ColorConverter.php
@@ -202,9 +202,9 @@ class ColorConverter
 			$cor = '#' . $cor[1] . $cor[1] . $cor[2] . $cor[2] . $cor[3] . $cor[3];
 		}
 
-		$r = hexdec(substr($cor, 1, 2));
-		$g = hexdec(substr($cor, 3, 2));
-		$b = hexdec(substr($cor, 5, 2));
+		$r = self::safeHexDec(substr($cor, 1, 2));
+		$g = self::safeHexDec(substr($cor, 3, 2));
+		$b = self::safeHexDec(substr($cor, 5, 2));
 
 		return [3, $r, $g, $b];
 	}
@@ -334,4 +334,14 @@ class ColorConverter
 		}
 	}
 
+	/**
+	 * Converts the given hexString to its decimal representation when all digits are hexadecimal
+	 *
+	 * @param string $hexString The hexadecimal string to convert
+	 * @return float|int The decimal representation of hexString or 0 if not all digits of hexString are hexadecimal
+	 */
+	private function safeHexDec($hexString)
+	{
+		return ctype_xdigit($hexString) ? hexdec($hexString) : 0;
+	}
 }

--- a/tests/Mpdf/Color/ColorConverterTest.php
+++ b/tests/Mpdf/Color/ColorConverterTest.php
@@ -59,6 +59,10 @@ class ColorConverterTest extends \PHPUnit_Framework_TestCase
 	{
 		return [
 
+			['#22pp44', "3\"\x00D\x00\x00"],
+			['#aaaazz', "3\xaa\xaa\x00\x00\x00"],
+			['#gghhii', "3\x00\x00\x00\x00\x00"],
+
 			['#220044', "3\"\x00D\x00\x00"],
 			[255, "1\xff\x00\x00\x00\x00"],
 			[85, "1U\x00\x00\x00\x00"],


### PR DESCRIPTION
This pull request resolves an issue with newer php versions printing a deprecation message (`Invalid characters passed for attempted conversion, these have been ignored`) when trying to decode invalid hex characters using the [hexdec](https://www.php.net/manual/function.hexdec.php) method.

The passed string is now validated to only contain hexadecimal characters before it gets passed to [hexdec](https://www.php.net/manual/function.hexdec.php) using [ctype_xdigit](https://www.php.net/manual/function.ctype-xdigit.php). If the passed string does not contain only hex chars the method returns `0` just as php does.