### PR TITLE
Fix column buffer offsets when ending multi-column layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bugfixes
 * Small change to better support list-style-type on list items within tables
 * Fixed parsing sheet-size CSS property for @page
 * Conditional calls to functions removed in PHP 8.5
+* Fixed undefined array key warning when ending a multi-column layout (#2214)
 
 mPDF 8.2.x
 ===========================

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -24489,9 +24489,15 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 			$last_col = 0;
 			// Recursively add previous column's height
 			for ($i = 1; $i < $this->NbCol; $i++) {
+				// Required for columns with breakpoints but no printed entries
+				$previousBottomMargin = isset($this->ColDetails[$i - 1]['bottom_margin'])
+					? $this->ColDetails[$i - 1]['bottom_margin']
+					: $this->y0;
+
+				$this->ColDetails[$i]['add_y'] = ($previousBottomMargin - $this->y0) + $this->ColDetails[$i - 1]['add_y'];
+
 				if (isset($this->ColDetails[$i]['bottom_margin']) && $this->ColDetails[$i]['bottom_margin']) { // If any entries in the column
-					$this->ColDetails[$i]['add_y'] = ($this->ColDetails[$i - 1]['bottom_margin'] - $this->y0) + $this->ColDetails[$i - 1]['add_y'];
-					$last_col = $i;  // Last column actually printed
+					$last_col = $i; // Last column actually printed
 				}
 			}
 

--- a/tests/Issues/Issue2214Test.php
+++ b/tests/Issues/Issue2214Test.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Issues;
+
+class Issue2214Test extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
+{
+
+	/**
+	 * @dataProvider columnContentProvider
+	 */
+	public function testEndingColumnsDoesNotAccessUndefinedColumnDetails($repeat)
+	{
+		$undefinedKey = false;
+
+		set_error_handler(function ($errno, $errstr) use (&$undefinedKey) {
+			if (strpos($errstr, 'Undefined array key') !== false
+				|| strpos($errstr, 'Undefined offset') !== false
+				|| strpos($errstr, 'Undefined index') !== false
+			) {
+				$undefinedKey = true;
+			}
+
+			return true;
+		});
+
+		try {
+			$mpdf = new \Mpdf\Mpdf();
+
+			$item =
+				'<h4>Voice</h4>'
+				. '<p>'
+				. 'Description Description Description Description '
+				. 'Description Description Description Description'
+				. '</p>'
+				. '<br />';
+
+			$html =
+				'<columns column-count="2" column-gap="15" />'
+				. str_repeat($item, $repeat)
+				. '<columns column-count="1" />';
+
+			$mpdf->WriteHTML($html);
+
+			$output = $mpdf->OutputBinaryData();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertFalse($undefinedKey);
+		$this->assertStringStartsWith('%PDF-', $output);
+	}
+
+	public function columnContentProvider()
+	{
+		return [
+			'breakpoints without column details' => [7],
+			'previous column without bottom margin' => [14],
+		];
+	}
+
+}


### PR DESCRIPTION
Fixes #2214

`printcolumnbuffer()` could access a column offset that had not been initialized when breakpoints existed without corresponding column details.

This change initializes the cumulative column offset safely when the previous column has no `bottom_margin`.

Added regression tests for the reported case and for the related empty-column state.

Tests:
- `composer test`
- `composer cs`
- `git diff --check`