### PR TITLE
Reduce memory usage by using array buffer

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Mpdf;
+
+class Buffer
+{
+
+	/** @var array<int, string> */
+	private $contents = [];
+
+	/** @var int */
+	private $length = 0;
+
+	public function __construct()
+	{
+	}
+
+	public function append($content, $newLine = false)
+	{
+		if ($content === null || $content === '') {
+			return;
+		}
+
+		$content = (string) $content;
+		$contentLength = strlen($content);
+
+		// Do not create an additional buffer entry if the content is relatively small.
+		if ($newLine && $contentLength < 1000000) {
+			$content .= "\n";
+			++$contentLength;
+		}
+
+		$this->contents[] = $content;
+		$this->length += $contentLength;
+
+		if ($newLine && $contentLength >= 1000000) {
+			$this->contents[] = "\n";
+			++$this->length;
+		}
+	}
+
+	public function getLength()
+	{
+		return $this->length;
+	}
+
+	public function writeToFile($handle)
+	{
+		foreach ($this->contents as $content) {
+			fwrite($handle, $content);
+		}
+	}
+
+	public function writeToOutput()
+	{
+		foreach ($this->contents as $content) {
+			echo $content;
+		}
+	}
+
+	public function writeToString()
+	{
+		return implode('', $this->contents);
+	}
+
+	public function getHash()
+	{
+		$hash = '';
+		foreach ($this->contents as $content) {
+			$hash = md5($hash.$content);
+		}
+
+		return $hash;
+	}
+
+}

--- a/src/FpdiTrait.php
+++ b/src/FpdiTrait.php
@@ -332,11 +332,7 @@ trait FpdiTrait
 
 	protected function _put($s, $newLine = true)
 	{
-		if ($newLine) {
-			$this->buffer .= $s . "\n";
-		} else {
-			$this->buffer .= $s;
-		}
+		$this->buffer->append($s, $newLine);
 	}
 
 	/**

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -1109,7 +1109,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->BMPonly = [];
 		$this->page = 0;
 		$this->n = 2;
-		$this->buffer = '';
+		$this->buffer = new Buffer();
 		$this->objectbuffer = [];
 		$this->pages = [];
 		$this->OrientationChanges = [];
@@ -9554,7 +9554,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		$this->logger->debug(sprintf('Compiled in %.6F seconds', microtime(true) - $this->time0), ['context' => LogContext::STATISTICS]);
 		$this->logger->debug(sprintf('Peak Memory usage %s MB', number_format(memory_get_peak_usage(true) / (1024 * 1024), 2)), ['context' => LogContext::STATISTICS]);
-		$this->logger->debug(sprintf('PDF file size %s kB', number_format(strlen($this->buffer) / 1024)), ['context' => LogContext::STATISTICS]);
+		$this->logger->debug(sprintf('PDF file size %s kB', number_format($this->buffer->getLength() / 1024)), ['context' => LogContext::STATISTICS]);
 		$this->logger->debug(sprintf('%d fonts used', count($this->fonts)), ['context' => LogContext::STATISTICS]);
 
 		if (is_bool($dest)) {
@@ -9591,7 +9591,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 					if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
 						// don't use length if server using compression
-						header('Content-Length: ' . strlen($this->buffer));
+						header('Content-Length: ' . $this->buffer->getLength());
 					}
 
 					header('Content-disposition: inline; filename="' . $name . '"');
@@ -9602,7 +9602,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 				}
 
-				echo $this->buffer;
+				$this->buffer->writeToOutput();
 
 				break;
 
@@ -9623,12 +9623,12 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 				if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
 					// don't use length if server using compression
-					header('Content-Length: ' . strlen($this->buffer));
+					header('Content-Length: ' . $this->buffer->getLength());
 				}
 
 				header('Content-Disposition: attachment; filename="' . $name . '"');
 
-				echo $this->buffer;
+				$this->buffer->writeToOutput();
 
 				break;
 
@@ -9639,14 +9639,15 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					throw new \Mpdf\MpdfException(sprintf('Unable to create output file %s', $name));
 				}
 
-				fwrite($f, $this->buffer, strlen($this->buffer));
+				$this->buffer->writeToFile($f);
+
 				fclose($f);
 
 				break;
 
 			case Destination::STRING_RETURN:
 				$this->cache->clearOld();
-				return $this->buffer;
+				return $this->buffer->writeToString();
 
 			default:
 				throw new \Mpdf\MpdfException(sprintf('Incorrect output destination %s', $dest));
@@ -10110,7 +10111,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->writer->write('endobj');
 
 		// Cross-ref
-		$o = strlen($this->buffer);
+		$o = $this->buffer->getLength();
 		$this->writer->write('xref');
 		$this->writer->write('0 ' . ($this->n + 1));
 		$this->writer->write('0000000000 65535 f ');
@@ -10129,7 +10130,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->writer->write('startxref');
 		$this->writer->write($o);
 
-		$this->buffer .= '%%EOF';
+		$this->buffer->append('%%EOF');
 		$this->state = 3;
 	}
 

--- a/src/Writer/BaseWriter.php
+++ b/src/Writer/BaseWriter.php
@@ -32,7 +32,7 @@ final class BaseWriter
 		if ($this->mpdf->state === 2) {
 			$this->endPage($s, $ln);
 		} else {
-			$this->mpdf->buffer .= $s . ($ln ? "\n" : '');
+			$this->mpdf->buffer->append($s, $ln);
 		}
 	}
 
@@ -53,7 +53,7 @@ final class BaseWriter
 
 		// Begin a new object
 		if (!$onlynewobj) {
-			$this->mpdf->offsets[$obj_id] = strlen($this->mpdf->buffer);
+			$this->mpdf->offsets[$obj_id] = $this->mpdf->buffer->getLength();
 			$this->write($obj_id . ' 0 obj');
 			$this->mpdf->currentObjectNumber = $obj_id; // for later use with encryption
 		}

--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -801,7 +801,7 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 			$this->writer->write('/Encrypt ' . $this->mpdf->enc_obj_id . ' 0 R');
 			$this->writer->write('/ID [<' . $this->protection->getUniqid() . '> <' . $this->protection->getUniqid() . '>]');
 		} else {
-			$uniqid = md5(time() . $this->mpdf->buffer);
+			$uniqid = md5(time() . $this->mpdf->buffer->getHash());
 			$this->writer->write('/ID [<' . $uniqid . '> <' . $uniqid . '>]');
 		}
 	}

--- a/src/Writer/PageWriter.php
+++ b/src/Writer/PageWriter.php
@@ -265,7 +265,7 @@ final class PageWriter
 		$this->metadataWriter->writeAnnotations(); // mPDF 5.7.2
 
 		// Pages root
-		$this->mpdf->offsets[1] = strlen($this->mpdf->buffer);
+		$this->mpdf->offsets[1] = $this->mpdf->buffer->getLength();
 		$this->writer->write('1 0 obj');
 		$this->writer->write('<</Type /Pages');
 

--- a/src/Writer/ResourceWriter.php
+++ b/src/Writer/ResourceWriter.php
@@ -121,7 +121,7 @@ final class ResourceWriter implements \Psr\Log\LoggerAwareInterface
 		$this->backgroundWriter->writePatterns();
 
 		// Resource dictionary
-		$this->mpdf->offsets[2] = strlen($this->mpdf->buffer);
+		$this->mpdf->offsets[2] = $this->mpdf->buffer->getLength();
 		$this->writer->write('2 0 obj');
 		$this->writer->write('<</ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
 

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -143,7 +143,7 @@ class FpdiTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$pdf->writePdfType($string);
 
 		// (xxxxx)
-		$string = substr($pdf->buffer, 1, -1);
+		$string = substr($pdf->buffer->writeToString(), 1, -1);
 		// we need to unescape the string, to get a comparable value
 		$this->assertEquals(5, strlen($writer->unescape($string)));
 	}


### PR DESCRIPTION
Previously, content was appended to the buffer which duplicated the memory consumption: the old buffer and the new buffer with the appended contents occupied the memory simultaneously.

In the new situation the appended content is added to an array and PHP does not consume additional memory for this action.

When writing the buffer to file or stdout the buffer is written piece by piece, again avoiding the need to construct the contents as one large string.

I hope you like the approach I've taken. I think it's a good idea to concentrate the buffer logic in a separate class.

The test cases don't show a reduction in memory, but the tests don't work with large files and usually append the contents in memory, which defeats the optimization.
In my application, I append large PDFs and this helps me to stay within the memory limits of my VPS.