### PR TITLE
fix: local assets with relative path

### DIFF
--- a/src/AssetFetcher.php
+++ b/src/AssetFetcher.php
@@ -64,6 +64,8 @@ class AssetFetcher implements \Psr\Log\LoggerAwareInterface
 			return $this->contentLoader->load($path);
 		}
 
+		$path = $this->mpdf->normalizePath($path);
+
 		if ($path && $check = @fopen($path, 'rb')) {
 			fclose($check);
 			$this->logger->debug(sprintf('Fetching content of file "%s" with non-local basepath', $path), ['context' => LogContext::REMOTE_CONTENT]);

--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -166,7 +166,7 @@ class CssManager
 			$CSSextblock = $this->assetFetcher->fetchDataFromPath($path);
 
 			if (!$CSSextblock) {
-				$path = $this->normalizePath($path);
+				$path = $this->mpdf->normalizePath($path);
 				$CSSextblock = $this->assetFetcher->fetchDataFromPath($path);
 			}
 
@@ -2290,32 +2290,6 @@ class CssManager
 			}
 		}
 		return $select;
-	}
-
-	private function normalizePath($path)
-	{
-		if ($this->mpdf->basepathIsLocal) {
-
-			$tr = parse_url($path);
-			$lp = __FILE__;
-			$ap = realpath($lp);
-			$ap = str_replace("\\", '/', $ap);
-			$docroot = substr($ap, 0, strpos($ap, $lp));
-
-			// WriteHTML parses all paths to full URLs; may be local file name
-			// DOCUMENT_ROOT is not returned on IIS
-			if (!empty($tr['scheme']) && $tr['host'] && !empty($_SERVER['DOCUMENT_ROOT'])) {
-				return $_SERVER['DOCUMENT_ROOT'] . $tr['path'];
-			}
-
-			if ($docroot) {
-				return $docroot . $tr['path'];
-			}
-
-			return $path;
-		}
-
-		return $path;
 	}
 
 }

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -27525,4 +27525,30 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		return $html;
 	}
 
+
+	public function normalizePath($path)
+	{
+		if ($this->basepathIsLocal) {
+
+			$tr = parse_url($path);
+			$lp = __FILE__;
+			$ap = realpath($lp);
+			$ap = str_replace("\\", '/', $ap);
+			$docroot = substr($ap, 0, strpos($ap, $lp));
+
+			// WriteHTML parses all paths to full URLs; may be local file name
+			// DOCUMENT_ROOT is not returned on IIS
+			if (!empty($tr['scheme']) && $tr['host'] && !empty($_SERVER['DOCUMENT_ROOT'])) {
+				return $_SERVER['DOCUMENT_ROOT'] . $tr['path'];
+			}
+
+			if ($docroot) {
+				return $docroot . $tr['path'];
+			}
+
+			return $path;
+		}
+
+		return $path;
+	}
 }

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -27525,7 +27525,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		return $html;
 	}
 
-
+	/**
+	 * If the base path is local, the method will return a full absolute path.
+	 * Otherwise, it will return the given path.
+	 * 
+	 * @param string $path
+	 * @return string
+	 */
 	public function normalizePath($path)
 	{
 		if ($this->basepathIsLocal) {
@@ -27538,7 +27544,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 			// WriteHTML parses all paths to full URLs; may be local file name
 			// DOCUMENT_ROOT is not returned on IIS
-			if (!empty($tr['scheme']) && $tr['host'] && !empty($_SERVER['DOCUMENT_ROOT'])) {
+			if (!empty($tr['scheme']) && isset($tr['host']) && !empty($_SERVER['DOCUMENT_ROOT'])) {
 				return $_SERVER['DOCUMENT_ROOT'] . $tr['path'];
 			}
 


### PR DESCRIPTION
Example:

`<img src="/assets/hello.jpeg">`

Will look by these patch:
`"/assets/hello.jpeg"`
If local file by this path is not found and base path is set to local, then will look by this path  (new behavior):
`$_SERVER["DOCUMENT_ROOT"]."/assets/hello.jpeg"`

Basically this PR applies the same logics, that used before to all assets, when fetching css files. 