### PR TITLE
overcome fread limit in buffered streams (e.g. phar) (Closes #1504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ mPDF 8.0.x
 * Updated `CssManager` to use the `RemoteContentFetcher` class instead of `curl` natively (@greew)
 * Added optional `continue2pages` parameter to `SetDocTemplate` method, allowing a template to continue the last 2 pages alternately (@bmg-ruudv)
 * Ensure that all digits of a string are hexadecimal before decoding in ColorConverter (@derklaro)
+* Fix: Using mpdf in phar package leads to weird errors (#1504, @sandreas)
 
 mPDF 8.0.0
 ===========================

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -511,8 +511,8 @@ class TTFontFile
 		return $this->splice($stream, $offset, $up);
 	}
 
-    function get_chunk($pos, $length)
-    {
+	function get_chunk($pos, $length)
+	{
 		fseek($this->fh, $pos);
 		if ($length < 1) {
 			return '';
@@ -527,11 +527,11 @@ class TTFontFile
 		// try to read the rest of the data
 		$dataLen = strlen($data);
 		while($dataLen < $length && !feof($this->fh)) {
-		    $data .= fread($this->fh, $length - $dataLen);
-		    $dataLen = strlen($data);
+			$data .= fread($this->fh, $length - $dataLen);
+			$dataLen = strlen($data);
 		}
-        return $data;
-    }
+		return $data;
+	}
 
 	function get_table($tag)
 	{

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -513,23 +513,23 @@ class TTFontFile
 
     function get_chunk($pos, $length)
     {
-        fseek($this->fh, $pos);
-        if ($length < 1) {
-            return '';
-        }
+		fseek($this->fh, $pos);
+		if ($length < 1) {
+			return '';
+		}
 
-        $data = (fread($this->fh, $length));
+		$data = (fread($this->fh, $length));
 
-        // fix for #1504
-        // if fread is used to read from a compressed / buffered stream (e.g. phar://...)
-        // the $length parameter will be ignored - fread is limited in size (usually 8192 bytes)
-        // to fix this, the data length must be checked after reading. If the read was incomplete,
-        // try to read the rest of the data
-        $dataLen = strlen($data);
-        while($dataLen < $length && !feof($this->fh)) {
-            $data .= fread($this->fh, $length - $dataLen);
-            $dataLen = strlen($data);
-        }
+		// fix for #1504
+		// if fread is used to read from a compressed / buffered stream (e.g. phar://...)
+		// the $length parameter will be ignored - fread is limited in size (usually 8192 bytes)
+		// to fix this, the data length must be checked after reading. If the read was incomplete,
+		// try to read the rest of the data
+		$dataLen = strlen($data);
+		while($dataLen < $length && !feof($this->fh)) {
+		    $data .= fread($this->fh, $length - $dataLen);
+		    $dataLen = strlen($data);
+		}
         return $data;
     }
 

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -511,15 +511,27 @@ class TTFontFile
 		return $this->splice($stream, $offset, $up);
 	}
 
-	function get_chunk($pos, $length)
-	{
-		fseek($this->fh, $pos);
-		if ($length < 1) {
-			return '';
-		}
+    function get_chunk($pos, $length)
+    {
+        fseek($this->fh, $pos);
+        if ($length < 1) {
+            return '';
+        }
 
-		return (fread($this->fh, $length));
-	}
+        $data = (fread($this->fh, $length));
+
+        // fix for #1504
+        // if fread is used to read from a compressed / buffered stream (e.g. phar://...)
+        // the $length parameter will be ignored - fread is limited in size (usually 8192 bytes)
+        // to fix this, the data length must be checked after reading. If the read was incomplete,
+        // try to read the rest of the data
+        $dataLen = strlen($data);
+        while($dataLen < $length && !feof($this->fh)) {
+            $data .= fread($this->fh, $length - $dataLen);
+            $dataLen = strlen($data);
+        }
+        return $data;
+    }
 
 	function get_table($tag)
 	{

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -526,7 +526,7 @@ class TTFontFile
 		// to fix this, the data length must be checked after reading. If the read was incomplete,
 		// try to read the rest of the data
 		$dataLen = strlen($data);
-		while($dataLen < $length && !feof($this->fh)) {
+		while ($dataLen < $length && !feof($this->fh)) {
 			$data .= fread($this->fh, $length - $dataLen);
 			$dataLen = strlen($data);
 		}


### PR DESCRIPTION
Fix for #1504 
Added the ability to check the fread result to overcome the 8192 bytes limit in compressed / buffered streams.