### PR TITLE
fix: apply @page :first margin overrides on the first page

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -13330,6 +13330,20 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			if ($fname) {
 				$this->firstPageBoxFooter = $fname;
 			}
+
+			// Apply @page :first margin overrides (do not touch orig_* so subsequent pages revert to generic @page)
+			if (strlen($pbmgt) > 0) {
+				$this->tMargin = $pbmgt;
+			}
+			if (strlen($pbmgb) > 0) {
+				$this->bMargin = $pbmgb;
+			}
+			if (strlen($pbmgh) > 0) {
+				$this->margin_header = $pbmgh;
+			}
+			if (strlen($pbmgf) > 0) {
+				$this->margin_footer = $pbmgf;
+			}
 		}
 		/* -- END CSS-PAGE -- */
 

--- a/tests/Issues/PageFirstMarginsTest.php
+++ b/tests/Issues/PageFirstMarginsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Issues;
+
+class PageFirstMarginsTest extends \Mpdf\BaseMpdfTest
+{
+
+	public function testFirstPageMarginHeaderOverride()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-header: 15mm;
+			}
+			@page :first {
+				margin-header: 5mm;
+				header: html_MyHeader;
+			}
+		</style>
+
+		<htmlpageheader name="MyHeader">
+			Header content
+		</htmlpageheader>
+
+		First page content
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(5.0, $this->mpdf->margin_header);
+	}
+
+	public function testFirstPageMarginFooterOverride()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-footer: 12mm;
+			}
+			@page :first {
+				margin-footer: 3mm;
+				footer: html_MyFooter;
+			}
+		</style>
+
+		<htmlpagefooter name="MyFooter">
+			Footer content
+		</htmlpagefooter>
+
+		First page content
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(3.0, $this->mpdf->margin_footer);
+	}
+
+	public function testFirstPageMarginTopOverride()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-top: 20mm;
+			}
+			@page :first {
+				margin-top: 10mm;
+			}
+		</style>
+
+		First page content
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(10.0, $this->mpdf->tMargin);
+	}
+
+	public function testFirstPageMarginBottomOverride()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-bottom: 20mm;
+			}
+			@page :first {
+				margin-bottom: 8mm;
+			}
+		</style>
+
+		First page content
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(8.0, $this->mpdf->bMargin);
+	}
+
+	public function testGenericPageMarginsPreservedWithoutFirstOverride()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-header: 15mm;
+				margin-footer: 12mm;
+			}
+		</style>
+
+		Content without @page :first
+		');
+
+		$this->mpdf->Close();
+
+		$this->assertSame(15.0, $this->mpdf->margin_header);
+		$this->assertSame(12.0, $this->mpdf->margin_footer);
+	}
+
+	public function testSubsequentPagesRevertToGenericMargins()
+	{
+		$this->mpdf->WriteHTML('
+		<style>
+			@page {
+				margin-header: 15mm;
+			}
+			@page :first {
+				margin-header: 5mm;
+				header: html_MyHeader;
+			}
+		</style>
+
+		<htmlpageheader name="MyHeader">
+			Header content
+		</htmlpageheader>
+
+		First page content
+		<pagebreak />
+		Second page content
+		');
+
+		$this->mpdf->Close();
+
+		// After page break, orig_hMargin (generic @page value) should be preserved
+		$this->assertSame(15.0, $this->mpdf->orig_hMargin);
+	}
+
+}


### PR DESCRIPTION
## Summary

- **Bug**: `@page :first { margin-header: ...; }` (and other margin properties) were parsed correctly by `SetPagedMediaCSS()` but silently discarded — only `header`/`footer` names were extracted from the `:first` pseudo-page result
- **Fix**: After extracting header/footer names from the `@page :first` call, apply the returned margin overrides (`margin-top`, `margin-bottom`, `margin-header`, `margin-footer`) to the first page. The `orig_*` values are intentionally left untouched so subsequent pages revert to the generic `@page` margins.
- **Tests**: 6 new test cases covering all four margin properties, preservation of generic margins without `:first`, and correct revert of `orig_hMargin` on subsequent pages

## Test plan

- [x] New test: `@page :first` `margin-header` override applied on first page
- [x] New test: `@page :first` `margin-footer` override applied on first page
- [x] New test: `@page :first` `margin-top` override applied on first page
- [x] New test: `@page :first` `margin-bottom` override applied on first page
- [x] New test: generic `@page` margins preserved when no `:first` is defined
- [x] New test: `orig_hMargin` stays at generic value after page break (page 2+ unaffected)
- [x] Existing `Issue732Test` (`@page :first` header/footer) still passes
- [x] Full test suite passes (454 tests, 800 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)