### PR TITLE
feature: prevent hyphenation in email addresses

### DIFF
--- a/src/Hyphenator.php
+++ b/src/Hyphenator.php
@@ -47,6 +47,10 @@ class Hyphenator
 		if (preg_match('/^(http:|www\.)/', $word)) {
 			return -1;
 		}
+		// Don't hyphenate email addresses
+		if (preg_match('/^[a-zA-Z0-9-_.+]+@[a-zA-Z0-9-_.]+/', $word)) {
+			return -1;
+		}
 
 		$ptr = -1;
 


### PR DESCRIPTION
Hi,
currently only URLs are prevented from hyphenation.  
I think it makes sense to also prevent E-Mail addresses from hyphenation too. Otherwise E-Mail addresses will be hyphenated by adding an hyphen and making it difficult/impossible to understand whether this hyphen is part of the address or only added due to the hyphenation.

Best, Hannes