### PR TITLE
Fix TypeError with `rotate: none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugfixes
 * Replace character entities with characters when processing the `code` attribute in the `<barcode />` tag
 * Escape XML predefined entities in XMP metadata (Fix for #2090)
 * Enable Font Subsetting by Default (Fix for #1315)
+* Fix `TypeError` with non-numeric `rotate` values like `none` or `90deg` on tables (@derrabus, #2178)
 
 mPDF 8.1.x
 ===========================

--- a/src/Tag/Table.php
+++ b/src/Tag/Table.php
@@ -212,7 +212,7 @@ class Table extends Tag
 			}
 		}
 		if (!empty($properties['ROTATE']) && $this->mpdf->tableLevel == 1) {
-			$this->mpdf->table_rotate = $properties['ROTATE'];
+			$this->mpdf->table_rotate = $this->parseTableRotate($properties['ROTATE']);
 		}
 		if (isset($properties['TOPNTAIL'])) {
 			$table['topntail'] = $properties['TOPNTAIL'];
@@ -496,7 +496,7 @@ class Table extends Tag
 			}
 		}
 		if (isset($attr['ROTATE']) && $this->mpdf->tableLevel == 1) {
-			$this->mpdf->table_rotate = $attr['ROTATE'];
+			$this->mpdf->table_rotate = $this->parseTableRotate($attr['ROTATE']);
 		}
 
 		//++++++++++++++++++++++++++++
@@ -1278,4 +1278,28 @@ class Table extends Tag
 		return $ret;
 	}
 
+	/**
+	 * @param string $rotate
+	 * @return int
+	 */
+	private function parseTableRotate($rotate)
+	{
+		if (1 !== preg_match('/^(-?[0-9]+)(?:deg)?$/', $rotate, $matches)) {
+			return 0;
+		}
+
+		$rotationDegrees = (int) $matches[1] % 360;
+		if ($rotationDegrees > 180) {
+			$rotationDegrees -= 360;
+		} elseif ($rotationDegrees < -180) {
+			$rotationDegrees += 360;
+		}
+
+		// Only 90 and -90 are supported
+		if ($rotationDegrees !== 90 && $rotationDegrees !== -90) {
+			$rotationDegrees = 0;
+		}
+
+		return $rotationDegrees;
+	}
 }

--- a/tests/Mpdf/Tag/TableTest.php
+++ b/tests/Mpdf/Tag/TableTest.php
@@ -111,15 +111,51 @@ class TableTest extends BaseTagTestCase
 		$this->assertEquals(Border::ALL, $table['border']);
 	}
 
-	public function testRotation()
+	/** @return \Generator<string, array{string, int}> */
+	public function provideRotations()
 	{
-		$attr = ['ROTATE' => '90'];
+		yield 'positive 90' => ['90', 90];
+		yield 'negative 90' => ['-90', -90];
+		yield 'positive 90deg' => ['90deg', 90];
+		yield 'negative 90deg' => ['-90deg', -90];
+		yield 'positive 270deg' => ['270deg', -90];
+		yield 'negative 270deg' => ['-270deg', 90];
+		yield 'positive 450deg' => ['450deg', 90];
+		yield 'none' => ['none', 0];
+		yield 'invalid value' => ['invalid', 0];
+		yield 'unsupported angle' => ['45', 0];
+	}
+
+	/**
+	 * @param string $rotate
+	 * @param int $expectedTableRotate
+	 * @dataProvider provideRotations
+	 */
+	public function testRotation($rotate, $expectedTableRotate)
+	{
+		$attr = ['ROTATE' => $rotate];
 		$ahtml = [];
 		$ihtml = 0;
 
 		$this->tag->open($attr, $ahtml, $ihtml);
 		
-		$this->assertEquals(90, $this->mpdf->table_rotate);
+		$this->assertEquals($expectedTableRotate, $this->mpdf->table_rotate);
+	}
+
+	/**
+	 * @param string $rotate
+	 * @param int $expectedTableRotate
+	 * @dataProvider provideRotations
+	 */
+	public function testRotationStyle($rotate, $expectedTableRotate)
+	{
+		$attr = ['STYLE' => "rotate: $rotate;"];
+		$ahtml = [];
+		$ihtml = 0;
+
+		$this->tag->open($attr, $ahtml, $ihtml);
+
+		$this->assertEquals($expectedTableRotate, $this->mpdf->table_rotate);
 	}
 
 	public function testAutosize()


### PR DESCRIPTION
When importing a table with `style="rotate: none;"`, mpdf currently crashes with a `TypeError`.

> Unsupported operand types: string * int

This happens in this line.

https://github.com/mpdf/mpdf/blob/b59670a09498689c33ce639bac8f5ba26721dab3/src/Mpdf.php#L26786

This PR fixes this issue for us. I've also added a test that covers my change.