### PR TITLE
Emit explicit /Resources dictionary for SVG Form-XObjects (PDF/A compliance)

### DIFF
--- a/src/Writer/FormWriter.php
+++ b/src/Writer/FormWriter.php
@@ -38,6 +38,7 @@ final class FormWriter
 			$this->writer->write('/Subtype /Form');
 			$this->writer->write('/Group ' . ($this->mpdf->n + 1) . ' 0 R');
 			$this->writer->write('/BBox [' . $info['x'] . ' ' . $info['y'] . ' ' . ($info['w'] + $info['x']) . ' ' . ($info['h'] + $info['y']) . ']');
+			$this->writer->write('/Resources <<' . $this->collectFormObjectResources() . '>>');
 
 			if ($this->mpdf->compress) {
 				$this->writer->write('/Filter /FlateDecode');
@@ -58,5 +59,77 @@ final class FormWriter
 			$this->writer->write('>>');
 			$this->writer->write('endobj');
 		}
+	}
+
+	private function collectFormObjectResources()
+	{
+		$resources = [];
+		$extGStates = [];
+
+		foreach ($this->mpdf->extgstates as $key => $extGState) {
+			if (!isset($extGState['fo']) || !$extGState['fo']) {
+				continue;
+			}
+
+			if (isset($extGState['trans'])) {
+				$extGStates[] = '/' . $extGState['trans'] . ' ' . $extGState['n'] . ' 0 R';
+			} else {
+				$extGStates[] = '/GS' . $key . ' ' . $extGState['n'] . ' 0 R';
+			}
+		}
+
+		if ($extGStates !== []) {
+			$resources[] = '/ExtGState <<' . implode('', $extGStates) . '>>';
+		}
+
+		if (isset($this->mpdf->gradients) && count($this->mpdf->gradients) > 0) {
+			$shadings = [];
+
+			foreach ($this->mpdf->gradients as $id => $gradient) {
+				if (!isset($gradient['fo']) || !$gradient['fo'] || !isset($gradient['id'])) {
+					continue;
+				}
+
+				$shadings[] = '/Sh' . $id . ' ' . $gradient['id'] . ' 0 R';
+			}
+
+			if ($shadings !== []) {
+				$resources[] = '/Shading <<' . implode('', $shadings) . '>>';
+			}
+		}
+
+		$fonts = [];
+
+		foreach ($this->mpdf->fonts as $font) {
+			if (!isset($font['type'])) {
+				continue;
+			}
+
+			if ($font['type'] === 'TTF' && (!isset($font['used']) || !$font['used'])) {
+				continue;
+			}
+
+			if (!isset($font['fo']) || !$font['fo']) {
+				continue;
+			}
+
+			if ($font['type'] === 'TTF' && ($font['sip'] || $font['smp'])) {
+				foreach ($font['n'] as $index => $fontReference) {
+					$fonts[] = '/F' . $font['subsetfontids'][$index] . ' ' . $fontReference . ' 0 R';
+				}
+
+				continue;
+			}
+
+			$fonts[] = '/F' . $font['i'] . ' ' . $font['n'] . ' 0 R';
+		}
+
+		if ($fonts !== []) {
+			$resources[] = '/Font <<' . implode('', $fonts) . '>>';
+		}
+
+		$resources[] = '/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]';
+
+		return implode('', $resources);
 	}
 }

--- a/tests/Mpdf/PDFATest.php
+++ b/tests/Mpdf/PDFATest.php
@@ -82,4 +82,38 @@ class PDFATest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertStringContainsString($expected, $output);
 	}
 
+	public function testPDFA_3B_SvgImageFormXObjectHasResources()
+	{
+		$mpdf = new Mpdf();
+		$mpdf->PDFA = true;
+		$mpdf->PDFAauto = true;
+		$mpdf->PDFAversion = '3-B';
+		$mpdf->compress = false;
+
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">'
+			. '<rect width="10" height="10" fill="rgb(206,37,32)" opacity="0.5"/>'
+			. '</svg>';
+		$svgFile = sys_get_temp_dir() . '/mpdf-fwtest-' . uniqid('', true) . '.svg';
+		file_put_contents($svgFile, $svg);
+
+		try {
+			$mpdf->writeHtml('<img src="' . $svgFile . '" style="width:30mm">');
+			$output = $mpdf->Output(null, 'S');
+		} finally {
+			@unlink($svgFile);
+		}
+
+		preg_match_all('/\d+\s+\d+\s+obj\s*(.*?)endobj/s', $output, $matches);
+		$formObjects = array_values(array_filter($matches[1], function ($object) {
+			return strpos($object, '/Subtype /Form') !== false;
+		}));
+
+		$this->assertNotEmpty($formObjects, 'Expected at least one Form XObject for the embedded SVG image');
+		$this->assertMatchesRegularExpression(
+			'#/Resources\s*<<.*?/ExtGState\s*<<.*?/GS\d+\s+\d+\s+0\s+R#s',
+			$formObjects[0],
+			'Form-XObject lacks an explicit /Resources dictionary listing the GS-states it references'
+		);
+	}
+
 }


### PR DESCRIPTION
## Summary

PDF/A content streams that reference external objects must declare them through an explicit `/Resources` dictionary. `FormWriter::writeFormObjects()` previously omitted that dictionary for SVG Form XObjects embedded via `<img>` tags, so validators could report missing `ExtGState` resources.

This change mirrors the existing `BackgroundWriter` resource emission and uses the `['fo']` markers set by the SVG renderer to attach the relevant `ExtGState`, `Shading`, `Font`, and `ProcSet` entries directly to the Form XObject.

## Changes

- emit an explicit `/Resources` dictionary for Form XObjects written by `FormWriter`
- include only the `ExtGState`, `Shading`, and `Font` entries that were marked as used by the SVG renderer
- add a PDF/A regression test covering an embedded SVG image in PDF/A-3 output

## Testing

- `composer test`
- `composer cs`
