### PR TITLE
Exception throw when running in localhost

### DIFF
--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2304,7 +2304,7 @@ class CssManager
 
 			// WriteHTML parses all paths to full URLs; may be local file name
 			// DOCUMENT_ROOT is not returned on IIS
-			if (!empty($tr['scheme']) && empty($tr['host']) && !empty($_SERVER['DOCUMENT_ROOT'])) {
+			if (!empty($tr['scheme']) && !empty($tr['host']) && !empty($_SERVER['DOCUMENT_ROOT'])) {
 				return $_SERVER['DOCUMENT_ROOT'] . $tr['path'];
 			}
 

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -2304,7 +2304,7 @@ class CssManager
 
 			// WriteHTML parses all paths to full URLs; may be local file name
 			// DOCUMENT_ROOT is not returned on IIS
-			if (!empty($tr['scheme']) && $tr['host'] && !empty($_SERVER['DOCUMENT_ROOT'])) {
+			if (!empty($tr['scheme']) && empty($tr['host']) && !empty($_SERVER['DOCUMENT_ROOT'])) {
 				return $_SERVER['DOCUMENT_ROOT'] . $tr['path'];
 			}
 


### PR DESCRIPTION
Fixed "undefined index: host" exception when running in localhost

In my situation the $path parameter in the normalizePath function was "C:/Projects/xampp-win64-7.4.16-0-VC15/htdocs/ivy/web/css/fonts/open-sans/open-sans.css"
Then the $tr = parse_url($path); return Array ( [scheme] => C [path] => /Projects/xampp-win64-7.4.16-0-VC15/htdocs/ivy/web/css/fonts/open-sans/open-sans.css )
After that the exception "Undefined index: host" throw at the line if (!empty($tr['scheme']) && $tr['host'] && !empty($_SERVER['DOCUMENT_ROOT'])) {