### PR TITLE
Fix for issue-1606

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -4005,7 +4005,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			'GPOSFeatures' => $font['GPOSFeatures'],
 			'GPOSLookups' => $font['GPOSLookups'],
 			'rtlPUAstr' => $font['rtlPUAstr'],
-			'glyphIDtoUni' => $glyphIDtoUni,
+			'glyphIDtoUni' => (isset($glyphIDtoUni) ? $glyphIDtoUni : null),
 			'haskerninfo' => $font['haskerninfo'],
 			'haskernGPOS' => $font['haskernGPOS'],
 			'hassmallcapsGSUB' => $font['hassmallcapsGSUB'],


### PR DESCRIPTION
We're using "carlos-meneses/laravel-mpdf" wrapper over mpdf in our Laravel project. Some of us are getting ErrorException "Undefined variable: $glyphIDtoUni" error. Using a ternary operator here fixed the problem.

Related to #1606 