### PR TITLE
Enable passing an ImageProcessor class via container

### DIFF
--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -99,7 +99,11 @@ class ServiceFactory
 
 		$hyphenator = new Hyphenator($mpdf);
 
-		$imageProcessor = new ImageProcessor(
+		$imageProcessorClass = $this->container && $this->container->has('ImageProcessorClass')
+			? $this->container->get('ImageProcessorClass')
+			: ImageProcessor::class;
+
+		$imageProcessor = new $imageProcessorClass(
 			$mpdf,
 			$otl,
 			$cssManager,


### PR DESCRIPTION
This PR solves our issue described in #2145. The AssetFetcher is not flexible enough to handle our media source, even with custom HttpClient and LocalContentLoader.

The src is a url of a fetcher script, like `https://example.dokuwiki/lib/exe/fetch.php?......` It gets interpreted as a local file '/lib/exe/fetch.php?......', which of course fopen() correctly says does not exist. In effect our custom LocalContentLoader never gets called.