### PR TITLE
Enable auto font-size for active forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features
 * Service container for internal services
 * Set /Lang entry for better accessibility when document language is available (@cuongmits, #1418)
 * More verbose helper methods for `Output`: `OutputBinaryData`, `OutputHttpInline`, `OutputHttpDownload`, `OutputFile`
+* Set font-size to `auto` in textarea and input in active forms to resize the font-size (@ChrisB9, #1721)
 
 Bugfixes
 --------

--- a/src/Form.php
+++ b/src/Form.php
@@ -214,6 +214,10 @@ class Form
 				$js[] = ['K', $objattr['onKeystroke']];
 			}
 
+			if (!empty($objattr['use_auto_fontsize']) && $objattr['use_auto_fontsize'] === true) {
+				$this->mpdf->FontSizePt = 0.0;
+			}
+
 			$this->SetFormText($w, $h, $objattr['fieldname'], $val, $val, $objattr['title'], $flags, $fieldalign, false, (isset($objattr['maxlength']) ? $objattr['maxlength'] : false), $js, (isset($objattr['background-col']) ? $objattr['background-col'] : false), (isset($objattr['border-col']) ? $objattr['border-col'] : false));
 
 		} else {
@@ -319,6 +323,11 @@ class Form
 			if (!empty($objattr['onKeystroke'])) {
 				$js[] = ['K', $objattr['onKeystroke']];
 			}
+
+			if (!empty($objattr['use_auto_fontsize']) && $objattr['use_auto_fontsize'] === true) {
+				$this->mpdf->FontSizePt = 0.0;
+			}
+
 			$this->SetFormText($w, $h, $objattr['fieldname'], $texto, $texto, (isset($objattr['title']) ? $objattr['title'] : ''), $flags, $fieldalign, false, -1, $js, (isset($objattr['background-col']) ? $objattr['background-col'] : false), (isset($objattr['border-col']) ? $objattr['border-col'] : false));
 			$this->mpdf->SetTColor($this->colorConverter->convert(0, $this->mpdf->PDFAXwarnings));
 

--- a/src/Tag/Input.php
+++ b/src/Tag/Input.php
@@ -70,7 +70,7 @@ class Input extends Tag
 		if (isset($properties['FONT-FAMILY'])) {
 			$this->mpdf->SetFont($properties['FONT-FAMILY'], $this->mpdf->FontStyle, 0, false);
 		}
-		if (isset($properties['FONT-SIZE'])) {
+		if (isset($properties['FONT-SIZE']) && $properties['FONT-SIZE'] !== 'auto') {
 			$mmsize = $this->sizeConverter->convert($properties['FONT-SIZE'], $this->mpdf->default_font_size / Mpdf::SCALE);
 			$this->mpdf->SetFontSize($mmsize * Mpdf::SCALE, false);
 		}
@@ -356,6 +356,11 @@ class Input extends Tag
 				if (strtoupper($attr['TYPE']) === 'PASSWORD') {
 					$type = 'PASSWORD';
 				}
+
+				if ($properties['FONT-SIZE'] === 'auto' && $this->mpdf->useActiveForms) {
+					$objattr['use_auto_fontsize'] = true;
+				}
+
 				if (isset($attr['VALUE'])) {
 					if ($type === 'PASSWORD') {
 						$num_stars = mb_strlen($attr['VALUE'], $this->mpdf->mb_enc);

--- a/src/Tag/TextArea.php
+++ b/src/Tag/TextArea.php
@@ -64,7 +64,7 @@ class TextArea extends Tag
 		if (isset($properties['FONT-FAMILY'])) {
 			$this->mpdf->SetFont($properties['FONT-FAMILY'], '', 0, false);
 		}
-		if (isset($properties['FONT-SIZE'])) {
+		if (isset($properties['FONT-SIZE']) && $properties['FONT-SIZE'] !== 'auto') {
 			$mmsize = $this->sizeConverter->convert($properties['FONT-SIZE'], $this->mpdf->default_font_size / Mpdf::SCALE);
 			$this->mpdf->SetFontSize($mmsize * Mpdf::SCALE, false);
 		}
@@ -142,6 +142,10 @@ class TextArea extends Tag
 
 		$objattr['rows'] = $rowsize;
 		$objattr['cols'] = $colsize;
+
+		if ($properties['FONT-SIZE'] === 'auto' && $this->mpdf->useActiveForms) {
+			$objattr['use_auto_fontsize'] = true;
+		}
 
 		$this->mpdf->specialcontent = serialize($objattr);
 

--- a/tests/Issues/Issue834Test.php
+++ b/tests/Issues/Issue834Test.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\BaseMpdfTest;
+use Mpdf\Output\Destination;
+
+final class Issue834Test extends BaseMpdfTest
+{
+	public function testInputFormFontSizeAuto()
+	{
+		$this->mpdf->useActiveForms = true;
+		$this->mpdf->WriteHTML('<form><input type="text" name="test" style="font-size: auto" /></form>');
+
+		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
+		$this->assertStringContainsString('/T (test)', $output);
+		$this->assertStringContainsString('/DA (/F2 0 Tf 0.000 g)', $output);
+	}
+
+	public function testTextareaFormFontSizeAuto()
+	{
+		$this->mpdf->useActiveForms = true;
+		$this->mpdf->WriteHTML('<form><textarea name="test" style="font-size: auto">&nbsp;</textarea></form>');
+
+		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
+		$this->assertStringContainsString('/T (test)', $output);
+		$this->assertStringContainsString('/DA (/F2 0 Tf 0.000 g)', $output);
+	}
+
+	public function testInputFormFontSize10pt()
+	{
+		$this->mpdf->useActiveForms = true;
+		$this->mpdf->WriteHTML('<form><input type="text" name="test" style="font-size: 10pt" /></form>');
+
+		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
+		$this->assertStringContainsString('/T (test)', $output);
+		$this->assertStringContainsString('/DA (/F2 10 Tf 0.000 g)', $output);
+	}
+
+	public function testTextareaFormFontSize10pt()
+	{
+		$this->mpdf->useActiveForms = true;
+		$this->mpdf->WriteHTML('<form><textarea name="test" style="font-size: 10pt">&nbsp;</textarea></form>');
+
+		$output = $this->mpdf->Output('', Destination::STRING_RETURN);
+		$this->assertStringContainsString('/T (test)', $output);
+		$this->assertStringContainsString('/DA (/F2 10 Tf 0.000 g)', $output);
+	}
+}


### PR DESCRIPTION
Solves issue https://github.com/mpdf/mpdf/issues/834

According to [this commit](https://github.com/foliojs/pdfkit/commit/131df9e0ae4bb7db8d3328a745a9acecdf74a311), it seems to be completely enough to just set the font-size parameter within the AcroForm definition to 0.
