### PR TITLE
Cache: Inherit Parent Directory Permissions

### DIFF
--- a/tests/Mpdf/CacheTest.php
+++ b/tests/Mpdf/CacheTest.php
@@ -7,6 +7,7 @@ class CacheTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 {
 	protected $basePath;
 	protected $oldTmpMode;
+	protected $oldUmask;
 
 	public function __construct($name = null, array $data = [], $dataName = '')
 	{
@@ -26,12 +27,14 @@ class CacheTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 
 		$dir = $this->path("tmp");
 		$this->oldTmpMode = fileperms($dir);
+		$this->oldUmask = umask(0);
 		chmod($dir, 0777);
 	}
 
 	protected function tear_down()
 	{
 		chmod($this->path("tmp"), $this->oldTmpMode);
+		umask($this->oldUmask);
 
 		parent::tear_down();
 	}
@@ -92,6 +95,43 @@ class CacheTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 						 "tmp/test4",
 					 ) as $subdir) {
 				$this->assertEquals(0777, fileperms($this->path($subdir)) & 0777);
+			}
+		} finally {
+			@rmdir($dir);
+			@rmdir($this->path("tmp/test4/subdir"));
+			@rmdir($this->path("tmp/test4"));
+		}
+	}
+
+	public function testCreatedDirectoryInheritsParentPermissions()
+	{
+		chmod($this->path("tmp"), 0755);
+
+		$dir = $this->path("tmp/test2");
+
+		try {
+			new Cache($dir);
+
+			$this->assertEquals(0755, fileperms($dir) & 0755);
+		} finally {
+			@rmdir($dir);
+		}
+	}
+
+	public function testRecursivelyCreatedDirectoriesInheritsParentPermissions()
+	{
+		chmod($this->path("tmp"), 0750);
+		$dir = $this->path("tmp/test4/subdir/subdir2");
+
+		try {
+			new Cache($dir);
+
+			foreach (array(
+				"tmp/test4/subdir/subdir2",
+				"tmp/test4/subdir",
+				"tmp/test4",
+			) as $subdir) {
+				$this->assertEquals(0750, fileperms($this->path($subdir)) & 0750);
 			}
 		} finally {
 			@rmdir($dir);


### PR DESCRIPTION
With web hosts taking a proactive approach to security, the 777 directory permissions used by the cache was creating problems for users (e.g. hosts continually sending security alerts).

To resolve the problem, this PR attempts to get the permissions used on an existing parent directory and applies that to the newly-created cache directory/ies.

Note: the `createBasePath` recursion is no longer required because `createDirectory` has been updated to use `mkdir(..., ..., $ recursive)` argument.