### PR TITLE
Add zero_pad_page_numbers option to support zero padded {PAGENO}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features
 * Added support for `psr/http-message` v2 without dropping v1. (@markdorison, @apotek, @greg-1-anderson, @NigelCunningham #1907)
 * PHP 8.3 support in mPDF 8.2.1
 * Add support for `page-break-before: avoid;` and `page-break-after: avoid;` for tr elements inside tables
+* Added `zero_pad_page_numbers` option to allow zero-padded page numbers in headers, footers, and body.
 
 Bugfixes
 --------

--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -2,10 +2,10 @@
 
 namespace Mpdf\Config;
 
-use Mpdf\Ucdn;
 use Mpdf\Css\DefaultCss;
 use Mpdf\Language\LanguageToFont;
 use Mpdf\Language\ScriptToLanguage;
+use Mpdf\Ucdn;
 
 class ConfigVariables
 {

--- a/src/Config/ConfigVariables.php
+++ b/src/Config/ConfigVariables.php
@@ -2,10 +2,10 @@
 
 namespace Mpdf\Config;
 
+use Mpdf\Ucdn;
 use Mpdf\Css\DefaultCss;
 use Mpdf\Language\LanguageToFont;
 use Mpdf\Language\ScriptToLanguage;
-use Mpdf\Ucdn;
 
 class ConfigVariables
 {
@@ -48,6 +48,8 @@ class ConfigVariables
 			'pagenumSuffix' => '',
 			'nbpgPrefix' => '',
 			'nbpgSuffix' => '',
+			// 1 = "1", 2 = "01", 3 = "001", etc.
+			'zero_pad_page_numbers' => 1,
 			// 1:Decimal, A:uppercase alphabetic etc. (as for list-style shorthands)
 			'defaultPageNumStyle' => '1',
 

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2,16 +2,16 @@
 
 namespace Mpdf;
 
-use Mpdf\Conversion;
-use Mpdf\QrCode;
 use Mpdf\Config\ConfigVariables;
 use Mpdf\Config\FontVariables;
+use Mpdf\Conversion;
 use Mpdf\Css\Border;
 use Mpdf\Css\TextVars;
-use Mpdf\Fonts\MetricsGenerator;
 use Mpdf\Log\Context as LogContext;
+use Mpdf\Fonts\MetricsGenerator;
 use Mpdf\Output\Destination;
 use Mpdf\PsrLogAwareTrait\MpdfPsrLogAwareTrait;
+use Mpdf\QrCode;
 use Mpdf\Utils\Arrays;
 use Mpdf\Utils\NumericString;
 use Mpdf\Utils\UtfString;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -2,16 +2,16 @@
 
 namespace Mpdf;
 
+use Mpdf\Conversion;
+use Mpdf\QrCode;
 use Mpdf\Config\ConfigVariables;
 use Mpdf\Config\FontVariables;
-use Mpdf\Conversion;
 use Mpdf\Css\Border;
 use Mpdf\Css\TextVars;
-use Mpdf\Log\Context as LogContext;
 use Mpdf\Fonts\MetricsGenerator;
+use Mpdf\Log\Context as LogContext;
 use Mpdf\Output\Destination;
 use Mpdf\PsrLogAwareTrait\MpdfPsrLogAwareTrait;
-use Mpdf\QrCode;
 use Mpdf\Utils\Arrays;
 use Mpdf\Utils\NumericString;
 use Mpdf\Utils\UtfString;
@@ -1041,6 +1041,14 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	 * @var \Mpdf\Container\ContainerInterface
 	 */
 	private $container;
+
+	/**
+	 * Set the zero pad amount for page numbers. 
+	 * 2 = 01, 3 = 001, etc.
+	 *
+	 * @var int
+	 */
+	private $zero_pad_page_numbers = 1;
 
 	/**
 	 * @param mixed[] $config
@@ -27546,6 +27554,13 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	 */
 	protected function aliasReplace($html, $PAGENO, $NbPgGp, $NbPg)
 	{
+		// Pad the page numbers if required
+		if ($this->zero_pad_page_numbers > 1) {
+			$PAGENO = str_pad($PAGENO, $this->zero_pad_page_numbers, '0', STR_PAD_LEFT);
+			$NbPgGp = str_pad($NbPgGp, $this->zero_pad_page_numbers, '0', STR_PAD_LEFT);
+			$NbPg   = str_pad($NbPg, $this->zero_pad_page_numbers, '0', STR_PAD_LEFT);
+		}
+
 		// Replaces for header and footer
 		$html = str_replace('{PAGENO}', $PAGENO, $html);
 		$html = str_replace($this->aliasNbPgGp, $NbPgGp, $html); // {nbpg}

--- a/tests/Mpdf/ZeroPadPageNumbersTest.php
+++ b/tests/Mpdf/ZeroPadPageNumbersTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Mpdf;
+
+class ZeroPadPageNumbersTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+    public function testPageNumbersWithoutZeroPadding()
+    {
+        $mpdf = new Mpdf();
+        $text = 'Page {PAGENO} / {nbpg}';
+
+        $pages = 3;
+        $contents = array_fill(0, $pages, $text);
+
+        $mpdf->SetCompression(false);
+        $mpdf->SetHTMLHeader('Header: ' . $text);
+        $mpdf->SetHTMLFooter('Footer: ' . $text);
+        $mpdf->WriteHTML('<html><body>' . implode('<pagebreak>', $contents) . '</body></html>');
+        $mpdf->Close();
+
+        for ($i = 1; $i <= $pages; $i++) {
+            $page = str_replace("\n", "", $mpdf->pages[$i]);
+
+            $expected_page = (string) $i;
+            $expected_total = (string) $pages;
+
+            $page_string = 'Page ' . $expected_page . ' / ' . $expected_total;
+            $page_string = mb_convert_encoding($page_string, 'UTF-16BE', 'UTF-8');
+
+            $number_page_string = substr_count($page, $page_string);
+
+            $this->assertGreaterThanOrEqual(
+                2,
+                $number_page_string,
+                "Page $i did not contain unpadded numbers"
+            );
+        }
+    }
+
+    public function testPageNumbersWithZeroPadding()
+    {
+        $mpdf = new Mpdf([
+            'zero_pad_page_numbers' => 2,
+        ]);
+
+        $text = 'Page {PAGENO} / {nbpg}';
+
+        $pages = 3;
+        $contents = array_fill(0, $pages, $text);
+
+        $mpdf->SetCompression(false);
+        $mpdf->SetHTMLHeader('Header: ' . $text);
+        $mpdf->SetHTMLFooter('Footer: ' . $text);
+        $mpdf->WriteHTML('<html><body>' . implode('<pagebreak>', $contents).'</body></html>');
+        $mpdf->Close();
+
+        for ($i = 1; $i <= $pages; $i++) {
+            $page = str_replace("\n", "", $mpdf->pages[$i]);
+
+            $expected_page = str_pad($i, 2, '0', STR_PAD_LEFT);
+            $expected_total = str_pad($pages, 2, '0', STR_PAD_LEFT);
+
+            $page_string = 'Page ' . $expected_page . ' / ' . $expected_total;
+            $page_string = mb_convert_encoding($page_string, 'UTF-16BE', 'UTF-8');
+
+            $number_page_string = substr_count($page, $page_string);
+
+            $this->assertGreaterThanOrEqual(
+                2,
+                $number_page_string,
+                "Page $i did not contain zero-padded numbers"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new configuration option `zero_pad_page_numbers` to allow zero-padded page numbering in headers, footers, and body text, so "1" would become "01", or "001", depending on configuration.

```
$mpdf = new \Mpdf\Mpdf([
    'zero_pad_page_numbers' => 2,
]);

// Output:
// Page 01 / 03
// Page 02 / 03
// Page 03 / 03
```

If the option is not set or is 1 (default), behaviour remains unchanged.

Side note, my VS Code formatter re-ordered the `use` statements and I hadn't realised, I restored this in the second commit.