### PR TITLE
Fix: SVG respects xml parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ mPDF 8.0.x
 * Added optional `continue2pages` parameter to `SetDocTemplate` method, allowing a template to continue the last 2 pages alternately (@bmg-ruudv)
 * Ensure that all digits of a string are hexadecimal before decoding in ColorConverter (@derklaro)
 * Fix: Using mpdf in phar package leads to weird errors (#1504, @sandreas)
+* Fix: SVG respects `xml_parse` errors (@decaseal)
 
 mPDF 8.0.0
 ===========================

--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -3310,7 +3310,10 @@ class Svg
 			[$this, 'characterData']
 		);
 
-		xml_parse($svg2pdf_xml_parser, $data);
+		$ok = xml_parse($svg2pdf_xml_parser, $data);
+		if (!$ok) {
+			$this->svg_error = true;
+		}
 
 		if ($this->svg_error) {
 			return false;


### PR DESCRIPTION
Set Svg::svg_error when xml_parse failure