### PR TITLE
Prevent hyphenation of urls starting with https and E-Mail addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ mPDF 8.0.x
 * Fix: Using mpdf in phar package leads to weird errors (#1504, @sandreas)
 * WEBP images support (#1525)
 * Add regex to prevent URLs starting with https from getting hyphenated
+* Prevent E-Mail addresses from getting hyphenated
 
 mPDF 8.0.0
 ===========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ mPDF 8.0.x
 * Ensure that all digits of a string are hexadecimal before decoding in ColorConverter (@derklaro)
 * Fix: Using mpdf in phar package leads to weird errors (#1504, @sandreas)
 * WEBP images support (#1525)
+* Add regex to prevent URLs starting with https from getting hyphenated
 
 mPDF 8.0.0
 ===========================

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -47,6 +47,10 @@ class Hyphenator
 		if (preg_match('/^(http:|https:|www\.)/', $word)) {
 			return -1;
 		}
+		// Don't hyphenate email addresses
+		if (preg_match('/^[a-zA-Z0-9-_.+]+@[a-zA-Z0-9-_.]+/', $word)) {
+			return -1;
+		}
 
 		$ptr = -1;
 

--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -44,7 +44,7 @@ class Hyphenator
 	{
 		// Do everything inside this function in utf-8
 		// Don't hyphenate web addresses
-		if (preg_match('/^(http:|www\.)/', $word)) {
+		if (preg_match('/^(http:|https:|www\.)/', $word)) {
 			return -1;
 		}
 

--- a/tests/Mpdf/HyphenatorTest.php
+++ b/tests/Mpdf/HyphenatorTest.php
@@ -63,6 +63,8 @@ class HyphenatorTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 			['http://yoursite.com', 5, -1],
 			['https://yoursite.com', 5, -1],
 			['www.yoursite.com', 5, -1],
+			['name@mail.com', 5, -1],
+			['first-name.last_name+suffix@mail.co.uk', 5, -1],
 		];
 	}
 

--- a/tests/Mpdf/HyphenatorTest.php
+++ b/tests/Mpdf/HyphenatorTest.php
@@ -60,6 +60,9 @@ class HyphenatorTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 			['disestablishmentarianism', 50, 21],
 			['capabilities', 5, 4],
 			['animation', 5, 5],
+			['http://yoursite.com', 5, -1],
+			['https://yoursite.com', 5, -1],
+			['www.yoursite.com', 5, -1],
 		];
 	}
 


### PR DESCRIPTION
Hi,
currently only URLs starting with `http:` or `www.` are prevented from hyphenation. I have added `https:` to the regex to include URLs starting with https.
Best, Hannes