### PR TITLE
Support compressed xref PDF imports

### DIFF
--- a/src/FpdiTrait.php
+++ b/src/FpdiTrait.php
@@ -2,6 +2,7 @@
 
 namespace Mpdf;
 
+use Mpdf\PdfParser\PdfParser as MpdfPdfParser;
 use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
 use setasign\Fpdi\PdfParser\Filter\AsciiHex;
 use setasign\Fpdi\PdfParser\Type\PdfArray;
@@ -45,6 +46,15 @@ trait FpdiTrait
 	 * @var int
 	 */
 	protected $templateId = 0;
+
+	protected function getPdfParserInstance(\setasign\Fpdi\PdfParser\StreamReader $streamReader, array $parserParams = [])
+	{
+		if (\class_exists(\setasign\FpdiPdfParser\PdfParser\PdfParser::class)) {
+			return new \setasign\FpdiPdfParser\PdfParser\PdfParser($streamReader, $parserParams);
+		}
+
+		return new MpdfPdfParser($streamReader);
+	}
 
 	protected function setPageFormat($format, $orientation)
 	{

--- a/src/PdfParser/CrossReference/CompressedReader.php
+++ b/src/PdfParser/CrossReference/CompressedReader.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Mpdf\PdfParser\CrossReference;
+
+use setasign\Fpdi\PdfParser\CrossReference\ReaderInterface;
+use setasign\Fpdi\PdfParser\Filter\Flate;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\Type\PdfArray;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfName;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfNull;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+class CompressedReader implements ReaderInterface
+{
+
+	/**
+	 * @var PdfDictionary
+	 */
+	private $trailer;
+
+	/**
+	 * @var int[]
+	 */
+	private $offsets = [];
+
+	/**
+	 * @var array<int, array{0:int, 1:int}>
+	 */
+	private $compressedObjects = [];
+
+	public function __construct(PdfParser $parser, PdfStream $stream)
+	{
+		$this->trailer = $stream->value;
+		$this->read($stream);
+	}
+
+	public function getOffsetFor($objectNumber)
+	{
+		return $this->offsets[$objectNumber] ?? false;
+	}
+
+	public function getCompressedObjectInfo($objectNumber)
+	{
+		return $this->compressedObjects[$objectNumber] ?? false;
+	}
+
+	public function getTrailer()
+	{
+		return $this->trailer;
+	}
+
+	private function read(PdfStream $stream)
+	{
+		$widths = PdfArray::ensure(PdfDictionary::get($this->trailer, 'W'), 3)->value;
+		$widths = [
+			PdfNumeric::ensure($widths[0])->value,
+			PdfNumeric::ensure($widths[1])->value,
+			PdfNumeric::ensure($widths[2])->value,
+		];
+
+		$index = PdfDictionary::get($this->trailer, 'Index');
+		if ($index instanceof PdfArray) {
+			$index = $index->value;
+		} else {
+			$index = [PdfNumeric::create(0), PdfDictionary::get($this->trailer, 'Size')];
+		}
+
+		$entryLength = array_sum($widths);
+		if ($entryLength === 0) {
+			throw new PdfTypeException('Invalid compressed xref entry width.');
+		}
+		$data = $this->getDecodedStream($stream, $entryLength);
+
+		$position = 0;
+		for ($i = 0, $count = count($index); $i < $count; $i += 2) {
+			$objectNumber = PdfNumeric::ensure($index[$i])->value;
+			$objectCount = PdfNumeric::ensure($index[$i + 1])->value;
+
+			for ($j = 0; $j < $objectCount; $j++, $objectNumber++) {
+				$entry = substr($data, $position, $entryLength);
+				if (strlen($entry) < $entryLength) {
+					return;
+				}
+
+				$position += $entryLength;
+				$fields = [];
+				$fieldPosition = 0;
+				foreach ($widths as $field => $width) {
+					$fields[$field] = $width === 0
+						? ($field === 0 ? 1 : 0)
+						: $this->readUnsignedInteger(substr($entry, $fieldPosition, $width));
+					$fieldPosition += $width;
+				}
+
+				if ($fields[0] === 1) {
+					$this->offsets[$objectNumber] = $fields[1];
+				} elseif ($fields[0] === 2) {
+					$this->compressedObjects[$objectNumber] = [$fields[1], $fields[2]];
+				}
+			}
+		}
+	}
+
+	private function readUnsignedInteger($bytes)
+	{
+		$value = 0;
+		for ($i = 0, $length = strlen($bytes); $i < $length; $i++) {
+			$value = ($value << 8) + ord($bytes[$i]);
+		}
+
+		return $value;
+	}
+
+	private function getDecodedStream(PdfStream $stream, $columns)
+	{
+		$data = $stream->getStream();
+		$filters = $stream->getFilters();
+		if ($filters === []) {
+			return $data;
+		}
+
+		$decodeParams = PdfDictionary::get($stream->value, 'DecodeParms');
+		if ($decodeParams instanceof PdfArray) {
+			$decodeParams = $decodeParams->value;
+		} else {
+			$decodeParams = [$decodeParams];
+		}
+
+		foreach ($filters as $key => $filter) {
+			if (!$filter instanceof PdfName) {
+				continue;
+			}
+
+			switch ($filter->value) {
+				case 'FlateDecode':
+				case 'Fl':
+					$data = (new Flate())->decode($data);
+					$decodeParam = $decodeParams[$key] ?? null;
+					if ($decodeParam instanceof PdfDictionary) {
+						$data = $this->decodePredictor($data, $decodeParam, $columns);
+					}
+					break;
+
+				default:
+					throw new PdfTypeException(sprintf('Unsupported xref stream filter "%s".', $filter->value));
+			}
+		}
+
+		return $data;
+	}
+
+	private function decodePredictor($data, PdfDictionary $decodeParam, $defaultColumns)
+	{
+		$predictor = PdfDictionary::get($decodeParam, 'Predictor', PdfNumeric::create(1));
+		if ($predictor instanceof PdfNull || $predictor->value === 1) {
+			return $data;
+		}
+
+		$columns = PdfDictionary::get($decodeParam, 'Columns', PdfNumeric::create($defaultColumns));
+		$columns = PdfNumeric::ensure($columns)->value;
+
+		if ($predictor->value === 2) {
+			return $this->decodeTiffPredictor($data, $columns);
+		}
+
+		if ($predictor->value >= 10 && $predictor->value <= 15) {
+			return $this->decodePngPredictor($data, $columns);
+		}
+
+		throw new PdfTypeException(sprintf('Unsupported xref stream predictor "%s".', $predictor->value));
+	}
+
+	private function decodeTiffPredictor($data, $columns)
+	{
+		$result = '';
+		for ($offset = 0, $length = strlen($data); $offset < $length; $offset += $columns) {
+			$row = substr($data, $offset, $columns);
+			for ($i = 1, $rowLength = strlen($row); $i < $rowLength; $i++) {
+				$row[$i] = chr((ord($row[$i]) + ord($row[$i - 1])) & 0xff);
+			}
+			$result .= $row;
+		}
+
+		return $result;
+	}
+
+	private function decodePngPredictor($data, $columns)
+	{
+		$result = '';
+		$previous = str_repeat("\0", $columns);
+		for ($offset = 0, $length = strlen($data); $offset < $length;) {
+			$filter = ord($data[$offset++]);
+			$row = substr($data, $offset, $columns);
+			$offset += $columns;
+			$rowLength = strlen($row);
+
+			for ($i = 0; $i < $rowLength; $i++) {
+				$left = $i > 0 ? ord($row[$i - 1]) : 0;
+				$up = ord($previous[$i]);
+				$upperLeft = $i > 0 ? ord($previous[$i - 1]) : 0;
+				$value = ord($row[$i]);
+
+				switch ($filter) {
+					case 0:
+						break;
+					case 1:
+						$value += $left;
+						break;
+					case 2:
+						$value += $up;
+						break;
+					case 3:
+						$value += (int) floor(($left + $up) / 2);
+						break;
+					case 4:
+						$value += $this->paethPredictor($left, $up, $upperLeft);
+						break;
+					default:
+						throw new PdfTypeException(sprintf('Unsupported PNG predictor filter "%s".', $filter));
+				}
+
+				$row[$i] = chr($value & 0xff);
+			}
+
+			$result .= $row;
+			$previous = str_pad($row, $columns, "\0");
+		}
+
+		return $result;
+	}
+
+	private function paethPredictor($left, $up, $upperLeft)
+	{
+		$p = $left + $up - $upperLeft;
+		$pa = abs($p - $left);
+		$pb = abs($p - $up);
+		$pc = abs($p - $upperLeft);
+
+		if ($pa <= $pb && $pa <= $pc) {
+			return $left;
+		}
+
+		return $pb <= $pc ? $up : $upperLeft;
+	}
+}

--- a/src/PdfParser/CrossReference/CrossReference.php
+++ b/src/PdfParser/CrossReference/CrossReference.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Mpdf\PdfParser\CrossReference;
+
+use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\StreamReader;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfIndirectObject;
+use setasign\Fpdi\PdfParser\Type\PdfName;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfType;
+use setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+class CrossReference extends \setasign\Fpdi\PdfParser\CrossReference\CrossReference
+{
+
+	/**
+	 * @var PdfIndirectObject[]
+	 */
+	private $compressedObjects = [];
+
+	protected function initReaderInstance($initValue)
+	{
+		if ($initValue instanceof PdfIndirectObject) {
+			try {
+				$stream = PdfStream::ensure($initValue->value);
+			} catch (PdfTypeException $e) {
+				throw new CrossReferenceException(
+					'Invalid object type at xref reference offset.',
+					CrossReferenceException::INVALID_DATA,
+					$e
+				);
+			}
+
+			$type = PdfDictionary::get($stream->value, 'Type');
+			if (!$type instanceof PdfName || $type->value !== 'XRef') {
+				throw new CrossReferenceException(
+					'The xref position points to an incorrect object type.',
+					CrossReferenceException::INVALID_DATA
+				);
+			}
+
+			$this->checkForEncryption($stream->value);
+
+			return new CompressedReader($this->parser, $stream);
+		}
+
+		return parent::initReaderInstance($initValue);
+	}
+
+	public function getIndirectObject($objectNumber)
+	{
+		try {
+			return parent::getIndirectObject($objectNumber);
+		} catch (CrossReferenceException $e) {
+			if ($e->getCode() !== CrossReferenceException::OBJECT_NOT_FOUND) {
+				throw $e;
+			}
+		}
+
+		$info = $this->getCompressedObjectInfo($objectNumber);
+		if ($info === false) {
+			throw new CrossReferenceException(
+				sprintf('Object (id:%s) not found.', $objectNumber),
+				CrossReferenceException::OBJECT_NOT_FOUND
+			);
+		}
+
+		return $this->getCompressedObject($objectNumber, $info[0], $info[1]);
+	}
+
+	private function getCompressedObjectInfo($objectNumber)
+	{
+		foreach ($this->getReaders() as $reader) {
+			if (!method_exists($reader, 'getCompressedObjectInfo')) {
+				continue;
+			}
+
+			$info = $reader->getCompressedObjectInfo($objectNumber);
+			if ($info !== false) {
+				return $info;
+			}
+		}
+
+		return false;
+	}
+
+	private function getCompressedObject($objectNumber, $objectStreamNumber, $index)
+	{
+		if (isset($this->compressedObjects[$objectNumber])) {
+			return $this->compressedObjects[$objectNumber];
+		}
+
+		$objectStream = parent::getIndirectObject($objectStreamNumber);
+		$stream = PdfStream::ensure($objectStream->value);
+		$dictionary = PdfDictionary::ensure($stream->value);
+		$type = PdfDictionary::get($dictionary, 'Type');
+		if (!$type instanceof PdfName || $type->value !== 'ObjStm') {
+			throw new CrossReferenceException(
+				sprintf('Object stream (id:%s) not found.', $objectStreamNumber),
+				CrossReferenceException::OBJECT_NOT_FOUND
+			);
+		}
+
+		$first = PdfNumeric::ensure(PdfDictionary::get($dictionary, 'First'))->value;
+		$count = PdfNumeric::ensure(PdfDictionary::get($dictionary, 'N'))->value;
+		$data = $stream->getUnfilteredStream();
+		$header = substr($data, 0, $first);
+		$tokens = preg_split('/\s+/', trim($header));
+		if (!is_array($tokens) || count($tokens) < ($count * 2)) {
+			throw new CrossReferenceException(
+				sprintf('Invalid object stream (id:%s).', $objectStreamNumber),
+				CrossReferenceException::INVALID_DATA
+			);
+		}
+
+		$entries = [];
+		for ($i = 0; $i < $count; $i++) {
+			$entries[] = [(int) $tokens[$i * 2], (int) $tokens[$i * 2 + 1]];
+		}
+
+		if (!isset($entries[$index]) || $entries[$index][0] !== (int) $objectNumber) {
+			throw new CrossReferenceException(
+				sprintf('Object (id:%s) not found in object stream.', $objectNumber),
+				CrossReferenceException::OBJECT_NOT_FOUND
+			);
+		}
+
+		$start = $first + $entries[$index][1];
+		$end = isset($entries[$index + 1]) ? $first + $entries[$index + 1][1] : strlen($data);
+		$objectData = substr($data, $start, $end - $start);
+		$parser = new PdfParser(StreamReader::createByString($objectData));
+		$value = $parser->readValue();
+		if (!$value instanceof PdfType) {
+			throw new CrossReferenceException(
+				sprintf('Invalid compressed object (id:%s).', $objectNumber),
+				CrossReferenceException::INVALID_DATA
+			);
+		}
+
+		return $this->compressedObjects[$objectNumber] = PdfIndirectObject::create($objectNumber, 0, $value);
+	}
+}

--- a/src/PdfParser/PdfParser.php
+++ b/src/PdfParser/PdfParser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mpdf\PdfParser;
+
+use Mpdf\PdfParser\CrossReference\CrossReference;
+
+class PdfParser extends \setasign\Fpdi\PdfParser\PdfParser
+{
+
+	public function getCrossReference()
+	{
+		if ($this->xref === null) {
+			$this->xref = new CrossReference($this, $this->resolveFileHeader());
+		}
+
+		return $this->xref;
+	}
+}

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -52,11 +52,13 @@ class FpdiTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 
 	public function testBehaviourOnCompressedXref()
 	{
-		$this->expectException(\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException::class);
-		$this->expectExceptionCode(\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException::COMPRESSED_XREF);
-
 		$pdf = new Mpdf();
-		$pdf->setSourceFile(__DIR__ . '/../data/pdfs/compressed-xref.pdf');
+		$this->assertSame(1, $pdf->setSourceFile(__DIR__ . '/../data/pdfs/compressed-xref.pdf'));
+
+		$pdf->AddPage();
+		$pdf->useTemplate($pdf->importPage(1));
+
+		$this->assertStringStartsWith('%PDF-', $pdf->Output('doc.pdf', 'S'));
 	}
 
 	public function testHandlingOfNoneExistingReferencedObjects()


### PR DESCRIPTION
## Summary
- add a native parser path for compressed xref streams when the commercial FPDI parser is not installed
- read compressed object streams referenced by xref streams
- update the existing compressed-xref import test to assert successful import/output

## Validation
- php -l src/FpdiTrait.php src/PdfParser/PdfParser.php src/PdfParser/CrossReference/CrossReference.php src/PdfParser/CrossReference/CompressedReader.php
- vendor/bin/phpcs --report-width=160 --standard=ruleset.xml --severity=1 --warning-severity=0 src/FpdiTrait.php src/PdfParser/PdfParser.php src/PdfParser/CrossReference/CrossReference.php src/PdfParser/CrossReference/CompressedReader.php tests/Mpdf/FpdiTest.php
- vendor/bin/phpunit tests/Mpdf/FpdiTest.php
- git diff --check github/development...HEAD