### PR TITLE
Fix casing in class reference

### DIFF
--- a/src/CssManager.php
+++ b/src/CssManager.php
@@ -95,7 +95,7 @@ class CssManager
 	 * @param CssParser $cssParser
 	 * @param CssMerger $cssMerger
 	 */
-	public function __construct(cssParser $cssParser, CssMerger $cssMerger)
+	public function __construct(CssParser $cssParser, CssMerger $cssMerger)
 	{
 		$this->cssParser = $cssParser;
 		$this->cssMerger = $cssMerger;


### PR DESCRIPTION
PHPStan got better at detecting class references with wrong casing. With this PR, mpdf's CI should be green again.