### PR TITLE
Fix division by zero on some SVG

### DIFF
--- a/src/Image/Svg.php
+++ b/src/Image/Svg.php
@@ -2063,6 +2063,7 @@ class Svg
 		// segment (a "lineto") joining the endpoints.
 		if ($rx == 0.0 || $ry == 0.0) {
 			//   return array(Lineto(x2, y2), $bounds);
+			return [$this->svgPolyline([$x1, $y1, $x1, $y1]), $bounds];
 		}
 
 		// If rX or rY have negative signs, these are dropped; the absolute


### PR DESCRIPTION
Corrects division by zero on some SVGs and if a point has a problem, this can be used to detect it.