### PR TITLE
Add support for page-break-before: avoid; and page-break-after: avoid; for <tr> elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features
 * Watermark text can now be colored using \Mpdf\Watermark DTO. \Mpdf\WatermarkImage DTO for images. (#1876)
 * Added support for `psr/http-message` v2 without dropping v1. (@markdorison, @apotek, @greg-1-anderson, @NigelCunningham #1907)
 * PHP 8.3 support in mPDF 8.2.1
+* Add support for `page-break-before: avoid;` and `page-break-after: avoid;` for tr elements inside tables
 
 mPDF 8.1.x
 ===========================

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22238,6 +22238,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						$extra = $table['max_cell_border_width']['B'] / 2;
 					}
 
+					// lookahead for pagebreak
+					$pagebreaklookahead = 1;
+					while (isset($table['pagebreak-before']) && isset($table['pagebreak-before'][$i + $pagebreaklookahead]) && $table['pagebreak-before'][$i + $pagebreaklookahead] == 'avoid') {
+						// pagebreak-after is mapped to pagebreak-before on i-1 in Tags/Tr.php
+						$pagebreaklookahead++;
+					}
 					if ($j == $startcol && ((($y + $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22244,7 +22244,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
 					}
-					if ($j == $startcol && ((($y + $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
+					if ($j == $startcol && ((($y + $pagebreaklookahead * $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;
 							$firstSpread = true;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22241,7 +22241,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					// lookahead for pagebreak
 					$pagebreaklookahead = 1;
 					while (isset($table['pagebreak-before']) && isset($table['pagebreak-before'][$i + $pagebreaklookahead]) && $table['pagebreak-before'][$i + $pagebreaklookahead] == 'avoid') {
-						// pagebreak-after is mapped to pagebreak-before on i-1 in Tags/Tr.php
+						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
 					}
 					if ($j == $startcol && ((($y + $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {

--- a/src/Tag/BlockTag.php
+++ b/src/Tag/BlockTag.php
@@ -247,7 +247,7 @@ abstract class BlockTag extends Tag
 		/* -- END CSS-PAGE -- */
 
 		// If page-box has changed AND/OR PAGE-BREAK-BEFORE
-		// mPDF 6 (uses $p - preview of properties so blklvl can be imcremented after page-break)
+		// mPDF 6 (uses $p - preview of properties so blklvl can be incremented after page-break)
 		if (!$this->mpdf->tableLevel && (($pagesel && (!$this->mpdf->page_box['current'] || $pagesel != $this->mpdf->page_box['current']))
 				|| (isset($p['PAGE-BREAK-BEFORE']) && $p['PAGE-BREAK-BEFORE']))) {
 			// mPDF 6 pagebreaktype

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -17,6 +17,17 @@ class Tr extends Tag
 		$this->mpdf->col = -1;
 		$properties = $this->cssManager->MergeCSS('TABLE', 'TR', $attr);
 
+		// write pagebreak markers into row list, so _tableWrite can respect it
+		if (isset($properties['PAGE-BREAK-BEFORE']) && strtoupper($properties['PAGE-BREAK-BEFORE']) === 'AVOID'
+			&& !$this->mpdf->ColActive && !$this->mpdf->keep_block_together && !isset($attr['PAGEBREAKAVOIDCHECKED'])) {
+			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['pagebreak-before'][$this->mpdf->row] = 'avoid';
+		}
+
+		if (isset($properties['PAGE-BREAK-AFTER']) && strtoupper($properties['PAGE-BREAK-AFTER']) === 'AVOID'
+			&& !$this->mpdf->ColActive && !$this->mpdf->keep_block_together && !isset($attr['PAGEBREAKAVOIDCHECKED'])) {
+			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['pagebreak-before'][$this->mpdf->row - 1] = 'avoid';
+		}
+
 		if (!$this->mpdf->simpleTables && (!isset($this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['borders_separate'])
 				|| !$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['borders_separate'])) {
 			if (!empty($properties['BORDER-LEFT'])) {

--- a/src/Tag/Tr.php
+++ b/src/Tag/Tr.php
@@ -25,7 +25,7 @@ class Tr extends Tag
 
 		if (isset($properties['PAGE-BREAK-AFTER']) && strtoupper($properties['PAGE-BREAK-AFTER']) === 'AVOID'
 			&& !$this->mpdf->ColActive && !$this->mpdf->keep_block_together && !isset($attr['PAGEBREAKAVOIDCHECKED'])) {
-			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['pagebreak-before'][$this->mpdf->row - 1] = 'avoid';
+			$this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['pagebreak-before'][$this->mpdf->row + 1] = 'avoid';
 		}
 
 		if (!$this->mpdf->simpleTables && (!isset($this->mpdf->table[$this->mpdf->tableLevel][$this->mpdf->tbctr[$this->mpdf->tableLevel]]['borders_separate'])

--- a/tests/Issues/Issue2004Test.php
+++ b/tests/Issues/Issue2004Test.php
@@ -8,6 +8,7 @@ class Issue2004Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 	public function testPdfTableBreakAvoid()
 	{
 		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
 		$html = '';
 		$itemsPerTwothirdsPage = 28;
 		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
@@ -17,10 +18,10 @@ class Issue2004Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 				$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
 			}
 		}
-		$this->mpdf->WriteHTML('<html><body><h1>Test</h1>
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
 		<table>'.$html.'</table>
 		</html>');
-		$this->assertEquals($this->mpdf->page, 3);
+		$this->assertEquals($mpdf->page, 3);
 	}
 
 }

--- a/tests/Issues/Issue2004Test.php
+++ b/tests/Issues/Issue2004Test.php
@@ -2,7 +2,7 @@
 
 namespace Issues;
 
-class Issue1003Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+class Issue2004Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 {
 
 	public function testPdfTableBreakAvoid()

--- a/tests/Issues/Issue2004Test.php
+++ b/tests/Issues/Issue2004Test.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Issues;
+
+class Issue1003Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfTableBreakAvoid()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$html = '';
+		$itemsPerTwothirdsPage = 28;
+		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
+			if ($i % $itemsPerTwothirdsPage == 0) {
+				$html .= '<tr style=""><td>groupheader</td></tr>';
+			} else {
+				$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
+			}
+		}
+		$this->mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<table>'.$html.'</table>
+		</html>');
+		$this->assertEquals($this->mpdf->page, 3);
+	}
+
+}

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -40,6 +40,24 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertMatchesRegularExpression('/\d+ 0 obj\n<<\n\/Producer \((.*?)\)\n\/CreationDate ' . $dateRegex . '\n\/ModDate ' . $dateRegex . '/', $output);
 	}
 
+	public function testPdfTableBreakAvoid() {
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$html = '';
+		$itemsPerTwothirdsPage = 28;
+		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
+			if ($i % $itemsPerTwothirdsPage == 0) {
+				$html .= '<tr style=""><td>groupheader</td></tr>';
+			} else {
+				$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
+			}
+		}
+		$this->mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<table>'.$html.'</table>
+		</html>');
+		$this->mpdf->Output('/tmp/ergebnis.pdf');
+		$this->assertEquals($this->mpdf->page, 3);
+	}
+
 	public function testAdjustHtmlTooLargeHtml()
 	{
 		$this->expectException(\Mpdf\MpdfException::class);

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -40,24 +40,6 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertMatchesRegularExpression('/\d+ 0 obj\n<<\n\/Producer \((.*?)\)\n\/CreationDate ' . $dateRegex . '\n\/ModDate ' . $dateRegex . '/', $output);
 	}
 
-	public function testPdfTableBreakAvoid()
-	{
-		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
-		$html = '';
-		$itemsPerTwothirdsPage = 28;
-		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
-			if ($i % $itemsPerTwothirdsPage == 0) {
-				$html .= '<tr style=""><td>groupheader</td></tr>';
-			} else {
-				$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
-			}
-		}
-		$this->mpdf->WriteHTML('<html><body><h1>Test</h1>
-		<table>'.$html.'</table>
-		</html>');
-		$this->assertEquals($this->mpdf->page, 3);
-	}
-
 	public function testAdjustHtmlTooLargeHtml()
 	{
 		$this->expectException(\Mpdf\MpdfException::class);

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -45,8 +45,7 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
 		$html = '';
 		$itemsPerTwothirdsPage = 28;
-		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++)
-		{
+		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
 			if ($i % $itemsPerTwothirdsPage == 0) {
 				$html .= '<tr style=""><td>groupheader</td></tr>';
 			} else {

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -40,11 +40,13 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertMatchesRegularExpression('/\d+ 0 obj\n<<\n\/Producer \((.*?)\)\n\/CreationDate ' . $dateRegex . '\n\/ModDate ' . $dateRegex . '/', $output);
 	}
 
-	public function testPdfTableBreakAvoid() {
+	public function testPdfTableBreakAvoid()
+	{
 		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
 		$html = '';
 		$itemsPerTwothirdsPage = 28;
-		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++) {
+		for ($i = 0; $i < 3*$itemsPerTwothirdsPage; $i++)
+		{
 			if ($i % $itemsPerTwothirdsPage == 0) {
 				$html .= '<tr style=""><td>groupheader</td></tr>';
 			} else {

--- a/tests/Mpdf/MpdfTest.php
+++ b/tests/Mpdf/MpdfTest.php
@@ -54,7 +54,6 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->mpdf->WriteHTML('<html><body><h1>Test</h1>
 		<table>'.$html.'</table>
 		</html>');
-		$this->mpdf->Output('/tmp/ergebnis.pdf');
 		$this->assertEquals($this->mpdf->page, 3);
 	}
 


### PR DESCRIPTION
This code is sponsored by Launix (https://launix.de) and released under GPL 2.0

In order to not get into fork hell, we appreciate a fast release of the feature in the next minor version.