### PR TITLE
Proof of Concept: psr/log v2 & v3 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New features
 * More verbose helper methods for `Output`: `OutputBinaryData`, `OutputHttpInline`, `OutputHttpDownload`, `OutputFile` (since v8.1.2)
 * Set font-size to `auto` in textarea and input in active forms to resize the font-size (@ChrisB9, #1721)
 * PHP 8.2 support in mPDF 8.1.3
+* Added support for `psr/log` v3 without dropping v2. (@markdorison, @apotek, @greg-1-anderson, #1857)
 
 Bugfixes
 --------

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,12 @@
 		"php": "^5.6 || ^7.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
 		"ext-gd": "*",
 		"ext-mbstring": "*",
+		"mpdf/psr-log-aware-trait": "^2.0 || ^3.0",
 		"myclabs/deep-copy": "^1.7",
 		"paragonie/random_compat": "^1.4|^2.0|^9.99.99",
 		"php-http/message-factory": "^1.0",
 		"psr/http-message": "^1.0",
-		"psr/log": "^1.0 || ^2.0",
+		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"setasign/fpdi": "^2.1"
 	},
 	"require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
 
 	<testsuites>
 		<testsuite name="Tests">
-			<directory suffix=".php">./tests</directory>
+			<directory suffix="Test.php">./tests</directory>
 		</testsuite>
 	</testsuites>
 

--- a/src/AssetFetcher.php
+++ b/src/AssetFetcher.php
@@ -7,18 +7,19 @@ use Mpdf\File\StreamWrapperChecker;
 use Mpdf\Http\ClientInterface;
 use Mpdf\Http\Request;
 use Mpdf\Log\Context as LogContext;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Psr\Log\LoggerInterface;
 
 class AssetFetcher implements \Psr\Log\LoggerAwareInterface
 {
+
+	use PsrLogAwareTrait;
 
 	private $mpdf;
 
 	private $contentLoader;
 
 	private $http;
-
-	private $logger;
 
 	public function __construct(Mpdf $mpdf, LocalContentLoaderInterface $contentLoader, ClientInterface $http, LoggerInterface $logger)
 	{
@@ -114,11 +115,6 @@ class AssetFetcher implements \Psr\Log\LoggerAwareInterface
 	public function isPathLocal($path)
 	{
 		return strpos($path, '://') === false; // @todo More robust implementation
-	}
-
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
 	}
 
 }

--- a/src/Http/CurlHttpClient.php
+++ b/src/Http/CurlHttpClient.php
@@ -4,15 +4,15 @@ namespace Mpdf\Http;
 
 use Mpdf\Log\Context as LogContext;
 use Mpdf\Mpdf;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 class CurlHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAwareInterface
 {
+	use PsrLogAwareTrait;
 
 	private $mpdf;
-
-	private $logger;
 
 	public function __construct(Mpdf $mpdf, LoggerInterface $logger)
 	{
@@ -114,11 +114,6 @@ class CurlHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAware
 		return $response
 			->withStatus($info['http_code'])
 			->withBody(Stream::create($data));
-	}
-
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
 	}
 
 }

--- a/src/Http/SocketHttpClient.php
+++ b/src/Http/SocketHttpClient.php
@@ -3,13 +3,14 @@
 namespace Mpdf\Http;
 
 use Mpdf\Log\Context as LogContext;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 class SocketHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAwareInterface
 {
 
-	private $logger;
+	use PsrLogAwareTrait;
 
 	public function __construct(LoggerInterface $logger)
 	{
@@ -102,11 +103,6 @@ class SocketHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAwa
 
 		return $response
 			->withBody($stream);
-	}
-
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
 	}
 
 }

--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -13,11 +13,14 @@ use Mpdf\Language\ScriptToLanguageInterface;
 use Mpdf\Log\Context as LogContext;
 use Mpdf\Mpdf;
 use Mpdf\Otl;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Mpdf\SizeConverter;
 use Psr\Log\LoggerInterface;
 
 class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 {
+
+	use PsrLogAwareTrait;
 
 	/**
 	 * @var \Mpdf\Mpdf
@@ -89,11 +92,6 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 	 */
 	private $assetFetcher;
 
-	/**
-	 * @var \Psr\Log\LoggerInterface
-	 */
-	public $logger;
-
 	public function __construct(
 		Mpdf $mpdf,
 		Otl $otl,
@@ -124,18 +122,6 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 		$this->guesser = new ImageTypeGuesser();
 
 		$this->failedImages = [];
-	}
-
-	/**
-	 * @param \Psr\Log\LoggerInterface
-	 *
-	 * @return self
-	 */
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
-
-		return $this;
 	}
 
 	public function getImage(&$file, $firstTime = true, $allowvector = true, $orig_srcpath = false, $interpolation = false)

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -10,11 +10,11 @@ use Mpdf\Css\TextVars;
 use Mpdf\Log\Context as LogContext;
 use Mpdf\Fonts\MetricsGenerator;
 use Mpdf\Output\Destination;
+use Mpdf\PsrLogAwareTrait\MpdfPsrLogAwareTrait;
 use Mpdf\QrCode;
 use Mpdf\Utils\Arrays;
 use Mpdf\Utils\NumericString;
 use Mpdf\Utils\UtfString;
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -30,6 +30,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	use Strict;
 	use FpdiTrait;
+	use MpdfPsrLogAwareTrait;
 
 	const VERSION = '8.1.6';
 
@@ -967,11 +968,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	private $scriptToLanguage;
 
 	/**
-	 * @var \Psr\Log\LoggerInterface
-	 */
-	private $logger;
-
-	/**
 	 * @var \Mpdf\Writer\BaseWriter
 	 */
 	private $writer;
@@ -1577,24 +1573,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		$this->createdReaders = [];
-	}
-
-	/**
-	 * @param \Psr\Log\LoggerInterface
-	 *
-	 * @return \Mpdf\Mpdf
-	 */
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
-
-		foreach ($this->services as $name) {
-			if ($this->$name && $this->$name instanceof \Psr\Log\LoggerAwareInterface) {
-				$this->$name->setLogger($logger);
-			}
-		}
-
-		return $this;
 	}
 
 	private function initConfig(array $config)

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -4,9 +4,12 @@ namespace Mpdf;
 
 use Psr\Log\LoggerInterface;
 use Mpdf\Log\Context as LogContext;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 
 class SizeConverter implements \Psr\Log\LoggerAwareInterface
 {
+
+	use PsrLogAwareTrait;
 
 	private $dpi;
 
@@ -17,21 +20,11 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 	 */
 	private $mpdf;
 
-	/**
-	 * @var \Psr\Log\LoggerInterface
-	 */
-	private $logger;
-
 	public function __construct($dpi, $defaultFontSize, Mpdf $mpdf, LoggerInterface $logger)
 	{
 		$this->dpi = $dpi;
 		$this->defaultFontSize = $defaultFontSize;
 		$this->mpdf = $mpdf;
-		$this->logger = $logger;
-	}
-
-	public function setLogger(LoggerInterface $logger)
-	{
 		$this->logger = $logger;
 	}
 

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -6,6 +6,7 @@ use Mpdf\Strict;
 use Mpdf\Form;
 use Mpdf\Mpdf;
 use Mpdf\Pdf\Protection;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Mpdf\Utils\PdfDate;
 
 use Psr\Log\LoggerInterface;
@@ -14,6 +15,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 {
 
 	use Strict;
+	use PsrLogAwareTrait;
 
 	/**
 	 * @var \Mpdf\Mpdf
@@ -34,11 +36,6 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 	 * @var \Mpdf\Pdf\Protection
 	 */
 	private $protection;
-
-	/**
-	 * @var \Psr\Log\LoggerInterface
-	 */
-	private $logger;
 
 	public function __construct(Mpdf $mpdf, BaseWriter $writer, Form $form, Protection $protection, LoggerInterface $logger)
 	{
@@ -806,11 +803,6 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			$uniqid = md5(time() . $this->mpdf->buffer);
 			$this->writer->write('/ID [<' . $uniqid . '> <' . $uniqid . '>]');
 		}
-	}
-
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
 	}
 
 	private function getVersionString()

--- a/src/Writer/ResourceWriter.php
+++ b/src/Writer/ResourceWriter.php
@@ -4,12 +4,14 @@ namespace Mpdf\Writer;
 
 use Mpdf\Strict;
 use Mpdf\Mpdf;
+use Mpdf\PsrLogAwareTrait\PsrLogAwareTrait;
 use Psr\Log\LoggerInterface;
 
 final class ResourceWriter implements \Psr\Log\LoggerAwareInterface
 {
 
 	use Strict;
+	use PsrLogAwareTrait;
 
 	/**
 	 * @var \Mpdf\Mpdf
@@ -65,11 +67,6 @@ final class ResourceWriter implements \Psr\Log\LoggerAwareInterface
 	 * @var \Mpdf\Writer\JavaScriptWriter
 	 */
 	private $javaScriptWriter;
-
-	/**
-	 * @var \Psr\Log\LoggerInterface
-	 */
-	private $logger;
 
 	public function __construct(
 		Mpdf $mpdf,
@@ -242,15 +239,5 @@ final class ResourceWriter implements \Psr\Log\LoggerAwareInterface
 			$this->writer->write('>>');
 			$this->writer->write('endobj');
 		}
-	}
-
-	/**
-	 * @param \Psr\Log\LoggerInterface $logger
-	 *
-	 * @return void
-	 */
-	public function setLogger(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
 	}
 }

--- a/tests/Mpdf/TestLogger.php
+++ b/tests/Mpdf/TestLogger.php
@@ -1,100 +1,14 @@
 <?php
-
-namespace Mpdf;
-
-/**
- * Copied from PSR repository where not available since 2.x
- */
-class TestLogger extends \Psr\Log\AbstractLogger
-{
-
-	/**
-	 * @var mixed[]
-	 */
-	public $records = [];
-
-	public $recordsByLevel = [];
-
-	/**
-	 * @inheritdoc
-	 */
-	public function log($level, $message, array $context = [])
-	{
-		$record = [
-			'level' => $level,
-			'message' => $message,
-			'context' => $context,
-		];
-
-		$this->recordsByLevel[$record['level']][] = $record;
-		$this->records[] = $record;
-	}
-
-	public function hasRecords($level)
-	{
-		return isset($this->recordsByLevel[$level]);
-	}
-
-	public function hasRecord($record, $level)
-	{
-		if (is_string($record)) {
-			$record = ['message' => $record];
-		}
-		return $this->hasRecordThatPasses(function ($rec) use ($record) {
-			if ($rec['message'] !== $record['message']) {
-				return false;
-			}
-			if (isset($record['context']) && $rec['context'] !== $record['context']) {
-				return false;
-			}
-			return true;
-		}, $level);
-	}
-
-	public function hasRecordThatContains($message, $level)
-	{
-		return $this->hasRecordThatPasses(function ($rec) use ($message) {
-			return strpos($rec['message'], $message) !== false;
-		}, $level);
-	}
-
-	public function hasRecordThatMatches($regex, $level)
-	{
-		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
-			return preg_match($regex, $rec['message']) > 0;
-		}, $level);
-	}
-
-	public function hasRecordThatPasses(callable $predicate, $level)
-	{
-		if (!isset($this->recordsByLevel[$level])) {
-			return false;
-		}
-		foreach ($this->recordsByLevel[$level] as $i => $rec) {
-			if (call_user_func($predicate, $rec, $i)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public function __call($method, $args)
-	{
-		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
-			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
-			$level = strtolower($matches[2]);
-			if (method_exists($this, $genericMethod)) {
-				$args[] = $level;
-				return call_user_func_array([$this, $genericMethod], $args);
-			}
-		}
-		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
-	}
-
-	public function reset()
-	{
-		$this->records = [];
-		$this->recordsByLevel = [];
-	}
-
+// Due to changes in signature of log() method (one with return type declared,
+// the other with no return type declared) we adapt which class is actually
+// included based on the signature of \Psr\Log\AbstractLogger included by
+// Composer.
+$loggerReflect = new \ReflectionClass('\Psr\Log\AbstractLogger');
+// Will throw desirable exception if AbstractLogger does not implement log().
+$loggerLogMethodReflect = $loggerReflect->getMethod('log');
+if (method_exists($loggerLogMethodReflect, 'getReturnType') && $loggerLogMethodReflect->getReturnType()) {
+	include __DIR__ . "/psr-log-3/TestLogger.php";
+}
+else {
+	include __DIR__ . "/psr-log-2/TestLogger.php";
 }

--- a/tests/Mpdf/psr-log-2/TestLogger.php
+++ b/tests/Mpdf/psr-log-2/TestLogger.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Mpdf;
+
+/**
+ * Copied from PSR repository where not available since 2.x
+ */
+class TestLogger extends \Psr\Log\AbstractLogger
+{
+
+	/**
+	 * @var mixed[]
+	 */
+	public $records = [];
+
+	public $recordsByLevel = [];
+
+	/**
+	 * @inheritdoc
+	 */
+	public function log($level, $message, array $context = [])
+	{
+		$record = [
+			'level' => $level,
+			'message' => $message,
+			'context' => $context,
+		];
+
+		$this->recordsByLevel[$record['level']][] = $record;
+		$this->records[] = $record;
+	}
+
+	public function hasRecords($level)
+	{
+		return isset($this->recordsByLevel[$level]);
+	}
+
+	public function hasRecord($record, $level)
+	{
+		if (is_string($record)) {
+			$record = ['message' => $record];
+		}
+		return $this->hasRecordThatPasses(function ($rec) use ($record) {
+			if ($rec['message'] !== $record['message']) {
+				return false;
+			}
+			if (isset($record['context']) && $rec['context'] !== $record['context']) {
+				return false;
+			}
+			return true;
+		}, $level);
+	}
+
+	public function hasRecordThatContains($message, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($message) {
+			return strpos($rec['message'], $message) !== false;
+		}, $level);
+	}
+
+	public function hasRecordThatMatches($regex, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+			return preg_match($regex, $rec['message']) > 0;
+		}, $level);
+	}
+
+	public function hasRecordThatPasses(callable $predicate, $level)
+	{
+		if (!isset($this->recordsByLevel[$level])) {
+			return false;
+		}
+		foreach ($this->recordsByLevel[$level] as $i => $rec) {
+			if (call_user_func($predicate, $rec, $i)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function __call($method, $args)
+	{
+		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+			$level = strtolower($matches[2]);
+			if (method_exists($this, $genericMethod)) {
+				$args[] = $level;
+				return call_user_func_array([$this, $genericMethod], $args);
+			}
+		}
+		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+	}
+
+	public function reset()
+	{
+		$this->records = [];
+		$this->recordsByLevel = [];
+	}
+
+}

--- a/tests/Mpdf/psr-log-3/TestLogger.php
+++ b/tests/Mpdf/psr-log-3/TestLogger.php
@@ -1,0 +1,99 @@
+<?php
+namespace Mpdf;
+
+/**
+ * Copied from PSR repository where not available since 2.x
+ */
+class TestLogger extends \Psr\Log\AbstractLogger
+{
+
+	/**
+	 * @var mixed[]
+	 */
+	public $records = [];
+
+	public $recordsByLevel = [];
+
+	/**
+	 * @inheritdoc
+	 */
+	public function log($level, $message, array $context = []): void
+	{
+		$record = [
+			'level' => $level,
+			'message' => $message,
+			'context' => $context,
+		];
+
+		$this->recordsByLevel[$record['level']][] = $record;
+		$this->records[] = $record;
+	}
+
+	public function hasRecords($level)
+	{
+		return isset($this->recordsByLevel[$level]);
+	}
+
+	public function hasRecord($record, $level)
+	{
+		if (is_string($record)) {
+			$record = ['message' => $record];
+		}
+		return $this->hasRecordThatPasses(function ($rec) use ($record) {
+			if ($rec['message'] !== $record['message']) {
+				return false;
+			}
+			if (isset($record['context']) && $rec['context'] !== $record['context']) {
+				return false;
+			}
+			return true;
+		}, $level);
+	}
+
+	public function hasRecordThatContains($message, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($message) {
+			return strpos($rec['message'], $message) !== false;
+		}, $level);
+	}
+
+	public function hasRecordThatMatches($regex, $level)
+	{
+		return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+			return preg_match($regex, $rec['message']) > 0;
+		}, $level);
+	}
+
+	public function hasRecordThatPasses(callable $predicate, $level)
+	{
+		if (!isset($this->recordsByLevel[$level])) {
+			return false;
+		}
+		foreach ($this->recordsByLevel[$level] as $i => $rec) {
+			if (call_user_func($predicate, $rec, $i)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function __call($method, $args)
+	{
+		if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+			$genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+			$level = strtolower($matches[2]);
+			if (method_exists($this, $genericMethod)) {
+				$args[] = $level;
+				return call_user_func_array([$this, $genericMethod], $args);
+			}
+		}
+		throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+	}
+
+	public function reset()
+	{
+		$this->records = [];
+		$this->recordsByLevel = [];
+	}
+
+}


### PR DESCRIPTION
Hi @finwe! 👋🏻 
I have seen some of the other [PRs related to adding `psr/log` v3 support](https://github.com/mpdf/mpdf/pull/1856). I understand you do not want to drop v2 support just to achieve compatibility with v3. @greg-1-anderson gave us the idea to try to achieve compatibility with both through the use of a trait. Thanks Greg!

This proposal shows how we might support `psr/log` v2 and v3 without having to support two different releases in *this* codebase.

In a separate [package](https://github.com/ChromaticHQ/psr-log-aware-trait):
* We created a trait to handle LoggerAwareInterface's `setLogger()` implementation. We implemented support for both psr/log [v2](https://github.com/ChromaticHQ/psr-log-aware-trait/blob/2.x/src/PsrLogAwareTrait.php) and [v3](https://github.com/ChromaticHQ/psr-log-aware-trait/blob/3.x/src/PsrLogAwareTrait.php) on separate branches.

In this repository:
* Added a dependency on the new `chromatic/psr-log-aware-trait` package.
* Widened `psr/log` version requirement to allow 3.x.
* Updated classes to use PsrLogAwareTrait in place of direct implementation.
* Updates to tests since psr/log v2 and v3 support fail on the php 7.x tests due to TestLogger.php::log() having a different file signature than the vendor supplied \Psr\Log\AbstractLogger. This [change](https://github.com/mpdf/mpdf/pull/1857/commits/637801aba0f869c51a83c615c70bd61072d575f0) allows for the `TestLogger` class to adapt its declaration based on its parent abstract class log() signature. Credit to @apotek and @greg-1-anderson on this one!