### PR TITLE
fix: {PAGENO} and {nb} placeholders break text-align right/center in body content

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -6594,7 +6594,8 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					$content[$k] = $chunk = str_replace(chr(173), '', $chunk);
 					$content[$k] = $chunk = str_replace(chr(160), chr(32), $chunk);
 				}
-				$contentWidth += $this->GetStringWidth($chunk, true, (isset($cOTLdata[$k]) ? $cOTLdata[$k] : false), $this->textvar) * Mpdf::SCALE;
+				$widthChunk = $this->aliasReplaceForWidth($chunk);
+				$contentWidth += $this->GetStringWidth($widthChunk, true, (isset($cOTLdata[$k]) ? $cOTLdata[$k] : false), $this->textvar) * Mpdf::SCALE;
 			} elseif (isset($this->objectbuffer[$k]) && $this->objectbuffer[$k]) {
 				// LIST MARKERS	// mPDF 6  Lists
 				if ($this->objectbuffer[$k]['type'] == 'image' && isset($this->objectbuffer[$k]['listmarker']) && $this->objectbuffer[$k]['listmarker'] && $this->objectbuffer[$k]['listmarkerposition'] == 'outside') {
@@ -6979,8 +6980,9 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 				}
 				// WORD SPACING
 				// mPDF 5.7.1
-				$stringWidth = $this->GetStringWidth($chunk, true, (isset($cOTLdata[$aord]) ? $cOTLdata[$aord] : false), $this->textvar);
-				$nch = mb_strlen($chunk, $this->mb_enc);
+				$widthChunk = $this->aliasReplaceForWidth($chunk);
+				$stringWidth = $this->GetStringWidth($widthChunk, true, (isset($cOTLdata[$aord]) ? $cOTLdata[$aord] : false), $this->textvar);
+				$nch = mb_strlen($widthChunk, $this->mb_enc);
 				// Use GPOS OTL
 				if (isset($this->CurrentFont['useOTL']) && $this->CurrentFont['useOTL']) {
 					if (isset($cOTLdata[$aord]['group']) && $cOTLdata[$aord]['group']) {
@@ -27468,6 +27470,20 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	public function _out($s)
 	{
 		$this->writer->write($s);
+	}
+
+	/**
+	 * Replace {PAGENO}, {nb}, and {nbpg} placeholders with current/estimated page numbers
+	 * for width calculation purposes. This ensures text-align right/center calculates
+	 * positions based on the actual rendered string width, not the placeholder string width.
+	 */
+	protected function aliasReplaceForWidth($text)
+	{
+		$pageNo = (string) $this->page;
+		$text = str_replace('{PAGENO}', $pageNo, $text);
+		$text = str_replace($this->aliasNbPg, $pageNo, $text);
+		$text = str_replace($this->aliasNbPgGp, $pageNo, $text);
+		return $text;
 	}
 
 	/**

--- a/tests/Issues/PagenoTextAlignTest.php
+++ b/tests/Issues/PagenoTextAlignTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Mpdf;
+use Mpdf\Output\Destination;
+
+class PagenoTextAlignTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	/**
+	 * Extract x-coordinates of text positioning commands (Td) from a PDF page buffer.
+	 */
+	private function extractTextXPositions($pageContent)
+	{
+		$positions = [];
+		// Match "X Y Td" text positioning operators in the PDF content stream
+		if (preg_match_all('/([0-9.]+)\s+[0-9.]+\s+Td/', $pageContent, $matches)) {
+			foreach ($matches[1] as $x) {
+				$positions[] = round((float) $x, 2);
+			}
+		}
+		return $positions;
+	}
+
+	/**
+	 * Test that {PAGENO} in right-aligned text produces the same right edge
+	 * as equivalent static text.
+	 */
+	public function testPagenoRightAlignmentMatchesStaticText()
+	{
+		// Render with static text
+		$mpdf1 = new Mpdf(['mode' => 'c']);
+		$mpdf1->WriteHTML(
+			'<div style="text-align: right; width: 60mm; border: 1px solid red;">Page 1 of 1</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$staticPage = $mpdf1->pages[1];
+
+		// Render with placeholders
+		$mpdf2 = new Mpdf(['mode' => 'c']);
+		$mpdf2->WriteHTML(
+			'<div style="text-align: right; width: 60mm; border: 1px solid blue;">Page {PAGENO} of {nb}</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$placeholderPage = $mpdf2->pages[1];
+
+		// Extract text x-positions from both page buffers
+		$staticPositions = $this->extractTextXPositions($staticPage);
+		$placeholderPositions = $this->extractTextXPositions($placeholderPage);
+
+		$this->assertNotEmpty($staticPositions, 'Static text should have text positioning commands');
+		$this->assertNotEmpty($placeholderPositions, 'Placeholder text should have text positioning commands');
+
+		// The first text Td x-position should be close (within 1pt tolerance)
+		// Both are right-aligned in a 60mm container, so x-positions should nearly match
+		// (small difference is acceptable due to different actual text widths)
+		$staticX = $staticPositions[0];
+		$placeholderX = $placeholderPositions[0];
+
+		// With the bug, the placeholder version has a much lower x (shifted left by ~67pt / 23.6mm)
+		// After the fix, the difference should be small (just the natural width difference between
+		// "Page 1 of 1" and "Page 1 of 1" after replacement — which is zero for a 1-page doc)
+		$this->assertEqualsWithDelta(
+			$staticX,
+			$placeholderX,
+			5.0, // 5pt tolerance (< 2mm)
+			"Right-aligned text with {PAGENO}/{nb} should have similar x-position as static text. " .
+			"Static x={$staticX}, Placeholder x={$placeholderX}, diff=" . abs($staticX - $placeholderX)
+		);
+	}
+
+	/**
+	 * Test that {PAGENO} in center-aligned text is similarly positioned as static text.
+	 */
+	public function testPagenoCenterAlignmentMatchesStaticText()
+	{
+		$mpdf1 = new Mpdf(['mode' => 'c']);
+		$mpdf1->WriteHTML(
+			'<div style="text-align: center; width: 60mm;">Page 1 of 1</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$staticPage = $mpdf1->pages[1];
+
+		$mpdf2 = new Mpdf(['mode' => 'c']);
+		$mpdf2->WriteHTML(
+			'<div style="text-align: center; width: 60mm;">Page {PAGENO} of {nb}</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$placeholderPage = $mpdf2->pages[1];
+
+		$staticPositions = $this->extractTextXPositions($staticPage);
+		$placeholderPositions = $this->extractTextXPositions($placeholderPage);
+
+		$this->assertNotEmpty($staticPositions);
+		$this->assertNotEmpty($placeholderPositions);
+
+		$this->assertEqualsWithDelta(
+			$staticPositions[0],
+			$placeholderPositions[0],
+			5.0,
+			"Center-aligned text with {PAGENO}/{nb} should have similar x-position as static text"
+		);
+	}
+
+	/**
+	 * Test that the PDF output is valid when using placeholders with right-align.
+	 */
+	public function testPagenoRightAlignProducesValidPdf()
+	{
+		$mpdf = new Mpdf(['mode' => 'c']);
+		$mpdf->WriteHTML(
+			'<div style="text-align: right;">Page {PAGENO} of {nb}</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$output = $mpdf->Output('', Destination::STRING_RETURN);
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+	/**
+	 * Test that left-aligned text with placeholders is unaffected (regression check).
+	 */
+	public function testPagenoLeftAlignUnaffected()
+	{
+		$mpdf1 = new Mpdf(['mode' => 'c']);
+		$mpdf1->WriteHTML(
+			'<div style="text-align: left; width: 60mm;">Page 1 of 1</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$staticPage = $mpdf1->pages[1];
+
+		$mpdf2 = new Mpdf(['mode' => 'c']);
+		$mpdf2->WriteHTML(
+			'<div style="text-align: left; width: 60mm;">Page {PAGENO} of {nb}</div>',
+			\Mpdf\HTMLParserMode::HTML_BODY
+		);
+		$placeholderPage = $mpdf2->pages[1];
+
+		$staticPositions = $this->extractTextXPositions($staticPage);
+		$placeholderPositions = $this->extractTextXPositions($placeholderPage);
+
+		$this->assertNotEmpty($staticPositions);
+		$this->assertNotEmpty($placeholderPositions);
+
+		// Left-aligned text should start at the same position regardless of content
+		$this->assertEqualsWithDelta(
+			$staticPositions[0],
+			$placeholderPositions[0],
+			0.5,
+			"Left-aligned text should not be affected by placeholder width"
+		);
+	}
+
+}


### PR DESCRIPTION
## Summary

- **Bug**: `{PAGENO}` and `{nb}` placeholders in body content cause `text-align: right` and `text-align: center` to miscalculate text positions. The width calculation uses the placeholder string width (8 chars for `{PAGENO}`, 4 chars for `{nb}`) instead of the actual rendered page number width, shifting text to the left by up to ~24mm.
- **Root cause**: In `finishFlowingBlock()`, `$contentWidth` and `$stringWidth` are computed via `GetStringWidth()` on text chunks that still contain placeholder strings. The alignment offset (`$empty`) is then calculated from the inflated width.
- **Fix**: Added `aliasReplaceForWidth()` that substitutes placeholders with the current page number before width calculation. The actual text in the PDF stream retains placeholders for final replacement by `aliasReplace()` during output. This mirrors how headers already handle it — they call `aliasReplace()` before `WriteHTML()`, so their widths are always correct.
- **Note**: For `{nb}` (total pages, unknown at layout time), the current page number is used as an estimate. This is exact for single-page documents and provides a much closer approximation than the 4-character placeholder width for multi-page documents.

## Test plan

- [x] New test: right-aligned `{PAGENO}/{nb}` text x-position matches equivalent static text (within 5pt)
- [x] New test: center-aligned `{PAGENO}/{nb}` text x-position matches equivalent static text (within 5pt)
- [x] New test: PDF output with placeholders is valid
- [x] New test: left-aligned text is unaffected (regression check)
- [x] Full test suite passes (694 tests, 1837 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)