### PR TITLE
Be more graceful with faulty HTML (created from famous email clients) which are interpreted by all browsers gracefully, too

### DIFF
--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -70,6 +70,7 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 				break;
 
 			case '%':
+			case '%%': // Issue2051
 				if ($fontsize && $usefontsize) {
 					$size *= $fontsize / 100;
 				} else {

--- a/tests/Issues/Issue2051Test.php
+++ b/tests/Issues/Issue2051Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Issues;
+
+class Issue2051Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfWithDoublePercent()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
+		$html = '';
+		for ($i = 0; $i < 10; $i++) {
+			$html .= 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
+		}
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<div style="width: 100%%;">'.$html.'</div>
+		</html>');
+
+		// without the bugfix, it would produce 10 pages, with the bugfix: 2
+		$this->assertEquals($mpdf->page, 2);
+	}
+
+}


### PR DESCRIPTION
A famous email client creates quotations with `<blockquote style="width: 100%%">`. This is faulty CSS however all browsers I tested interpreted %% as % but not as px. Mpdf however defaults to "px" interpretation which leads to 100px wide blockquotes which in consequence creates PDF documents with a very small stripe of text, lots of line breaks and a large number of pages.

So we should mimic the browser's behaviour and interpret CSS measurements with %% as unit as percent rather than pixels.
