### PR TITLE
refactor: curl_close since PHP 8.0 has no effect

### DIFF
--- a/src/Http/CurlHttpClient.php
+++ b/src/Http/CurlHttpClient.php
@@ -92,7 +92,9 @@ class CurlHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAware
 				throw new \Mpdf\MpdfException($message);
 			}
 
-			curl_close($ch);
+			if (\PHP_VERSION_ID < 80000) {
+            	curl_close($ch);
+        	}
 
 			return $response;
 		}
@@ -106,12 +108,16 @@ class CurlHttpClient implements \Mpdf\Http\ClientInterface, \Psr\Log\LoggerAware
 				throw new \Mpdf\MpdfException($message);
 			}
 
-			curl_close($ch);
+			if (\PHP_VERSION_ID < 80000) {
+            	curl_close($ch);
+        	}
 
 			return $response->withStatus($info['http_code']);
 		}
 
-		curl_close($ch);
+		if (\PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
 		return $response
 			->withStatus($info['http_code'])

--- a/utils/image_details.php
+++ b/utils/image_details.php
@@ -592,7 +592,9 @@ function file_get_contents_by_curl($url, &$data)
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
 	$data = curl_exec($ch);
-	curl_close($ch);
+	if (\PHP_VERSION_ID < 80000) {
+    	curl_close($ch);
+    }
 }
 
 


### PR DESCRIPTION
Deprecated on PHP 8.5 

Reference:
- https://github.com/mpdf/mpdf/actions/runs/17035895100/job/48288185137
- https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion
