### PR TITLE
Header absolute fix

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -22244,6 +22244,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 						// pagebreak-after is mapped to pagebreak-before on i+1 in Tags/Tr.php
 						$pagebreaklookahead++;
 					}
+					// corner case: if the pagelookahead is bigger than the pagesize, we break anyway, so fill up the page
+					if ($pagebreaklookahead * $maxrowheight + $extra > $pagetrigger + 0.001) {
+						$pagebreaklookahead = 1;
+					}
+					// if we exceed page boundaries: restart table on next page before printing the line
 					if ($j == $startcol && ((($y + $pagebreaklookahead * $maxrowheight + $extra ) > ($pagetrigger + 0.001)) || (($this->keepColumns || !$this->ColActive) && !empty($tablefooter) && ($y + $maxrowheight + $tablefooterrowheight + $extra) > $pagetrigger) && ($this->tableLevel == 1 && $i < ($numrows - $table['headernrows']))) && ($y0 > 0 || $x0 > 0) && !$this->InFooter && $this->autoPageBreak) {
 						if (!$skippage) {
 							$finalSpread = true;

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -14030,6 +14030,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 		$save_y = $this->y;
 		$save_x = $this->x;
+		$save_blklvl = $this->blklvl;
+		$save_blk = $this->blk;
+		$save_lastblocklevelchange = $this->lastblocklevelchange;
+		$save_blockContext = $this->blockContext;
 		$this->fullImageHeight = $this->h;
 		$save_cols = false;
 		/* -- COLUMNS -- */
@@ -14040,6 +14044,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 		/* -- END COLUMNS -- */
 		$save_annots = $this->title2annots; // *ANNOTATIONS*
+		$save_writingHTMLheader = $this->writingHTMLheader;
+		$save_writingHTMLfooter = $this->writingHTMLfooter;
+		$save_inFooter = $this->InFooter;
 		$this->writingHTMLheader = true; // a FIX to stop pagebreaks etc.
 		$this->writingHTMLfooter = true;
 		$this->InFooter = true; // suppresses autopagebreaks
@@ -14863,10 +14870,14 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$this->HTMLheaderPageAnnots = $save_header_annots;
 		$this->HTMLheaderPageForms = $save_header_forms;
 		$this->pageBackgrounds = $save_bgs;
-		$this->writingHTMLheader = false;
-
-		$this->writingHTMLfooter = false;
+		$this->writingHTMLheader = $save_writingHTMLheader;
+		$this->writingHTMLfooter = $save_writingHTMLfooter;
+		$this->InFooter = $save_inFooter;
 		$this->fullImageHeight = false;
+		$this->blk = $save_blk;
+		$this->blklvl = $save_blklvl;
+		$this->lastblocklevelchange = $save_lastblocklevelchange;
+		$this->blockContext = $save_blockContext;
 		$this->ResetMargins();
 		$this->pgwidth = $this->w - $this->lMargin - $this->rMargin;
 		$this->SetXY($save_x, $save_y);

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -14046,6 +14046,11 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		$save_bgs = $this->pageBackgrounds;
 		$checkinnerhtml = preg_replace('/\s/', '', $html);
 		$rotate = 0;
+		// Preserve header buffers when fixed-position blocks are rendered during header parsing.
+		$save_headerbuffer = $this->headerbuffer;
+		$save_header_links = $this->HTMLheaderPageLinks;
+		$save_header_annots = $this->HTMLheaderPageAnnots;
+		$save_header_forms = $this->HTMLheaderPageForms;
 
 		if ($w > $this->w) {
 			$x = 0;
@@ -14853,10 +14858,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		}
 
 		// Restore
-		$this->headerbuffer = '';
-		$this->HTMLheaderPageLinks = [];
-		$this->HTMLheaderPageAnnots = [];
-		$this->HTMLheaderPageForms = [];
+		$this->headerbuffer = $save_headerbuffer;
+		$this->HTMLheaderPageLinks = $save_header_links;
+		$this->HTMLheaderPageAnnots = $save_header_annots;
+		$this->HTMLheaderPageForms = $save_header_forms;
 		$this->pageBackgrounds = $save_bgs;
 		$this->writingHTMLheader = false;
 

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -70,6 +70,7 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 				break;
 
 			case '%':
+			case '%%':
 				if ($fontsize && $usefontsize) {
 					$size *= $fontsize / 100;
 				} else {

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -70,7 +70,6 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 				break;
 
 			case '%':
-			case '%%':
 				if ($fontsize && $usefontsize) {
 					$size *= $fontsize / 100;
 				} else {

--- a/tests/Issues/Issue2013Test.php
+++ b/tests/Issues/Issue2013Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Issues;
+
+class Issue2013Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testPdfTableBreakAvoidTooMuch()
+	{
+		// test case: spill items that take about a bit more than half a page, no page-break-avoid would fit them on two pages, with page-break it will be three
+		$mpdf = new \Mpdf\Mpdf();
+		$html = '';
+		$itemsPerTwothirdsPage = 28;
+		for ($i = 0; $i < 5*$itemsPerTwothirdsPage; $i++) {
+			$html .= '<tr style="page-break-before: avoid; background: lime;"><td>content</td></tr>';
+		}
+		$mpdf->WriteHTML('<html><body><h1>Test</h1>
+		<table>'.$html.'</table>
+		</html>');
+
+		// without the bugfix, it would produce 98 pages, with the bugfix: 7
+		$this->assertEquals($mpdf->page, 7);
+	}
+
+}


### PR DESCRIPTION
# Preserve Header Buffers for Fixed-Position Blocks

## Summary
- Preserve header buffer state while rendering fixed-position blocks during header parsing.
- Prevent header links/annots/forms from being cleared after the fixed block render.
- Restore header buffers after rendering to keep header output intact.

## Changes
- Save and restore `headerbuffer`, `HTMLheaderPageLinks`, `HTMLheaderPageAnnots`, and
  `HTMLheaderPageForms` in `src/Mpdf.php`.
- Replace the previous buffer resets with restoring the saved header state.

## Disclaimer
I don't know why you reset the rendering state but it was without this patch impossible for me to place absolute positioned items in the header.

