### PR TITLE
Add return type hint annotations to avoid Symfony deprecation notices

### DIFF
--- a/src/PageBox.php
+++ b/src/PageBox.php
@@ -17,6 +17,9 @@ class PageBox implements \ArrayAccess
 		];
 	}
 
+    /**
+     * @return void
+     */
 	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
@@ -27,12 +30,18 @@ class PageBox implements \ArrayAccess
 		$this->container[$offset] = $value;
 	}
 
+    /**
+     * @return bool
+     */
 	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return array_key_exists($offset, $this->container);
 	}
 
+    /**
+     * @return void
+     */
 	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
@@ -43,6 +52,9 @@ class PageBox implements \ArrayAccess
 		$this->container[$offset] = null;
 	}
 
+    /**
+     * @return mixed
+     */
 	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{


### PR DESCRIPTION
We can't add the real type hints because mpdf still supports older php versions, but we can add the phpdocs with the expected return types, this should be enough to remove the deprecation warnings.

This should fix https://github.com/mpdf/mpdf/issues/2014