### PR TITLE
Fix TypeError in transformRotate for non-numeric CSS values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features
 
 Bugfixes
 --------
+* Fix `TypeError` in `transformRotate` for non-numeric CSS transform values (#2056)
 * Fix `TypeError` with non-numeric `rotate` values like `none` or `90deg` on tables (@derrabus, #2178)
 * Small change to better support list-style-type on list items within tables
 * Fixed parsing sheet-size CSS property for @page

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -267,7 +267,7 @@ parameters:
 		-
 			message: '#^Binary operation "\*" between string and 100 results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 4
+			count: 1
 			path: src/Mpdf.php
 
 		-

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -7296,7 +7296,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 							} elseif ($c == 'translatey' && count($vv)) {
 								$translate_y = $this->sizeConverter->convert($vv[0], $maxsize_y, false, false);
 								$tr2 .= $this->transformTranslate(0, $translate_y, true) . ' ';
-							} elseif ($c == 'scale' && count($vv)) {
+							} elseif ($c == 'scale' && count($vv) && is_numeric($vv[0])) {
 								$scale_x = $vv[0] * 100;
 								if (count($vv) == 2) {
 									$scale_y = $vv[1] * 100;
@@ -7304,10 +7304,10 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 									$scale_y = $scale_x;
 								}
 								$tr2 .= $this->transformScale($scale_x, $scale_y, $cx, $cy, true) . ' ';
-							} elseif ($c == 'scalex' && count($vv)) {
+							} elseif ($c == 'scalex' && count($vv) && is_numeric($vv[0])) {
 								$scale_x = $vv[0] * 100;
 								$tr2 .= $this->transformScale($scale_x, 0, $cx, $cy, true) . ' ';
-							} elseif ($c == 'scaley' && count($vv)) {
+							} elseif ($c == 'scaley' && count($vv) && is_numeric($vv[0])) {
 								$scale_y = $vv[0] * 100;
 								$tr2 .= $this->transformScale(0, $scale_y, $cx, $cy, true) . ' ';
 							} elseif ($c == 'skew' && count($vv)) {
@@ -26984,7 +26984,7 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			}
 
 		} else {
-			$angle = $s + 0;
+			$angle = is_numeric($s) ? $s + 0 : 0;
 		}
 
 		return $angle;

--- a/tests/Issues/Issue2056Test.php
+++ b/tests/Issues/Issue2056Test.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Issues;
+
+class Issue2056Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testTransformRotateWithNonNumericValue()
+	{
+		$mpdf = new \Mpdf\Mpdf();
+
+		$mpdf->WriteHTML('<html><body><div style="transform: rotate(revert)">hello</div></body></html>');
+
+		$output = $mpdf->OutputBinaryData();
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+}


### PR DESCRIPTION
`transformRotate` crashes with `TypeError: Unsupported operand types: string * int` when CSS transform properties contain non-numeric values like `revert` or `revert !important`.

`ConvertAngle` now returns 0 for non-numeric raw strings instead of crashing on `$s + 0`. Also added `is_numeric` guards to the scale/scalex/scaley CSS transform branches.

Fixes #2056