### PR TITLE
Fix "Undefined array key" warning in MultiCell with an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bugfixes
 * Small change to better support list-style-type on list items within tables
 * Fixed parsing sheet-size CSS property for @page
 * Conditional calls to functions removed in PHP 8.5
+* Fix "Undefined array key" warning in `MultiCell()` with an empty string (#2158)
 
 mPDF 8.2.x
 ===========================

--- a/src/Otl.php
+++ b/src/Otl.php
@@ -5744,6 +5744,13 @@ class Otl
 
 	public function sliceOTLdata($OTLdata, $pos, $len)
 	{
+		if (!isset($OTLdata['group'])) {
+			$OTLdata['group'] = '';
+		}
+		if (!isset($OTLdata['GPOSinfo'])) {
+			$OTLdata['GPOSinfo'] = [];
+		}
+
 		$newOTLdata = ['GPOSinfo' => [], 'char_data' => []];
 		$newOTLdata['group'] = substr($OTLdata['group'], $pos, $len);
 

--- a/tests/Issues/Issue2158Test.php
+++ b/tests/Issues/Issue2158Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Issues;
+
+class Issue2158Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	public function testMultiCellWithEmptyStringDoesNotAccessUndefinedKey()
+	{
+		$undefinedKey = false;
+		set_error_handler(function ($errno, $errstr) use (&$undefinedKey) {
+			if (strpos($errstr, 'Undefined array key') !== false || strpos($errstr, 'Undefined index') !== false) {
+				$undefinedKey = true;
+			}
+			return true;
+		});
+
+		try {
+			$mpdf = new \Mpdf\Mpdf(['default_font' => 'dejavusans']);
+			$mpdf->AddPage();
+			$mpdf->MultiCell(0, 5, '');
+			$output = $mpdf->OutputBinaryData();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertFalse($undefinedKey);
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+}


### PR DESCRIPTION
`MultiCell()` with an empty string warns on PHP 8. `Otl::sliceOTLdata()` reads the `group` and `GPOSinfo` keys before they are set when there is no OpenType layout data, which raises "Undefined array key". The fix sets both keys to their empty defaults at the top of the function, the same way `char_data` is already guarded just below.

The other error in #2158 (long text with `align: 'J'`) is a different path in `GetJspacing()`, tracked in #2184. Out of scope here.
