### PR TITLE
feat: Add PHP 8.3 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         operating-system: [ubuntu-latest, windows-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features
 ------------
 * Watermark text can now be colored using \Mpdf\Watermark DTO. \Mpdf\WatermarkImage DTO for images. (#1876)
 * Added support for `psr/http-message` v2 without dropping v1. (@markdorison, @apotek, @greg-1-anderson, @NigelCunningham #1907)
+* PHP 8.3 support in mPDF 8.2.1
 
 mPDF 8.1.x
 ===========================

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ PHP versions and extensions
 - `PHP 8.0` is supported since `mPDF v8.0.10`
 - `PHP 8.1` is supported as of `mPDF v8.0.13`
 - `PHP 8.2` is supported as of `mPDF v8.1.3`
+- `PHP 8.3` is supported as of `mPDF v8.2.1`
 
 PHP `mbstring` and `gd` extensions have to be loaded.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"docs": "http://mpdf.github.io"
 	},
 	"require": {
-		"php": "^5.6 || ^7.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+		"php": "^5.6 || ^7.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
 		"ext-gd": "*",
 		"ext-mbstring": "*",
 		"mpdf/psr-http-message-shim": "^1.0 || ^2.0",


### PR DESCRIPTION
Hey there :wave: 

I saw that there were already some issues tackled regarding PHP 8.3 compatibility and I wondered, why mpdf was not marked as compatible yet :slightly_smiling_face: 

If I missed something, please let me know. Otherwise it would be nice, if we could get a release, that is compatible with PHP 8.3 :rocket: 

