### PR TITLE
Remove MBString Regex Checks

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -603,7 +603,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 	var $mb_enc;
 	var $originalMbEnc;
-	var $originalMbRegexEnc;
 
 	var $directionality;
 
@@ -1146,7 +1145,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		$this->mb_enc = 'windows-1252';
 		$this->originalMbEnc = mb_internal_encoding();
-		$this->originalMbRegexEnc = mb_regex_encoding();
 
 		$this->directionality = 'ltr';
 		$this->defaultAlign = 'L';
@@ -1420,7 +1418,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		} else {
 			$this->setMBencoding('UTF-8'); // sets $this->mb_enc
 		}
-		@mb_regex_encoding('UTF-8'); // required only for mb_ereg... and mb_split functions
 
 		// Adobe CJK fonts
 		$this->available_CJK_fonts = [
@@ -1570,7 +1567,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 	public function cleanup()
 	{
 		mb_internal_encoding($this->originalMbEnc);
-		@mb_regex_encoding($this->originalMbRegexEnc);
 
 		// this will free up the readers, based on code from Setasign's FpdiTrait::cleanUp()
 		foreach ($this->createdReaders as $id) {
@@ -9708,15 +9704,6 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		if (!function_exists('mb_substr')) {
 			throw new \Mpdf\MpdfException('mbstring extension must be loaded in order to run mPDF');
-		}
-
-		if (!function_exists('mb_regex_encoding')) {
-			$mamp = '';
-			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-				$mamp = ' If using MAMP, there is a bug in its PHP build causing this.';
-			}
-
-			throw new \Mpdf\MpdfException('mbstring extension with mbregex support must be loaded in order to run mPDF.' . $mamp);
 		}
 	}
 


### PR DESCRIPTION
The MBString regex functions are being removed from PHP (https://wiki.php.net/rfc/eol-oniguruma). An audit of mPDF's codebase shows the last use of these functions (`mb_eregi_replace`) got replaced in mPDF v5.4, but the relevant startup checks / backup encoding process was overlooked at the time.

This PR removes these unnecessary startup checks. A separate PR for the docs will be made.