### PR TITLE
Replace entities with characters for <barcode code="" />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ New features
 * PHP 8.3 support in mPDF 8.2.1
 * Add support for `page-break-before: avoid;` and `page-break-after: avoid;` for tr elements inside tables
 
+Bugfixes
+--------
+
+* Replace character entities with characters when processing the `code` attribute in the `<barcode />` tag
+
 mPDF 8.1.x
 ===========================
 

--- a/src/Tag/BarCode.php
+++ b/src/Tag/BarCode.php
@@ -33,7 +33,7 @@ class BarCode extends Tag
 			$objattr['border_bottom']['w'] = 0;
 			$objattr['border_left']['w'] = 0;
 			$objattr['border_right']['w'] = 0;
-			$objattr['code'] = $attr['CODE'];
+			$objattr['code'] = htmlspecialchars_decode($attr['CODE']);
 
 			if (isset($attr['TYPE'])) {
 				$objattr['btype'] = strtoupper(trim($attr['TYPE']));

--- a/tests/Issues/Issue1760Test.php
+++ b/tests/Issues/Issue1760Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\BaseMpdfTest;
+use Mpdf\HTMLParserMode;
+use Mpdf\Mpdf;
+
+class Issue1760Test extends BaseMpdfTest
+{
+	public function testGenerateQrCodeWithDecodedEntities()
+	{
+		$originalCode = '{"t":1,"d":5}';
+		$this->mpdf->WriteHTML('<barcode code="'.htmlspecialchars($originalCode).'" type="qr"/>', HTMLParserMode::DEFAULT_MODE, true, false);
+
+		$barcodeObj = $this->mpdf->_getObjAttr($this->mpdf->textbuffer[0][0]);
+
+		$this->assertSame($originalCode, $barcodeObj['code']);
+	}
+}


### PR DESCRIPTION
Per the HTML specification, [CDATA should have encoded entities replaced with the decoded characters](https://www.w3.org/TR/html401/types.html#type-cdata). This change allows QR codes (or any other barcodes) to be generated with double quote characters, provided they are first encoded to `&quot;`  – usually using `htmlspecialchars()`.

It isn't possible to workaround the problem by switching the attribute delimiter to single quotes `<barcode code='{"t":1,"d":5}' type="qr"/>`. This is because [mPDF silently converts single quote to double quotes when processing tag attributes](https://github.com/mpdf/mpdf/blob/development/src/Mpdf.php#L13861-L13862), without taking into account the contents of the attribute (something to tackle at a later date).

Resolves #1761

