### PR TITLE
Fix page-break: avoid for oversized blocks by splitting at page limit

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22246,6 +22246,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
 					}
+					// corner case: if the pagelookahead is bigger than the pagesize, we break anyway, so fill up the page
+					if ($pagebreaklookahead * $maxrowheight + $extra > $pagetrigger + 0.001) {
+						$pagebreaklookahead = 1;
+					}
+					// if we exceed page boundaries: restart table on next page before printing the line
 					if ($j == $startcol && ((($y + $pagebreaklookahead * $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;

--- a/tests/Issues/Issue2013Test.php
+++ b/tests/Issues/Issue2013Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Issues;
+
+class Issue2013Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfTableBreakAvoidTooMuch()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
+		$html = '';
+		$itemsPerTwothirdsPage = 28;
+		for ($i = 0; $i < 5*$itemsPerTwothirdsPage; $i++) {
+			$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
+		}
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<table>'.$html.'</table>
+		</html>');
+
+		// without the bugfix, it would produce 98 pages, with the bugfix: 7
+		$this->assertEquals($mpdf->page, 7);
+	}
+
+}


### PR DESCRIPTION
When a block with `page-break: avoid;` is too large to fit on a single page, mPDF used to paginate it one line per page, which is unwanted. This change detects unavoidable oversized “avoid” blocks and forces a break exactly at the page boundary to produce sensible pagination.

- Adjust pagination to split oversized avoid blocks at page limits
- Add unit test covering the oversized avoid-block scenario

Note: Merge/revert noise has been squashed; no net change for the earlier Outlook blockquote styling experiment (added then reverted).