### PR TITLE
fix: set PDF version 1.7 for PDF/A-2 and PDF/A-3 compliance

### DIFF
--- a/src/Writer/MetadataWriter.php
+++ b/src/Writer/MetadataWriter.php
@@ -328,6 +328,16 @@ class MetadataWriter implements \Psr\Log\LoggerAwareInterface
 	public function writeCatalog() //_putcatalog
 	{
 		$this->writer->write('/Type /Catalog');
+
+		// PDF/A-2 and PDF/A-3 are based on PDF 1.7 (ISO 32000-1).
+		// The /Version entry in the catalog overrides the header version.
+		if ($this->mpdf->PDFA && strpos($this->mpdf->PDFAversion, '-') !== false) {
+			list($part) = explode('-', $this->mpdf->PDFAversion);
+			if ((int) $part >= 2) {
+				$this->writer->write('/Version /1.7');
+			}
+		}
+
 		$this->writer->write('/Pages 1 0 R');
 
 		if (is_string($this->mpdf->currentLang)) {

--- a/tests/Mpdf/PDFATest.php
+++ b/tests/Mpdf/PDFATest.php
@@ -32,6 +32,31 @@ class PDFATest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertStringContainsString($expected, $output);
 	}
 
+	public function testPDFA_1B_DoesNotSetCatalogVersion()
+	{
+		$output = $this->mpdf->Output(null, 'S');
+
+		$this->assertStringNotContainsString('/Version /1.7', $output);
+	}
+
+	public function testPDFA_2B_SetsCatalogVersion17()
+	{
+		$this->mpdf->PDFAversion = '2-B';
+
+		$output = $this->mpdf->Output(null, 'S');
+
+		$this->assertStringContainsString('/Version /1.7', $output);
+	}
+
+	public function testPDFA_3B_SetsCatalogVersion17()
+	{
+		$this->mpdf->PDFAversion = '3-B';
+
+		$output = $this->mpdf->Output(null, 'S');
+
+		$this->assertStringContainsString('/Version /1.7', $output);
+	}
+
 	public function testPDFA_Version_Fail()
 	{
 		$this->mpdf->PDFAversion = '11';


### PR DESCRIPTION
## Summary
- PDF/A-2 (ISO 19005-2) and PDF/A-3 (ISO 19005-3) are based on PDF 1.7 (ISO 32000-1), but mPDF declared version 1.4. Strict validators like VeraPDF flag this.
- Adds a `/Version /1.7` entry in the document catalog for PDF/A part >= 2. This is the standard PDF mechanism for overriding the header version, and avoids timing issues with the `%PDF-` header being written before `PDFAversion` is set.
- PDF/A-1 (based on PDF 1.4) remains unaffected.

## Test plan
- [x] New test: PDF/A-1B does **not** set `/Version /1.7` in catalog
- [x] New test: PDF/A-2B sets `/Version /1.7` in catalog
- [x] New test: PDF/A-3B sets `/Version /1.7` in catalog
- [x] All existing PDFA tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)