### PR TITLE
Fix PHP Notice Processing Font GPOS OTL Data

### DIFF
--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -3374,7 +3374,9 @@ class TTFontFile
 
 				$lg = [];
 				foreach ($langsys as $ft) {
-					$lg[$ft['LookupListIndex'][0]] = $ft;
+					if (isset($ft['LookupListIndex'][0])) {
+						$lg[ $ft['LookupListIndex'][0] ] = $ft;
+					}
 				}
 
 				// list of Lookups in order they need to be run i.e. order listed in Lookup table


### PR DESCRIPTION
This notice occurred when loading mPDF with the commercially-licensed Myriad Pro TTF font file. Because it isn't an open-source font, and I don't have another font that exhibits this behaviour, I haven't written a unit test for it.

If you have access to the font, the following snippet will generate the PHP notice when the font cache is being created (delete the font cache afterward to replicate consecutively):

```
<?php

use Mpdf\Mpdf;

require_once __DIR__ . '/vendor/autoload.php';

error_reporting(E_ALL);

$mpdf = new Mpdf([
	'fontDir' => [
		__DIR__ . '/ttfonts',
		__DIR__ . '/test-fonts',
	],
	'fontdata' => [
		'myriadpro' => [
			'R' => 'MyriadPro-Regular.ttf',
			'useOTL' => 0x80,

		]
	],
	'default_font' => 'myriadpro',
]);

$mpdf->WriteHTML( 'Test' );
$mpdf->Close();
```

The underlying issue was when reading the font's GPOS FeatureList table. In the case of Myriad Pro, it includes the "Size" feature, but has no data associated with it. mPDF expects [all features to have associated data in the form of a LookUpListIndex](https://github.com/mpdf/mpdf/blob/development/src/TTFontFile.php#L3377), even though a features [LookUpCount can be zero](https://github.com/mpdf/mpdf/blob/development/src/TTFontFile.php#L3355-L3357).

I gather this [font supported "Size" in the past, but it was replaced by the STAT table](https://learn.microsoft.com/en-us/typography/opentype/spec/features_pt#size) and the feature key was never fully removed.