### PR TITLE
Fix debugfont mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes
 --------
 
 * Replace character entities with characters when processing the `code` attribute in the `<barcode />` tag
+* Correctly read open type data from ttf files when `debugfont` is enabled (#2053, @MarcelBolten)
 
 mPDF 8.1.x
 ===========================

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -89,6 +89,14 @@ class Cache
 		return unlink($this->getFilePath($filename));
 	}
 
+	public function clear()
+	{
+		$currentCleanupInterval = $this->cleanupInterval;
+		$this->cleanupInterval = -1; // not 0 as just created files would not be deleted
+		$this->clearOld();
+		$this->cleanupInterval = $currentCleanupInterval;
+	}
+
 	public function clearOld()
 	{
 		$iterator = new DirectoryIterator($this->basePath);

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -952,6 +952,7 @@ class TTFontFile
 			if ($ver_maj < 1 || $ver_maj > 4) {
 				throw new \Mpdf\Exception\FontException(sprintf('Error loading font: Unknown post table version %s', $ver_maj));
 			}
+			$this->skip(2); // minor version
 		} else {
 			$this->skip(4);
 		}
@@ -980,7 +981,7 @@ class TTFontFile
 			if ($ver_maj != 1) {
 				throw new \Mpdf\Exception\FontException(sprintf('Error loading font: Unknown hhea table version %s', $ver_maj));
 			}
-			$this->skip(28);
+			$this->skip(30);
 		} else {
 			$this->skip(32);
 		}
@@ -1004,6 +1005,7 @@ class TTFontFile
 			if ($ver_maj != 1) {
 				throw new \Mpdf\Exception\FontException(sprintf('Error loading font: Unknown maxp table version %s', $ver_maj));
 			}
+			$this->skip(2); // minor version
 		} else {
 			$this->skip(4);
 		}

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -796,25 +796,25 @@ class TTFontFile
 			}
 			$this->fontRevision = $this->read_ushort() . $this->read_ushort();
 
-			$this->skip(4);
+			$this->skip(4); // checksumAdjustment
 			$magic = $this->read_ulong();
 			if ($magic !== 0x5F0F3CF5) {
 				throw new \Mpdf\Exception\FontException('Error loading font: Invalid head table magic ' . $magic);
 			}
-			$this->skip(2);
+			$this->skip(2); // flags
 		} else {
 			$this->skip(18);
 		}
 		$this->unitsPerEm = $unitsPerEm = $this->read_ushort();
 		$scale = 1000 / $unitsPerEm;
-		$this->skip(16);
+		$this->skip(16); // created and modified, each 8 bytes
 		$xMin = $this->read_short();
 		$yMin = $this->read_short();
 		$xMax = $this->read_short();
 		$yMax = $this->read_short();
 		$this->bbox = [($xMin * $scale), ($yMin * $scale), ($xMax * $scale), ($yMax * $scale)];
 
-		$this->skip(3 * 2);
+		$this->skip(3 * 2); // macStyle, lowestRecPPEM, fontDirectionHint
 		$indexToLocFormat = $this->read_ushort();
 		$glyphDataFormat = $this->read_ushort();
 		if ($glyphDataFormat != 0) {
@@ -824,7 +824,7 @@ class TTFontFile
 		// hhea metrics table
 		if (isset($this->tables["hhea"])) {
 			$this->seek_table("hhea");
-			$this->skip(4);
+			$this->skip(4); // majorVersion, minorVersion each ushort
 			$hheaAscender = $this->read_short();
 			$hheaDescender = $this->read_short();
 			$hheaLineGap = $this->read_short();
@@ -840,15 +840,15 @@ class TTFontFile
 		if (isset($this->tables["OS/2"])) {
 			$this->seek_table("OS/2");
 			$version = $this->read_ushort();
-			$this->skip(2);
+			$this->skip(2); // xAvgCharWidth
 			$usWeightClass = $this->read_ushort();
-			$this->skip(2);
+			$this->skip(2); // usWidthClass
 			$fsType = $this->read_ushort();
 			if ($fsType == 0x0002 || ($fsType & 0x0300) != 0) {
 				$this->restrictedUse = true;
 			}
 
-			$this->skip(16);
+			$this->skip(16); // ySubscript values, ySuperscript values, 2 × 4 × short
 			$yStrikeoutSize = $this->read_short();
 			$yStrikeoutPosition = $this->read_short();
 			$this->strikeoutSize = ($yStrikeoutSize * $scale);
@@ -865,10 +865,10 @@ class TTFontFile
 				$this->panose[] = ord($panose[$p]);
 			}
 
-			$this->skip(20);
+			$this->skip(20); // ulUnicodeRange1-4, achVendID
 			$fsSelection = $this->read_ushort();
 			$use_typo_metrics = (($fsSelection & 0x80) === 0x80); // bit#7 = USE_TYPO_METRICS
-			$this->skip(4);
+			$this->skip(4); // first/lastCharIndex
 
 			$sTypoAscender = $this->read_short();
 			$sTypoDescender = $this->read_short();
@@ -894,7 +894,7 @@ class TTFontFile
 			}
 
 			if ($version > 1) {
-				$this->skip(8);
+				$this->skip(8); // ulCodePageRange1/2
 				$sxHeight = $this->read_short();
 				$this->xHeight = ($sxHeight * $scale);
 				$sCapHeight = $this->read_short();
@@ -1011,7 +1011,7 @@ class TTFontFile
 
 		// cmap - Character to glyph index mapping table
 		$cmap_offset = $this->seek_table('cmap');
-		$this->skip(2);
+		$this->skip(2); // version
 		$cmapTableCount = $this->read_ushort();
 		$unicode_cmap_offset = 0;
 		for ($i = 0; $i < $cmapTableCount; $i++) {
@@ -1061,7 +1061,7 @@ class TTFontFile
 			$this->seek($unicode_cmap_offset + 4);
 			$length = $this->read_ulong();
 			$limit = $unicode_cmap_offset + $length;
-			$this->skip(4);
+			$this->skip(4); // language
 
 			$nGroups = $this->read_ulong();
 
@@ -1442,7 +1442,7 @@ class TTFontFile
 
 		$ffeats = [];
 		$gsub_offset = $this->seek_table('GSUB');
-		$this->skip(4);
+		$this->skip(4); // major minor version
 		$ScriptList_offset = $gsub_offset + $this->read_ushort();
 		$FeatureList_offset = $gsub_offset + $this->read_ushort();
 		$LookupList_offset = $gsub_offset + $this->read_ushort();
@@ -1598,10 +1598,10 @@ class TTFontFile
 				$PosFormat = $this->read_ushort();
 
 				if ($GSLookup[$i]['Type'] == 5 && $PosFormat == 3) {
-					$this->skip(4);
+					$this->skip(4); // glyphCount + seqLookupCount
 				} elseif ($GSLookup[$i]['Type'] == 6 && $PosFormat == 3) {
 					$BacktrackGlyphCount = $this->read_ushort();
-					$this->skip(2 * $BacktrackGlyphCount + 2);
+					$this->skip(2 * $BacktrackGlyphCount + 2); // backtrackCoverageOffsets + inputGlyphCount
 				}
 
 				// NB Coverage only looks at glyphs for position 1 (i.e. 5.3 and 6.3)	// NEEDS TO READ ALL ********************
@@ -4653,17 +4653,17 @@ class TTFontFile
 		$this->seek($unicode_cmap_offset + 2);
 		$length = $this->read_ushort();
 		$limit = $unicode_cmap_offset + $length;
-		$this->skip(2);
+		$this->skip(2); // language
 
 		$segCount = $this->read_ushort() / 2;
-		$this->skip(6);
+		$this->skip(6); // searchRange, entrySelector, rangeShift
 		$endCount = [];
 
 		for ($i = 0; $i < $segCount; $i++) {
 			$endCount[] = $this->read_ushort();
 		}
 
-		$this->skip(2);
+		$this->skip(2); // reservedPad
 		$startCount = [];
 
 		for ($i = 0; $i < $segCount; $i++) {

--- a/src/TTFontFile.php
+++ b/src/TTFontFile.php
@@ -815,8 +815,8 @@ class TTFontFile
 		$this->bbox = [($xMin * $scale), ($yMin * $scale), ($xMax * $scale), ($yMax * $scale)];
 
 		$this->skip(3 * 2); // macStyle, lowestRecPPEM, fontDirectionHint
-		$indexToLocFormat = $this->read_ushort();
-		$glyphDataFormat = $this->read_ushort();
+		$indexToLocFormat = $this->read_short();
+		$glyphDataFormat = $this->read_short();
 		if ($glyphDataFormat != 0) {
 			throw new \Mpdf\Exception\FontException(sprintf('Error loading font: Unknown glyph data format %s', $glyphDataFormat));
 		}
@@ -986,7 +986,7 @@ class TTFontFile
 			$this->skip(32);
 		}
 
-		$metricDataFormat = $this->read_ushort();
+		$metricDataFormat = $this->read_short();
 
 		if ($metricDataFormat != 0) {
 			throw new \Mpdf\Exception\FontException(sprintf('Error loading font: Unknown horizontal metric data format "%s"', $metricDataFormat));
@@ -1689,14 +1689,14 @@ class TTFontFile
 				} // LookupType 2: Multiple Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 2) {
 					$Lookup[$i]['Subtable'][$c]['CoverageTableOffset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
-					$Lookup[$i]['Subtable'][$c]['SequenceCount'] = $SequenceCount = $this->read_short();
+					$Lookup[$i]['Subtable'][$c]['SequenceCount'] = $SequenceCount = $this->read_ushort();
 					for ($s = 0; $s < $SequenceCount; $s++) {
-						$Lookup[$i]['Subtable'][$c]['Sequences'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['Sequences'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
 					}
 					for ($s = 0; $s < $SequenceCount; $s++) {
 						// Sequence Tables
 						$this->seek($Lookup[$i]['Subtable'][$c]['Sequences'][$s]['Offset']);
-						$Lookup[$i]['Subtable'][$c]['Sequences'][$s]['GlyphCount'] = $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['Sequences'][$s]['GlyphCount'] = $this->read_ushort();
 						for ($g = 0; $g < $Lookup[$i]['Subtable'][$c]['Sequences'][$s]['GlyphCount']; $g++) {
 							$Lookup[$i]['Subtable'][$c]['Sequences'][$s]['SubstituteGlyphID'][] = $this->read_ushort();
 						}
@@ -1704,15 +1704,15 @@ class TTFontFile
 				} // LookupType 3: Alternate Forms
 				elseif ($Lookup[$i]['Type'] == 3) {
 					$Lookup[$i]['Subtable'][$c]['CoverageTableOffset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
-					$Lookup[$i]['Subtable'][$c]['AlternateSetCount'] = $AlternateSetCount = $this->read_short();
+					$Lookup[$i]['Subtable'][$c]['AlternateSetCount'] = $AlternateSetCount = $this->read_ushort();
 					for ($s = 0; $s < $AlternateSetCount; $s++) {
-						$Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
 					}
 
 					for ($s = 0; $s < $AlternateSetCount; $s++) {
 						// AlternateSet Tables
 						$this->seek($Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['Offset']);
-						$Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['GlyphCount'] = $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['GlyphCount'] = $this->read_ushort();
 						for ($g = 0; $g < $Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['GlyphCount']; $g++) {
 							$Lookup[$i]['Subtable'][$c]['AlternateSets'][$s]['SubstituteGlyphID'][] = $this->read_ushort();
 						}
@@ -1720,14 +1720,14 @@ class TTFontFile
 				} // LookupType 4: Ligature Substitution Subtable
 				elseif ($Lookup[$i]['Type'] == 4) {
 					$Lookup[$i]['Subtable'][$c]['CoverageTableOffset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
-					$Lookup[$i]['Subtable'][$c]['LigSetCount'] = $LigSetCount = $this->read_short();
+					$Lookup[$i]['Subtable'][$c]['LigSetCount'] = $LigSetCount = $this->read_ushort();
 					for ($s = 0; $s < $LigSetCount; $s++) {
-						$Lookup[$i]['Subtable'][$c]['LigSet'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['LigSet'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
 					}
 					for ($s = 0; $s < $LigSetCount; $s++) {
 						// LigatureSet Tables
 						$this->seek($Lookup[$i]['Subtable'][$c]['LigSet'][$s]['Offset']);
-						$Lookup[$i]['Subtable'][$c]['LigSet'][$s]['LigCount'] = $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['LigSet'][$s]['LigCount'] = $this->read_ushort();
 						for ($g = 0; $g < $Lookup[$i]['Subtable'][$c]['LigSet'][$s]['LigCount']; $g++) {
 							$Lookup[$i]['Subtable'][$c]['LigSet'][$s]['LigatureOffset'][$g] = $Lookup[$i]['Subtable'][$c]['LigSet'][$s]['Offset'] + $this->read_ushort();
 						}
@@ -1748,14 +1748,14 @@ class TTFontFile
 					// Format 1: Context Substitution
 					if ($SubstFormat == 1) {
 						$Lookup[$i]['Subtable'][$c]['CoverageTableOffset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
-						$Lookup[$i]['Subtable'][$c]['SubRuleSetCount'] = $SubRuleSetCount = $this->read_short();
+						$Lookup[$i]['Subtable'][$c]['SubRuleSetCount'] = $SubRuleSetCount = $this->read_ushort();
 						for ($s = 0; $s < $SubRuleSetCount; $s++) {
-							$Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_short();
+							$Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['Offset'] = $Lookup[$i]['Subtable'][$c]['Offset'] + $this->read_ushort();
 						}
 						for ($s = 0; $s < $SubRuleSetCount; $s++) {
 							// SubRuleSet Tables
 							$this->seek($Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['Offset']);
-							$Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['SubRuleCount'] = $this->read_short();
+							$Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['SubRuleCount'] = $this->read_ushort();
 							for ($g = 0; $g < $Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['SubRuleCount']; $g++) {
 								$Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['SubRuleOffset'][$g] = $Lookup[$i]['Subtable'][$c]['SubRuleSet'][$s]['Offset'] + $this->read_ushort();
 							}

--- a/tests/Mpdf/ConfigurationTest.php
+++ b/tests/Mpdf/ConfigurationTest.php
@@ -24,7 +24,7 @@ class ConfigurationTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 
 		$this->assertSame('1.5', $mpdf->pdf_version);
 		$this->assertTrue($mpdf->autoPadding);
-		$this->assertObjectNotHasAttribute('nonexisting_key', $mpdf);
+		$this->assertObjectNotHasProperty('nonexisting_key', $mpdf);
 	}
 
 	public function testFontSettings()

--- a/tests/Mpdf/TTFontFileTest.php
+++ b/tests/Mpdf/TTFontFileTest.php
@@ -11,6 +11,8 @@ class TTFontFileTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 	 */
 	protected $ttf;
 
+	protected $tmpPath;
+
 	/**
 	 * @throws MpdfException
 	 */
@@ -18,12 +20,24 @@ class TTFontFileTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 	{
 		parent::set_up();
 
+		$this->tmpPath = __DIR__ . '/tmp/mpdf/ttfontdata';
+
 		$this->ttf = new TTFontFile(
 			new FontCache(
-				new Cache(__DIR__ . '/tmp/mpdf/ttfontdata')
+				new Cache($this->tmpPath)
 			),
 			'win'
 		);
+	}
+
+	/**
+	 * tearDown
+	 */
+	public function tear_down()
+	{
+		parent::tear_down();
+
+		(new Cache($this->tmpPath))->clear();
 	}
 
 	/**
@@ -37,5 +51,17 @@ class TTFontFileTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->ttf->getMetrics(__DIR__ . '/../data/ttf/NotoSans-Regular.ttf', (string) time(), 0, false, false, 0xFF);
 		$this->assertSame('NotoSans-Regular', $this->ttf->fullName);
 	}
+	/**
+	 * Verify fonts can be successfully parsed when useOTL is enabled and debugfont is enabled, without throwing any PHP notices/warnings
+	 */
+	public function testGetMetricWithOtlAndFontdebug()
+	{
+		(new Cache($this->tmpPath))->clear();
+		$this->ttf->getMetrics(__DIR__ . '/../data/ttf/Poppins-Regular.ttf', (string) time(), 0, true, false, 0xFF);
+		$this->assertSame('Poppins-Regular', $this->ttf->fullName);
 
+		(new Cache($this->tmpPath))->clear();
+		$this->ttf->getMetrics(__DIR__ . '/../data/ttf/NotoSans-Regular.ttf', (string) time(), 0, true, false, 0xFF);
+		$this->assertSame('NotoSans-Regular', $this->ttf->fullName);
+	}
 }


### PR DESCRIPTION
If debugfont mode is enabled while using a font that uses OTL features (useOTL is enabled) mpdf throws ```Mpdf\Exception\FontException: Error loading font: Number of horizontal metrics is 0```.
This exception is triggered in `TTFontFile.php#L988-992`

https://github.com/mpdf/mpdf/blob/7bcfd71a56aa63612188b1ff8211d30ca667a26d/src/TTFontFile.php#L988-L992

as can be reproduced with the modified test in the first commit (f15253cf54845772303db2cdebf9b8a0b451705f) of this PR.

To reliably reproduce this observation not only with the call of `getMetrics()` in the test but while using mpdf, the font cache needs to be empty in order for the error-triggering code to be executed.

To fix this bug I went over all the `skip()` calls in `TTFontFile.php` and annotated the majority of them with the descriptor (commit 8569ffa1be3b199b4b3d9ea5cc598a4ddd12a877) as provided by the [OpenType Specification Version 1.9.1](https://learn.microsoft.com/en-us/typography/opentype/spec/). This revealed that 3 times 2 bytes were not skipped in debugfont mode (commit 19eb790e91b24b2bb87e9fc03291f27079613e09) as already identified earlier (https://github.com/mpdf/mpdf/issues/674#issuecomment-423321799).

Additionally, in some places font data was wrongly read as ushort (16 bit unsigned integer) or short (16 bit signed integer) according to version 1.9.1 of the OpenType specification. This has been addressed in commit 10e2c0e4af468c6dc4f8070ab340760982d9b25e although there should be very rare cases where it would manifest as an error considering the usual data amount found in open type font files and the range that ushort and short cover (compare `0 to 65535` to `-32768 to 32767` respectively).

Finally, the deprecation warning of PHPunit was addressed (`assertObjectNotHasAttribute()` -> `assertObjectNotHasProperty()`).