### PR TITLE
Fix error message property in Mpdf.php

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -26147,7 +26147,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				$a = @iconv('UTF-8', 'UTF-8', $html);
 				$error = error_get_last();
 				if ($error && $error['message'] === 'iconv(): Detected an illegal character in input string') {
-					throw new \Mpdf\MpdfException('Invalid input characters. Did you set $mpdf->in_charset properly?');
+					throw new \Mpdf\MpdfException('Invalid input characters. Did you set $mpdf->charset_in properly?');
 				}
 
 				$pos = $start = strlen($a);


### PR DESCRIPTION
Exception thrown on invalid UTF-8 input asks about property `in_charset`. The actual property name is `charset_in`:

https://github.com/cebe/mpdf/blob/dfb5346e2e7ffdb4b0f6d588e94629ad52fb3466/src/Mpdf.php#L529