### PR TITLE
Improve Font Family Normalizer

### DIFF
--- a/src/Css/NormalizeProperties.php
+++ b/src/Css/NormalizeProperties.php
@@ -229,33 +229,61 @@ class NormalizeProperties
 	/**
 	 * Process FONT-FAMILY property.
 	 *
+	 * Try and parse the property (including malformed values).
+	 * This could take the shape of valid properties like:
+	 * - "Times New Roman", Times, serif
+	 * - serif
+	 * - dejavusans, 'DejaVu Sans Condensed'
+	 *
+	 * And invalid properties like:
+	 * - dejavusans 'DejaVu Sans' (missing comma)
+	 * - 'DejaVu Sans' dejavusans (missing comma)
+	 * - "DejaVu Sans" dejavusans (missing comma)
+	 * - dejavusans sans-serif (missing comma)
+	 *
 	 * @param string $propertyKey Property key
 	 * @param string $value Font family value
 	 * @return void
 	 */
 	protected function processFontFamilyProperty($propertyKey, $value)
 	{
-		/* Normalize the font list */
-		$fontList = array_map(
-			function ($fontName) {
-				return trim($fontName, " \t\n\r\0\x0B\"'");
-			},
-			explode(',', $value)
-		);
+		foreach (explode(',', $value) as $entry) {
 
-		foreach ($fontList as $fontName) {
-			$fontName = str_replace(' ', '', strtolower($fontName));
+			// Try to parse invalid properties
+			$candidates = [];
+			if (preg_match_all('/"([^"]*)"|\'([^\']*)\'/', $entry, $matches)) { // `"DejaVu Sans" 'Helvetica Neue'` → ['DejaVu Sans', 'Helvetica Neue']
+				foreach ($matches[0] as $i => $_unused) {
+					$inner = $matches[1][$i] !== '' ? $matches[1][$i] : $matches[2][$i];
+					$candidates[] = str_replace(' ', '', $inner);
+				}
+			}
 
-			if (in_array($fontName, $this->mpdf->fontdata, true) ||
-				in_array($fontName, $this->mpdf->available_unifonts, true) ||
-				in_array($fontName, $this->mpdf->sans_fonts, true) ||
-				in_array($fontName, $this->mpdf->serif_fonts, true) ||
-				in_array($fontName, $this->mpdf->mono_fonts, true) ||
-				($this->mpdf->onlyCoreFonts && in_array($fontName, ['courier', 'times', 'helvetica', 'arial'], true)) ||
-				in_array($fontName, ['sjis', 'uhc', 'big5', 'gb'], true)
-			) {
-				$this->properties[$propertyKey] = $fontName;
-				return;
+			$unquoted = preg_replace('/"[^"]*"|\'[^\']*\'/', ' ', $entry); // `dejavusans 'DejaVu Sans' helvetica` → "dejavusans   helvetica"
+			foreach (preg_split('/\s+/', trim($unquoted)) as $word) { // `dejavusans   helvetica` → ['dejavusans', 'helvetica']
+				if ($word !== '') {
+					$candidates[] = $word;
+				}
+			}
+
+			$candidates[] = str_replace(' ', '', trim($entry, " \t\n\r\0\x0B\"'"));
+
+			foreach ($candidates as $candidate) {
+				$candidate = strtolower(trim($candidate, " \t\n\r\0\x0B\"'"));
+				if (empty($candidate)) {
+					continue;
+				}
+
+				if (isset($this->mpdf->fontdata[$candidate]) ||
+					in_array($candidate, $this->mpdf->available_unifonts, true) ||
+					in_array($candidate, $this->mpdf->sans_fonts, true) ||
+					in_array($candidate, $this->mpdf->serif_fonts, true) ||
+					in_array($candidate, $this->mpdf->mono_fonts, true) ||
+					($this->mpdf->onlyCoreFonts && in_array($candidate, ['courier', 'times', 'helvetica', 'arial'], true)) ||
+					in_array($candidate, ['sjis', 'uhc', 'big5', 'gb'], true)
+				) {
+					$this->properties[$propertyKey] = $candidate;
+					return;
+				}
 			}
 		}
 	}

--- a/tests/Issues/Issue2194Test.php
+++ b/tests/Issues/Issue2194Test.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Issues;
+
+use Mpdf\Color\ColorConverter;
+use Mpdf\Color\ColorModeConverter;
+use Mpdf\Color\ColorSpaceRestrictor;
+use Mpdf\Css\NormalizeProperties;
+use Mpdf\SizeConverter;
+use Psr\Log\NullLogger;
+
+class Issue2194Test extends \Mpdf\BaseMpdfTest
+{
+
+	private function makeNormalizer()
+	{
+		$sizeConverter = new SizeConverter(96, 11, $this->mpdf, new NullLogger());
+		$colorModeConverter = new ColorModeConverter();
+		$colorConverter = new ColorConverter(
+			$this->mpdf,
+			$colorModeConverter,
+			new ColorSpaceRestrictor($this->mpdf, $colorModeConverter)
+		);
+
+		return new NormalizeProperties($this->mpdf, $sizeConverter, $colorConverter);
+	}
+
+	public function testFontFamilyWithUnknownTokensStillDropsProperty()
+	{
+		$result = $this->makeNormalizer()->normalize([
+			'FONT-FAMILY' => "doesnotexist 'AlsoDoesNotExist'",
+		]);
+
+		$this->assertArrayNotHasKey('FONT-FAMILY', $result);
+	}
+
+	/**
+	 * Regression test to ensure font is correctly selected when it is only in the fontdata array
+	 */
+	public function testFontFamilyResolvesAgainstFontdataKeysNotValues()
+	{
+		$this->mpdf->fontdata['issue2194customfont'] = [
+			'R' => 'DummyRegular.ttf',
+		];
+
+		$this->assertNotContains('issue2194customfont', $this->mpdf->available_unifonts);
+		$this->assertNotContains('issue2194customfont', $this->mpdf->sans_fonts);
+		$this->assertNotContains('issue2194customfont', $this->mpdf->serif_fonts);
+		$this->assertNotContains('issue2194customfont', $this->mpdf->mono_fonts);
+
+		$result = $this->makeNormalizer()->normalize([
+			'FONT-FAMILY' => 'issue2194customfont, sans-serif',
+		]);
+
+		$this->assertArrayHasKey('FONT-FAMILY', $result);
+		$this->assertSame('issue2194customfont', $result['FONT-FAMILY']);
+	}
+
+	/**
+	 * @dataProvider providerMultiFontFontFamilyValues
+	 */
+	public function testFontFamilyMultiFontResolution($expected, $value)
+	{
+		$result = $this->makeNormalizer()->normalize([
+			'FONT-FAMILY' => $value,
+		]);
+
+		$this->assertArrayHasKey('FONT-FAMILY', $result);
+		$this->assertSame($expected, $result['FONT-FAMILY']);
+	}
+
+	public function providerMultiFontFontFamilyValues()
+	{
+		return [
+			// Bare names — case insensitivity
+			['dejavusanscondensed', 'dejavusanscondensed'],
+			['dejavusanscondensed', 'DEJAVUSANSCONDENSED'],
+			['dejavusanscondensed', 'DejaVuSansCondensed'],
+
+			// Single entry wrapped in quotes
+			['dejavusanscondensed', "'dejavusanscondensed'"],
+			['dejavusanscondensed', '"dejavusanscondensed"'],
+			['dejavusanscondensed', "'DejaVu Sans Condensed'"],
+			['dejavusanscondensed', '"DejaVu Sans Condensed"'],
+
+			// Generic keywords on their own
+			['sans-serif', 'sans-serif'],
+			['serif', 'serif'],
+			['monospace', 'monospace'],
+			['cursive', 'cursive'],
+			['fantasy', 'fantasy'],
+
+			// Comma-separated, varying registered position
+			['dejavusanscondensed', 'dejavusanscondensed, foo, bar'],
+			['dejavusanscondensed', 'foo, dejavusanscondensed, bar'],
+			['dejavusanscondensed', 'foo, bar, dejavusanscondensed'],
+
+			// Comma-separated, mixed single/double quotes
+			['dejavusanscondensed', "'foo', \"bar\", dejavusanscondensed"],
+			['dejavusanscondensed', "\"a\", 'b', \"c\", 'd', dejavusanscondensed"],
+			['dejavusanscondensed', "'a', \"b\", dejavusanscondensed, 'c', \"d\""],
+			['dejavusanscondensed', "\"foo bar\", 'baz qux', dejavusanscondensed"],
+			['dejavusanscondensed', "\"a\", 'b', \"c\", 'd', 'e', dejavusanscondensed"],
+
+			// Missing commas between names (the #2194 bug shape)
+			['dejavusanscondensed', "dejavusanscondensed 'DejaVu Sans Condensed'"],
+			['dejavusanscondensed', "'DejaVu Sans Condensed' dejavusanscondensed"],
+			['dejavusanscondensed', '"DejaVu Sans Condensed" dejavusanscondensed'],
+			['dejavusanscondensed', 'foo bar dejavusanscondensed'],
+			['dejavusanscondensed', "'A B' 'C D' 'E F' dejavusanscondensed"],
+			['dejavusanscondensed', "dejavusanscondensed 'A B' \"C D\" 'E F' \"G H\""],
+
+			// Missing commas mixed with commas
+			['dejavusanscondensed', "'foo bar' baz, dejavusanscondensed"],
+			['dejavusanscondensed', "'no match' 'also none', dejavusanscondensed"],
+			['dejavusanscondensed', "'A B' \"C D\", dejavusanscondensed, 'E F'"],
+
+			// Generic keyword fallback after failing chains
+			['sans-serif', 'doesnotexist, sans-serif'],
+			['serif', "doesnotexist, 'AlsoMissing', serif"],
+			['monospace', "'foo', \"bar\", 'baz', monospace"],
+			['cursive', "'a', 'b', 'c', 'd', cursive"],
+			['fantasy', "'a', 'b', 'c', 'd', 'e', fantasy"],
+			['sans-serif', "doesnotexist 'AlsoMissing' \"StillMissing\", sans-serif"],
+			['monospace', "'a' 'b', 'c' 'd', monospace"],
+
+			// Invalid input shapes — empty entries, whitespace, unclosed quote
+			['dejavusanscondensed', ', , dejavusanscondensed'],
+			['dejavusanscondensed', 'dejavusanscondensed,,,'],
+			['dejavusanscondensed', '   dejavusanscondensed   '],
+			['dejavusanscondensed', "\t\n dejavusanscondensed \t"],
+			['sans-serif', ',,,  ,, sans-serif'],
+			['dejavusanscondensed', "'unclosed, dejavusanscondensed"],
+		];
+	}
+
+	public function testFullPipelineAppliesCssFontToTableCell()
+	{
+		$mpdf = new \Mpdf\Mpdf([
+			'default_font' => 'dejavusans',
+		]);
+
+		$css = ".mytable td, .mytable th { font-family: dejavusanscondensed 'DejaVu Sans Condensed'; font-size: 12pt; }";
+		$html = '<p>Outside table.</p>'
+			. '<table class="mytable"><thead><tr><th>Header</th></tr></thead>'
+			. '<tbody><tr><td>Cell</td></tr></tbody></table>';
+
+		$mpdf->WriteHTML($css, \Mpdf\HTMLParserMode::HEADER_CSS);
+		$mpdf->WriteHTML($html, \Mpdf\HTMLParserMode::HTML_BODY);
+
+		$output = $mpdf->OutputBinaryData();
+
+		$this->assertStringStartsWith('%PDF-', $output);
+		$this->assertStringContainsString('DejaVuSansCondensed', $output);
+	}
+
+}


### PR DESCRIPTION
Support `font-family` property with missing comma between font names (regression introduced in 8.3 refactor). This update also correctly checks the `fontdata` array keys (not the values) for a matching font name.

Fixes #2194