### PR TITLE
Add a 8.3.x section to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
+mPDF 8.3.x
+===========================
+
+New features
+------------
+ 
+* Add support for custom `AssetFetcher` via the service container (@splitbrain, #2165) 
+
+Bugfixes
+--------
+
+* Fix `TypeError` with non-numeric `rotate` values like `none` or `90deg` on tables (@derrabus, #2178)
+* Small change to better support list-style-type on list items within tables
+
 mPDF 8.2.x
 ===========================
 
 New features
 ------------
+
 * Watermark text can now be colored using \Mpdf\Watermark DTO. \Mpdf\WatermarkImage DTO for images. (#1876)
 * Added support for `psr/http-message` v2 without dropping v1. (@markdorison, @apotek, @greg-1-anderson, @NigelCunningham #1907)
 * PHP 8.3 support in mPDF 8.2.1
@@ -15,8 +30,6 @@ Bugfixes
 * Replace character entities with characters when processing the `code` attribute in the `<barcode />` tag
 * Escape XML predefined entities in XMP metadata (Fix for #2090)
 * Enable Font Subsetting by Default (Fix for #1315)
-* Fix `TypeError` with non-numeric `rotate` values like `none` or `90deg` on tables (@derrabus, #2178)
-* Small change to better support list-style-type on list items within tables
 
 mPDF 8.1.x
 ===========================


### PR DESCRIPTION
Changes that were introduced after the 8.2.7 release and thus landed in 8.3.0/8.3.1 are still documented under "mPDF 8.2.x" in the changelog. This PR adds a new section "mPDF 8.3.x" to reflect the new minor release.