### PR TITLE
Feature/stop warning on broken lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ New features
 Bugfixes
 --------
 
+* Fixed warning when LI is not wrapped in parent UL/OL
 * Better exception message about fonts with MarkGlyphSets (Fix for #1408)
 * Updated Garuda font with fixed "k" character (Fix for #1440)
 * Testing and suppressing PNG file conversion errors

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -894,8 +894,15 @@ abstract class BlockTag extends Tag
 
 			$this->mpdf->listitem = [];
 
-			// Listitem-type
-			$this->mpdf->_setListMarker($currblk['list_style_type'], $currblk['list_style_image'], $currblk['list_style_position']);
+			// Sometimes LI's are created without the UL/OL tag around them. Bad HTML, but possible.
+			// With PHP 8.1 - this causes a WARNING to be thrown here, because the three array key's noted below do not get set up
+			// Some systems break execution with WARNING level errors - adding a check here to default this information
+			if (!isset($currblk['list_style_type']) || !isset($currblk['list_style_image']) || !isset($currblk['list_style_position'])) {
+				$this->mpdf->_setListMarker('disc', 'none', 'outside');
+			} else {
+				// Listitem-type
+				$this->mpdf->_setListMarker($currblk['list_style_type'], $currblk['list_style_image'], $currblk['list_style_position']);
+			}
 		}
 
 		// mPDF 6 Bidirectional formatting for block elements


### PR DESCRIPTION
Hello,

I was working on a Magento 2 site that has MPDF integrated to make PDF's out of product listings.

A good number of the product descriptions on the site have LI's without a parent UL/OL (bad HTML - I know - but will take time to fix and can't guarantee a future user won't do this again)

When the PDF is going through MPDF, the BlockTag class has an issue where a WARNING level error is thrown in this instance. The warning is that an array key doesn't exist -> list_style_type (and presumably list_style_image and list_style_position as well - just errors before those)

This pull adds a check to see if any of those are not set and calls _setListMarker with default values ('disc' for list_style_type, the defaults noted higher in the file for the others).

This prevents the WARNING from being thrown - allowing a system like Magento 2 (which stops script execution when a WARNING is thrown) to properly finish generating the PDF.

Adding a pull request as I thought this fix might be helpful for others.