### PR TITLE
Update default user agent used for cURL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bugfixes
 * Prevent hyphenation of urls starting with https and e-mail addresses (@HKandulla, #1634)
 * Colorspace restrictor reads mode from Mpdf and works again (Fix for #1094)
 * Prevent exception when multiple columns wrap to next page
+* Update default `curlUserAgent` configuration variable from Firefox 13 to 108
 
 mPDF 8.0.x
 ===========================

--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -515,7 +515,7 @@ class ConfigVariables
 			'curlExecutionTimeout' => null,
 			'curlProxy' => null,
 			'curlProxyAuth' => null,
-			'curlUserAgent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:13.0) Gecko/20100101 Firefox/13.0.1',
+			'curlUserAgent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
 
 			'exposeVersion' => true,
 		];


### PR DESCRIPTION
Recently I started getting reports about HTTP(S) images not being loaded in PDFs from SiteGround hosted websites. The investigation into this revealed that SiteGround's anti-bot system is now blocking requests with old user agents because they are considered suspicious.

Information from SiteGround:
> "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:13.0) Gecko/20100101 Firefox/13.0.1"
> As you can see, it is using a quite old Firefox version (released in June 5, 2012) which is considered as suspicious and blocked by our anti-bot system. We recently started blocking such requests which originate from User Agents with quite old browser versions as in most cases these are malicious.

The recommended solution is to update the user agent to the current version of Firefox.

I haven't added any unit tests for this change because it would require an external HTTP request to a SiteGround hosted website to replicate, which is slow, flaky, and a potential privacy issue. Since the issue only happens on an external request, I don't believe an appropriate unit test can be written for this specific update (let me know if you've any ideas, and I'll be happy to add it). 