### PR TITLE
fix "Undefined array key 1 & 2" notice in ImageProcessor.php

### DIFF
--- a/src/Image/ImageProcessor.php
+++ b/src/Image/ImageProcessor.php
@@ -310,7 +310,7 @@ class ImageProcessor implements \Psr\Log\LoggerAwareInterface
 								$b = $rgb & 0xFF;
 								if ($colspace === 'DeviceGray' && $b == $trns[0]) {
 									$alpha = 0;
-								} elseif ($r == $trns[0] && $g == $trns[1] && $b == $trns[2]) {
+								} elseif ($r == $trns[0] && (isset($trns[1]) && $g == $trns[1]) && (isset($trns[2]) && $b == $trns[2])) {
 									$alpha = 0;
 								} // ct==2
 								else {


### PR DESCRIPTION
Fixing an issue of  "Undefined array key 1 & 2" notice in ImageProcessor.php.
Link to the reported issue: https://app.glitchtip.com/evoludata/issues/2379941   || 
  https://app.glitchtip.com/evoludata/issues/2379942


```php
		$r = ($rgb >> 16) & 0xFF;
		$g = ($rgb >> 8) & 0xFF;
		$b = $rgb & 0xFF;
		if ($colspace === 'DeviceGray' && $b == $trns[0]) {
			$alpha = 0;
		} elseif ($r == $trns[0] && $g == $trns[1] && $b == $trns[2]) {
			$alpha = 0;
		} else { // ct==2
			$alpha = 255;
		}
		if ($alpha > 0) {
``` 