### PR TITLE
Add feature UseAttachments to allow to show attachments on the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features
 * Added support for `psr/http-message` v2 without dropping v1. (@markdorison, @apotek, @greg-1-anderson, @NigelCunningham #1907)
 * PHP 8.3 support in mPDF 8.2.1
 * Add support for `page-break-before: avoid;` and `page-break-after: avoid;` for tr elements inside tables
+* Add support for viewing list of attachments in PDF viewer (UseAttachments PageMode) by including 'UseAttachments' text on DisplayPreferences property
 
 Bugfixes
 --------

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -377,6 +377,11 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			$this->writer->write('/PageMode /FullScreen');
 		}
 
+    //UseAttachments to show attachments on the left
+    if (is_int(strpos($this->mpdf->DisplayPreferences, 'UseAttachments'))) {
+      $this->writer->write('/PageMode /UseAttachments');
+    }
+
 		// Metadata
 		if ($this->mpdf->PDFA || $this->mpdf->PDFX) {
 			$this->writer->write('/Metadata ' . $this->mpdf->MetadataRoot . ' 0 R');


### PR DESCRIPTION
Add support for viewing list of attachments in PDF viewer (UseAttachments PageMode) by including 'UseAttachments' text on DisplayPreferences property

Typical usage
After using 
$mpdf->SetAssociatedFiles($associatedFiles);
to add file, use 
$mpdf->DisplayPreferences.= ' UseAttachments';
to have the attachment tab open by default (else it's not easy to see there's attached file to the pdf)
