### PR TITLE
 Table Rendering: tr with page-break-{before,after} avoid will compute exact line heights to decide whether to break #2138 

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22176,16 +22176,21 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 					// lookahead for pagebreak
 					$pagebreaklookahead = 1;
+					$pagebreaklookaheadheight = $h;
 					while (isset($table['pagebreak-before']) && isset($table['pagebreak-before'][$i + $pagebreaklookahead]) && $table['pagebreak-before'][$i + $pagebreaklookahead] == 'avoid') {
 						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
+						list($y2, $h2) = $this->_tableGetHeight($table, $i + $pagebreaklookahead, $j);
+						$pagebreaklookaheadheight += $h2;
+
 					}
 					// corner case: if the pagelookahead is bigger than the pagesize, we break anyway, so fill up the page
-					if ($pagebreaklookahead * $maxrowheight + $extra > $pagetrigger + 0.001) {
+					if ($pagebreaklookaheadheight + $extra > $pagetrigger + 0.001) {
 						$pagebreaklookahead = 1;
+						$pagebreaklookaheadheight = $h;
 					}
 					// if we exceed page boundaries: restart table on next page before printing the line
-					if ($j == $startcol && ((($y + $pagebreaklookahead * $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
+					if ($j == $startcol && ((($y + $pagebreaklookaheadheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;
 							$firstSpread = true;

--- a/tests/Issues/Issue2013Test.php
+++ b/tests/Issues/Issue2013Test.php
@@ -18,8 +18,8 @@ class Issue2013Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		<table>'.$html.'</table>
 		</html>');
 
-		// without the bugfix, it would produce 98 pages, with the bugfix: 7
-		$this->assertEquals($mpdf->page, 7);
+		// without the bugfix, it would produce 98 pages, with the bugfix: 8
+		$this->assertEquals($mpdf->page, 8);
 	}
 
 }


### PR DESCRIPTION
 Table Rendering: tr with page-break-{before,after} avoid will compute exact line heights to decide whether to break #2138 