### PR TITLE
Replace the ToC clone lookahead with an internal state snapshot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
 		"ext-mbstring": "*",
 		"mpdf/psr-http-message-shim": "^1.0 || ^2.0",
 		"mpdf/psr-log-aware-trait": "^2.0 || ^3.0",
-		"myclabs/deep-copy": "^1.7",
 		"paragonie/random_compat": "^1.4|^2.0|^9.99.99",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -27513,4 +27513,46 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		return $html;
 	}
 
+	/**
+	 * Capture a snapshot of mPDFs mutable document state
+	 *
+	 * In combination with {@see restoreStateSnapshot()} this allows for document look-aheads that
+	 * can only be computed by writing to the document. For example, {@see TableOfContents::insertTOC}
+	 * uses this functionality to determine the correct page numbers.
+	 *
+	 * Only scalar and array values are captured in the snapshot. All objects and resources are excluded.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @internal Needs to be public to let internal mPDF classes use it, but is not part of the public API
+	 */
+	public function getStateSnapshot()
+	{
+		$snapshot = [];
+		foreach (get_object_vars($this) as $key => $value) {
+			if (is_object($value) || is_resource($value)) {
+				continue;
+			}
+
+			$snapshot[$key] = $value;
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Restore document state previously captured by {@see getStateSnapshot()}.
+	 *
+	 * @param array<string, mixed> $snapshot
+	 *
+	 * @return void
+	 *
+	 * @internal Needs to be public to let internal mPDF classes use it, but is not part of the public API
+	 */
+	public function restoreStateSnapshot(array $snapshot)
+	{
+		foreach ($snapshot as $key => $value) {
+			$this->{$key} = $value;
+		}
+	}
 }

--- a/src/TableOfContents.php
+++ b/src/TableOfContents.php
@@ -3,7 +3,6 @@
 namespace Mpdf;
 
 use Mpdf\Utils\Arrays;
-use DeepCopy\DeepCopy;
 
 class TableOfContents
 {
@@ -299,22 +298,32 @@ class TableOfContents
 
 	public function insertTOC()
 	{
-		/*
+		/**
 		 * Fix the TOC page numbering problem
 		 *
-		 * To do this, the current class is deep cloned and then the TOC functionality run. The correct page
-		 * numbers are calculated when the TOC pages are moved into position in the cloned object (see Mpdf::MovePages).
-		 * It's then a matter of copying the correct page numbers to the original object and letting the TOC functionality
-		 * run as per normal.
+		 * The correct page numbers are only known once the TOC pages have been painted and moved into
+		 * position (@see Mpdf::MovePages). To break that chicken-and-egg problem the TOC is first painted
+		 * as a trial "look-ahead" pass, run in-place against a snapshot of the document state. The
+		 * corrected page numbers (and page-number substitutions) are read from that pass, the document is
+		 * rolled back to the snapshot, and the TOC is then painted for real with the correct numbers.
 		 *
-		 * See https://github.com/mpdf/mpdf/issues/642
+		 * @see https://github.com/mpdf/mpdf/issues/642
 		 */
+		$lookAheadToc = null;
+		$lookAheadPageNumSubstitutions = null;
 		if (!$this->tocTocPaintBegun) {
-			$copier = new DeepCopy(true);
-			$tocClassClone = $copier->copy($this);
-			$tocClassClone->beginTocPaint();
-			$tocClassClone->insertTOC();
-			$this->_toc = $tocClassClone->_toc;
+			$mpdfState = $this->mpdf->getStateSnapshot();
+			$mTocState = $this->m_TOC;
+
+			$this->beginTocPaint();
+			$this->insertTOC();
+
+			$lookAheadToc = $this->_toc;
+			$lookAheadPageNumSubstitutions = $this->mpdf->PageNumSubstitutions;
+
+			$this->mpdf->restoreStateSnapshot($mpdfState);
+			$this->m_TOC = $mTocState;
+			$this->tocTocPaintBegun = false;
 		}
 
 		$notocs = 0;
@@ -446,11 +455,11 @@ class TableOfContents
 			 * @see https://github.com/mpdf/mpdf/issues/792
 			 * @see https://github.com/mpdf/mpdf/issues/777
 			 */
-			if (isset($tocClassClone)) {
+			if ($lookAheadPageNumSubstitutions !== null) {
 				$this->mpdf->PageNumSubstitutions = array_map(function ($sub) {
 					$sub['suppress'] = '';
 					return $sub;
-				}, $tocClassClone->mpdf->PageNumSubstitutions);
+				}, $lookAheadPageNumSubstitutions);
 			}
 
 			// mPDF 5.6.31
@@ -589,10 +598,9 @@ class TableOfContents
 		}
 
 		/* Fix the over adjustment of the TOC and Page Substitutions values */
-		if (isset($tocClassClone)) {
-			$this->_toc = $tocClassClone->_toc;
-			$this->mpdf->PageNumSubstitutions = $tocClassClone->mpdf->PageNumSubstitutions;
-			unset($tocClassClone);
+		if ($lookAheadToc !== null) {
+			$this->_toc = $lookAheadToc;
+			$this->mpdf->PageNumSubstitutions = $lookAheadPageNumSubstitutions;
 		}
 	}
 

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -416,4 +416,33 @@ class FpdiTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$contentStream = $pageTwo->getContentStream();
 		$this->assertSame(1, preg_match_all('~/TPL\d~', $contentStream));
 	}
+
+	/**
+	 * Regression test for https://github.com/mpdf/mpdf/issues/1206
+	 * and https://github.com/mpdf/mpdf/issues/1345
+	 *
+	 * Importing a PDF and building a TOC in the same document must not close the imported
+	 * file's stream. The former deep-copy TOC look-ahead duplicated the reader and errors
+	 * would occur when the discarded clone was garbage collected.
+	 */
+	public function testTocLookAheadKeepsImportedPdfStreamOpen()
+	{
+		$handle = fopen(__DIR__ . '/../data/pdfs/Noisy-Tube.pdf', 'rb');
+		$streamReader = new StreamReader($handle, true);
+
+		$pdf = new Mpdf();
+		$pdf->h2toc = ['H1' => 0];
+		$pdf->setSourceFile($streamReader);
+		$pdf->useTemplate($pdf->importPage(1));
+		$pdf->WriteHTML('<tocpagebreak links="on" /><h1>Heading</h1>');
+		$pdf->Close();
+
+		// A discarded look-ahead clone is cyclic, so force its destructor to run now
+		gc_collect_cycles();
+
+		$this->assertTrue(
+			is_resource($handle),
+			'The imported PDF stream must stay open after the TOC look-ahead (see #1206)'
+		);
+	}
 }


### PR DESCRIPTION
PR https://github.com/mpdf/mpdf/pull/667 introduced the `myclabs/deep-copy` library to solve a page number look-ahead problem when rendering Table of Contents. This mostly worked, but was a heavy-handed solution that intermittently broke other mPDF features in subtle ways (see #1206 and #1345). This new approach uses a much lighter internal state snapshot/restore process, and the PDF output is identical.

Disclaimer: AI has been used to determine how best to resolve the issues caused by using deep-copy in mPDF. All code/comments have been reviewed and curated (including this description).

# Fun Facts

## Why Replace DeepCopy

1. Cloned more than was needed to do a look-ahead
2. Caused bugs with streams and PHP garbage collection
3. Not everything in the mPDF object is clonable (nor needs to be) leading to unexpected results
4. Performance (see below)
5. Reduce 3rd-party dependencies

## Alternatives

### Limit state snapshots to ToC properties

Since the look-ahead is only used for ToC elements, consideration was given to restricting the snapshot to these properties. However, the ToC completes a full `WriteHTML` pass which touches a considerable number of properties. This includes: page arrays, font and colour state, link tables, footnote and column counters, page-number substitutions, and all services used in this method that writes back to `$mpdf`. 

If the new snapshot approach surfaces subtle bugs, a blacklist of non-relevant properties could be added. But this seems premature considering there aren't any bug reports against the deep-copy approach affecting scalar / array values.

### A look ahead that never writes to the document

Consideration was also given to emitting placeholder tokens for the page numbers in the ToC (like `{nbpg}` in headers/footers) and then replacing them once pages were settled. This approach worked for basic use-cases where the correct width in the PDF could be reserved, but broken down when the width couldn't be correctly calculated (e.g. Roman Numerals or styled text).

## Performance Benchmarks

Measured on PHP 7.4.33. Full mPDF generation run 5 times rendering a 100-page document with 4 TOCs, 30 entries, included tables, columns and images. 

| Implementation | Best time | Peak memory |
| --- | --- | --- |
| deep-copy| 1816 ms | 30.0 MB |
| internal snapshot | 1695 ms | 26.0 MB |
| **change** | **−121 ms (−6.7%)** | **−4 MB (−13%)** |

**The clone step in isolation**: run 15 times, median figures shown

| Document state | deep-copy | internal snapshot | speedup |
| --- | --- | --- | --- |
| 11 pages | 52.5 ms | 0.10 ms | 536× |
| 121 pages | 76.2 ms | 0.10 ms | 778× |
| 251 pages | 106.6 ms | 0.10 ms | 1075× |
| 100 pages, 4 TOCs | 100.4 ms | 0.15 ms | 664× |

The snapshot copies only scalar and array state (copy-on-write) instead of deep-cloning mPDF's cyclic graph of services, so the look-ahead no longer scales with document size and there is no whole-object clone to keep working as that graph grows. On a 100-page document with 4 TOCs it renders about 120ms quicker and peaks 4MB lower, and the underlying clone step is hundreds of times cheaper. 

Resolves #1206
Resolves #1345 