### PR TITLE
Preserve consecutive spaces in quoted HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features
 
 Bugfixes
 --------
+* Preserve consecutive spaces inside quoted HTML attribute values in `AdjustHTML()` (#2208)
 * Fix `TypeError` in `transformRotate` for non-numeric CSS transform values (#2056)
 * Fix `TypeError` with non-numeric `rotate` values like `none` or `90deg` on tables (@derrabus, #2178)
 * Small change to better support list-style-type on list items within tables

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -27112,7 +27112,22 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 
 		// Converts < to &lt; when not a tag
 		$html = preg_replace('/<([^!\/a-zA-Z_:])/i', '&lt;\\1', $html); // mPDF 5.7.3
+
+		// Protect quoted attribute values so space collapsing does not corrupt
+		// legitimate consecutive spaces in paths (e.g. src/href filenames).
+		// Same extract/restore idea as <pre>/<textarea> handling above. (#2208)
+		$attrPlaceholders = [];
+		$html = preg_replace_callback('/=([\'"])(.*?)\1/s', function ($m) use (&$attrPlaceholders) {
+			$key = '###MPDF_ATTR_' . count($attrPlaceholders) . '###';
+			$attrPlaceholders[$key] = $m[2];
+			return '=' . $m[1] . $key . $m[1];
+		}, $html);
+
 		$html = preg_replace("/[ ]+/", ' ', $html);
+
+		if ($attrPlaceholders) {
+			$html = strtr($html, $attrPlaceholders);
+		}
 
 		$html = preg_replace('/\/li>\s+<\/(u|o)l/i', '/li></\\1l', $html);
 		$html = preg_replace('/\/(u|o)l>\s+<\/li/i', '/\\1l></li', $html);

--- a/tests/Mpdf/AdjustHtmlTest.php
+++ b/tests/Mpdf/AdjustHtmlTest.php
@@ -38,4 +38,32 @@ class AdjustHtmlTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$this->assertStringContainsString('<h5 align="center" style="color: red" keep-with-table="1">', $adjustedHtml);
 		$this->assertStringContainsString('<h6 class="name" keep-with-table="1">', $adjustedHtml);
 	}
+
+	public function testAdjustHtmlPreservesMultipleSpacesInDoubleQuotedAttributes()
+	{
+		$html = '<img src="/tmp/Photo  Name.jpg" width="50"><a href="/path/to/my  file.pdf">link</a>';
+		$adjustedHtml = $this->mpdf->AdjustHTML($html);
+
+		$this->assertStringContainsString('Photo  Name.jpg', $adjustedHtml);
+		$this->assertStringContainsString('my  file.pdf', $adjustedHtml);
+		$this->assertStringNotContainsString('Photo Name.jpg', $adjustedHtml);
+	}
+
+	public function testAdjustHtmlPreservesMultipleSpacesInSingleQuotedAttributes()
+	{
+		$html = "<img src='/tmp/Photo  Name.jpg' width='50'>";
+		$adjustedHtml = $this->mpdf->AdjustHTML($html);
+
+		$this->assertStringContainsString('Photo  Name.jpg', $adjustedHtml);
+		$this->assertStringNotContainsString('Photo Name.jpg', $adjustedHtml);
+	}
+
+	public function testAdjustHtmlStillCollapsesSpacesInTextContent()
+	{
+		$html = '<p>Hello    world</p>';
+		$adjustedHtml = $this->mpdf->AdjustHTML($html);
+
+		$this->assertStringContainsString('Hello world', $adjustedHtml);
+		$this->assertStringNotContainsString('Hello    world', $adjustedHtml);
+	}
 }


### PR DESCRIPTION
## Summary
- Fix `AdjustHTML()` so consecutive spaces inside quoted attribute values (`src`, `href`, etc.) are preserved.
- Previously `/[ ]+/` ran on the entire HTML string and corrupted real filenames like `Photo  Name.jpg`.
- Protect/restore quoted attributes around the collapse (same idea as `<pre>`/`<textarea>` handling).
- Add regression tests; text-node space collapsing is unchanged.
- CHANGELOG entry for #2208.

Fixes #2208

## Test plan
- [x] `vendor/bin/phpunit --filter AdjustHtmlTest`
- [x] Before fix: new attribute tests fail (`Photo  Name.jpg` collapsed to `Photo Name.jpg`)
- [x] After fix: 5 tests, 15 assertions, OK
- [x] Text content still collapses multiple spaces (`Hello    world` → `Hello world`)