### PR TITLE
Add check useDictionaryLBR before replace word boundary marker

### DIFF
--- a/src/Otl.php
+++ b/src/Otl.php
@@ -979,7 +979,7 @@ class Otl
 			// Shapers - KHMER & THAI & LAO - Replace Word boundary marker with U+200B
 			// Also TIBETAN (no shaper)
 			//=======================================================
-			if (($this->shaper == "K" || $this->shaper == "T" || $this->shaper == "L") || $scriptblock == Ucdn::SCRIPT_TIBETAN) {
+			if ($this->mpdf->useDictionaryLBR && ($this->shaper == "K" || $this->shaper == "T" || $this->shaper == "L") || $scriptblock == Ucdn::SCRIPT_TIBETAN) {
 				// Set up properties to insert a U+200B character
 				$newinfo = [];
 				//$newinfo[0] = array('general_category' => 1, 'bidi_type' => 14, 'group' => 'S', 'uni' => 0x200B, 'hex' => '0200B');


### PR DESCRIPTION
Add Flag useDictionaryLBR check before replace word boundary marker with U+200B 

Hello

I want to fix for some Thai font like TH Sarabun New (Standard Fonts for Thai Public Sectors) because it does not support with ZWSP (U+200B).

<img width="546" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/f3329595-1e44-4f9f-91c2-3f46e5438cc5">

The reason that I have to use OTL because some characters require processing before display.
without useOTL and "useDictionaryLBR" => false

<img width="546" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/47f11d82-e98a-44f7-bf8d-2d821624e157">

with "useOTL" => 0xFF and "useDictionaryLBR" => false

<img width="1043" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/6efd88f5-7bfd-4391-b885-3993a6b78fc7">

When I add flag "useDictionaryLBR" => false and edit Otl.php:351 for check before process $this->seaLineBreaking(); can fix this issue. See output like this picture below

<img width="495" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/52886e04-7984-4a87-8ba0-3668e350b41e">

Added a pull request as I think this edit might be helpful for other Thai people. and this a pull request can fix for issue #1272 

## Info

This line is have flag useDictionaryLBR before insert U+200B
In Otl.php: 982
<img width="1490" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/c3757569-7a5c-40ed-a3b4-af80f6504c89">

But this line isn't have flag useDictionaryLBR before insert U+200B
In Otl.php: 351
<img width="1490" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/a30dcd8e-fcce-4b69-b0ed-48a69a1a118e">

I want to add flag useDictionaryLBR check before insert U+200B. This can fix some thai font like Sarabun it does not support ZWSP (U+200B)
<img width="1490" alt="image" src="https://github.com/mpdf/mpdf/assets/13148290/fc5ae541-27bb-4850-8163-5dcbc19c0944">

## Version Info
- mpdf/mpdf: "8.1"
- PHP: "8.2.7"

Font: 
[THSarabunNew.zip](https://github.com/mpdf/mpdf/files/11966830/THSarabunNew.zip)

## This is a PHP code
```php
<?php
require __DIR__ . '/../src/vendor/autoload.php';

$defaultConfig = (new Mpdf\Config\ConfigVariables())->getDefaults();
$fontDirs = $defaultConfig['fontDir'];

$defaultFontConfig = (new Mpdf\Config\FontVariables())->getDefaults();
$fontData = $defaultFontConfig['fontdata'];

$mpdf = new \Mpdf\Mpdf([
            'mode' => 'utf-8',
            'orientation' => 'P',
            'tempDir' => '/tmp',
            'fontDir' => '../src/resources/fonts/',
            'fontdata' => $fontData + [
                    'thsarabunnew' => [
                        'R' => 'THSarabunNew.ttf',
                        'I' => 'THSarabunNew Italic.ttf',
                        'B' => 'THSarabunNew Bold.ttf',
                        'BI' => 'THSarabunNew BoldItalic.ttf',
                        'useOTL' => 0xFF
                    ]
                ],
            'default_font' => 'thsarabunnew',
            'default_font_size' => 16
]);

$html = '
<div>1. ทดสอบ ข้อความ</div>
<div>2. ทดสอบ ข้อความ</div>
<div>3. ทดสอบ ข้อความ</div>
<div>4. ทดสอบ ข้อความ</div>
<div>5. ทดสอบ ข้อความ</div>
<div>123/4 ถ.ทดสอบ ต.ทดสอบ อ.ทดสอบ จ.ทดสอบ 12345</div>
';

$mpdf->useDictionaryLBR = false;
$mpdf->WriteHTML($html);
$mpdf->Output();
?>
```
