### PR TITLE
Add new attribute disableAutoScriptToLang #1817

### DIFF
--- a/tests/Issues/Issue1817Test.php
+++ b/tests/Issues/Issue1817Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Issues;
+
+class Issue1817Test extends \Mpdf\BaseMpdfTest
+{
+	public function testDisableAutoScriptOnLangForElement()
+	{
+		$this->mpdf->autoScriptToLang = true;
+		$this->mpdf->autoLangToFont = true;
+
+		$this->mpdf->WriteHtml('
+			<body>
+				<table>
+				<tr>
+					<td lang="ja" disableAutoScriptToLang>ンターJA健康ー康</td>
+				</tr>
+				</table>
+				<div>Hello 健康</div>
+			</body>');
+
+		$output = $this->mpdf->Output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+}


### PR DESCRIPTION
**Usage**:

```html
<body>
  <table>
    <tr>
      <td lang="ja" disableAutoScriptToLang>ンターJA健康ー康</td>
    </tr>
  </table>
  <div>Hello 健康</div>
</body>'
```

**Result**:

mPDF will not process content of `<td lang="ja" disableAutoScriptToLang>ンターJA健康ー康</td>` via `autoScriptToLang`. Also applies to inner elements:

```html
<body>
  <table>
    <tr>
      <td lang="ja" disableAutoScriptToLang>
        ンターJA健康ー康
        <span>健康</span> <!-- ignored too -->
      </td>
    </tr>
  </table>
  <div>Hello <span lang="und-Hans">健康</span></div> <!-- autoScriptToLang performed its action here -->
</body>'
```