### PR TITLE
Fix failing watermark with asian font #1807

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -10841,8 +10841,22 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		} else {
 			$up = -130;
 		}
+
 		// ? 'up' and 'ut' do not seem to be referenced anywhere
-		$this->fonts[$fontkey] = ['i' => $i, 'type' => 'Type0', 'name' => $name, 'up' => $up, 'ut' => 40, 'cw' => $cw, 'CMap' => $CMap, 'registry' => $registry, 'MissingWidth' => 1000, 'desc' => $desc];
+		$this->fonts[$fontkey] = [
+			'i' => $i,
+			'type' => 'Type0',
+			'name' => $name,
+			'up' => $up,
+			'ut' => 40,
+			'cw' => $cw,
+			'CMap' => $CMap,
+			'registry' => $registry,
+			'MissingWidth' => 1000,
+			'desc' => $desc,
+			'sip' => '',
+			'smp' => ''
+		];
 	}
 
 	function AddCJKFont($family)

--- a/tests/Issues/Issue1807Test.php
+++ b/tests/Issues/Issue1807Test.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Issues;
+
+class Issue1807Test extends \Mpdf\BaseMpdfTest
+{
+	public function testJapaneseFontInWatermark()
+	{
+		$this->mpdf->autoScriptToLang = true;
+		$this->mpdf->autoLangToFont = true;
+		$this->mpdf->showWatermarkText = true;
+		$this->mpdf->watermark_font = 'SJIS';
+
+		$this->mpdf->WriteHtml('<html><body><watermarktext content="御 見 積 書" alpha="0.2" />Some content</body></html>');
+		$out = $this->mpdf->Output('', 'S');
+	}
+}


### PR DESCRIPTION
Fix for #1807 by adding missing array keys for CID fonts