### PR TITLE
Update Mpdf.php

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -18747,6 +18747,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					if (isset($this->OTLtags['Plus'])) {
 						$this->OTLtags['Plus'] = str_replace(['sups', 'subs'], '', $this->OTLtags['Plus']);
 					}
+					if (!isset($this->OTLtags['Plus'])) {
+						$this->OTLtags['Plus'] = '';
+					}
 					switch (strtoupper($v)) {
 						case 'SUPER':
 							$this->OTLtags['Plus'] .= ' sups';


### PR DESCRIPTION
Error:
The original code does not check if the variable `$this->OTLtags['Plus']` is initialized before manipulating it. This can cause an error if the variable has not been defined previously, resulting in an attempt to manipulate a non-existent variable and potentially generating a runtime error.

Proposed Fix:
We added a check to ensure that the variable `$this->OTLtags['Plus']` is initialized as an empty string before being used in the code. This is done with the following line of code added before the switch statement:

if (!isset($this->OTLtags['Plus'])) {
    $this->OTLtags['Plus'] = '';
}

This fix prevents errors related to manipulating an undefined variable, ensuring that the code functions correctly regardless of the initial state of the `$this->OTLtags['Plus']` variable.