### PR TITLE
Suppress GD errors for PNG images

### DIFF
--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -578,7 +578,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 					return $this->imageError($file, $firsttime, sprintf('GD library with PNG support required for image (%s)', $errpng));
 				}
 
-				$im = imagecreatefromstring($data);
+				$im = @imagecreatefromstring($data);
 				if (!$im) {
 					return $this->imageError($file, $firsttime, sprintf('Error creating GD image from PNG file (%s)', $errpng));
 				}


### PR DESCRIPTION
Currently an ErrorException is thrown when trying to use an interlaced PNG and there's no way to prevent this from halting execution.

`imagecreatefromstring(): gd-png: libpng warning: Interlace handling should be turned on when using png_read_image`

This PR proposes to suppress the warnings from `imagecreatefromstring()` when loading PNG files. I notice the other file formats suppress the errors from this function, so it would be good to do this for PNG also for consistency.