### PR TITLE
Table Rendering: tr with page-break-{before,after} avoid will compute exact line heights to decide whether to break

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22252,6 +22252,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					// corner case: if the pagelookahead is bigger than the pagesize, we break anyway, so fill up the page
 					if ($pagebreaklookaheadheight + $extra > $pagetrigger + 0.001) {
 						$pagebreaklookahead = 1;
+						$pagebreaklookaheadheight = $h;
 					}
 					if ($j == $startcol && ((($y + $pagebreaklookaheadheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {

--- a/tests/Issues/Issue2013Test.php
+++ b/tests/Issues/Issue2013Test.php
@@ -18,8 +18,8 @@ class Issue2013Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		<table>'.$html.'</table>
 		</html>');
 
-		// without the bugfix, it would produce 98 pages, with the bugfix: 7
-		$this->assertEquals($mpdf->page, 7);
+		// without the bugfix, it would produce 98 pages, with the bugfix: 8
+		$this->assertEquals($mpdf->page, 8);
 	}
 
 }


### PR DESCRIPTION
The previous code had a heuristic that took maxrowheight so spot whether the page has to be breaked inside a table.

I fixed the behaviour to take the exact height computation of the upcoming rows into account.

I also reappled a unmerged change that fixes the corner case when all page-break-avoid items exceed one page size and added a test case.