### PR TITLE
Enable require package psr/log v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"paragonie/random_compat": "^1.4|^2.0|^9.99.99",
 		"php-http/message-factory": "^1.0",
 		"psr/http-message": "^1.0",
-		"psr/log": "^1.0 || ^2.0",
+		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"setasign/fpdi": "^2.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Since psr/log version is updated to version 3.0.0, enable to solve required dependencies.